### PR TITLE
Extend compatibility layer to expose all src.* packages

### DIFF
--- a/src/src/__init__.py
+++ b/src/src/__init__.py
@@ -34,6 +34,17 @@ _EXPOSED_MODULES = [
     # modules import it via ``src.genome``, so expose it here to avoid
     # import errors when ``src`` is on ``sys.path``.
     'genome',
+
+    # Additional top-level packages referenced via ``src.`` in various modules.
+    # Exposing these names ensures that imports like ``src.domain.models`` or
+    # ``src.governance.token_manager`` resolve correctly when ``src`` is on
+    # ``sys.path``.  Without listing them here, attempting to import them
+    # through the ``src`` namespace would result in a ModuleNotFoundError.
+    'domain',
+    'ecosystem',
+    'governance',
+    'operational',
+    'thinking',
 ]
 
 for _mod_name in _EXPOSED_MODULES:


### PR DESCRIPTION
- Added domain, ecosystem, governance, operational, and thinking to _EXPOSED_MODULES
- Ensures imports like src.domain.models, src.governance.token_manager work correctly
- Prevents 'attempted relative import beyond top-level package' errors in CI
- Comprehensive fix for all src.* namespace imports