### PR TITLE
Fix MarketData zero spread bug

### DIFF
--- a/src/core/market_data.py
+++ b/src/core/market_data.py
@@ -58,10 +58,10 @@ class MarketData:
     
     def __post_init__(self):
         """Calculate derived values after initialization"""
-        if self.spread is None and self.bid and self.ask:
+        if self.spread is None and self.bid is not None and self.ask is not None:
             self.spread = self.ask - self.bid
-            
-        if self.mid_price is None and self.bid and self.ask:
+
+        if self.mid_price is None and self.bid is not None and self.ask is not None:
             self.mid_price = (self.bid + self.ask) / 2
     
     @property

--- a/tests/unit/test_market_data.py
+++ b/tests/unit/test_market_data.py
@@ -186,6 +186,26 @@ class TestMarketData:
         assert str(data.bid) == "1.095012345"
         assert str(data.volume) == "1000000.123"
 
+    def test_zero_bid_ask_calculations(self):
+        """Ensure spread and mid_price are calculated when prices include zeros."""
+        timestamp = datetime.now()
+
+        data = MarketData(
+            symbol="ZERO",
+            timestamp=timestamp,
+            bid=Decimal("0"),
+            ask=Decimal("1"),
+            last=Decimal("0.5"),
+            high=Decimal("1"),
+            low=Decimal("0"),
+            open=Decimal("0"),
+            close=Decimal("1"),
+            volume=Decimal("100")
+        )
+
+        assert data.spread == Decimal("1")
+        assert data.mid_price == Decimal("0.5")
+
 
 if __name__ == "__main__":
     pytest.main([__file__])


### PR DESCRIPTION
## Summary
- fix calculation of spread and mid_price when bid or ask are zero
- cover new edge case with unit test

## Testing
- `pytest -q`
- `pytest tests/unit/test_market_data.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6888cef0eedc832ca71c991dbb01d103