### PR TITLE
Fix docstring in sensory base

### DIFF
--- a/src/sensory/core/base.py
+++ b/src/sensory/core/base.py
@@ -1,10 +1,11 @@
 """
 Sensory Cortex v2.2 - Core Base Classes
-from src.core.market_data import MarketData
 
 Canonical dataclasses that serve as the common language for the entire sensory system.
 These provide type safety, clear data contracts, and eliminate the need for ad-hoc data structures.
 """
+
+from src.core.market_data import MarketData
 
 import logging
 from abc import ABC, abstractmethod


### PR DESCRIPTION
## Summary
- close the module docstring in `src/sensory/core/base.py`
- ensure `from src.core.market_data import MarketData` executes outside of the docstring

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'market_intelligence')*

------
https://chatgpt.com/codex/tasks/task_e_6888e0f9cc64832cb81f9ddc12a95105