### PR TITLE
Strengthen evolution and validation scaffolding

### DIFF
--- a/src/core/evolution/engine.py
+++ b/src/core/evolution/engine.py
@@ -1,6 +1,12 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from time import time
+from typing import Callable, Optional, cast
+
+from src.core.genome import get_genome_provider
+from src.core.interfaces import DecisionGenome, PopulationManager as PopulationManagerProtocol
+from src.core.population_manager import PopulationManager as PopulationManagerImpl
 
 
 @dataclass
@@ -12,11 +18,86 @@ class EvolutionConfig:
     max_generations: int = 100
 
 
+@dataclass
+class EvolutionSummary:
+    """Lightweight summary describing the outcome of an evolution step."""
+
+    generation: int
+    population_size: int
+    best_fitness: float
+    average_fitness: float
+    elite_count: int
+    timestamp: float
+
+
 class EvolutionEngine:
     """Consolidated evolution engine surface."""
 
-    def __init__(self, config: EvolutionConfig | None = None) -> None:
+    def __init__(
+        self,
+        config: EvolutionConfig | None = None,
+        population_manager: PopulationManagerProtocol | None = None,
+    ) -> None:
         self.config = config or EvolutionConfig()
+        self._population_manager: PopulationManagerProtocol = population_manager or PopulationManagerImpl(
+            population_size=self.config.population_size
+        )
+        self._initialized = False
+        self._genome_counter = 0
 
-    def evolve(self) -> None:
-        raise NotImplementedError
+    def evolve(
+        self, genome_factory: Optional[Callable[[], DecisionGenome]] = None
+    ) -> EvolutionSummary:
+        """Run a minimal evolution cycle and return a summary of the results."""
+
+        factory = genome_factory or self._default_genome_factory
+
+        if not self._initialized:
+            self._population_manager.initialize_population(factory)
+            self._initialized = True
+
+        if not self._population_manager.get_population():
+            self._population_manager.initialize_population(factory)
+
+        elite_count = max(1, self.config.elite_count)
+        elites = list(self._population_manager.get_best_genomes(elite_count))
+
+        if elites:
+            new_population = list(elites)
+            while len(new_population) < self.config.population_size:
+                new_population.extend(elites)
+            new_population = new_population[: self.config.population_size]
+            self._population_manager.update_population(new_population)
+        else:
+            self._population_manager.initialize_population(factory)
+
+        self._population_manager.advance_generation()
+        stats = self._population_manager.get_population_statistics()
+
+        return EvolutionSummary(
+            generation=int(stats.get("generation", 0)),
+            population_size=int(stats.get("population_size", 0)),
+            best_fitness=float(stats.get("best_fitness", 0.0) or 0.0),
+            average_fitness=float(stats.get("average_fitness", 0.0) or 0.0),
+            elite_count=len(elites),
+            timestamp=time(),
+        )
+
+    def _default_genome_factory(self) -> DecisionGenome:
+        provider = get_genome_provider()
+        self._genome_counter += 1
+        identifier = f"core-evo-{self._genome_counter:05d}"
+        parameters = {
+            "risk_tolerance": 0.5,
+            "momentum_window": float(10 + (self._genome_counter % 15)),
+            "mean_reversion": 0.2,
+        }
+        genome = provider.new_genome(
+            id=identifier,
+            parameters=parameters,
+            generation=0,
+            species_type="core_strategy",
+        )
+        if isinstance(genome, DecisionGenome):
+            return genome
+        return cast(DecisionGenome, provider.from_legacy(genome))

--- a/src/core/population_manager.py
+++ b/src/core/population_manager.py
@@ -377,3 +377,11 @@ class PopulationManager(IPopulationManager):
             return provider.mutate(working, "gaussian", new_params)
         except Exception:
             return genome
+
+
+def create_population_manager(
+    population_size: int = 100, cache_ttl: int = 300
+) -> PopulationManager:
+    """Factory helper mirroring legacy construction patterns."""
+
+    return PopulationManager(population_size=population_size, cache_ttl=cache_ttl)

--- a/src/validation/real_market_validation.py
+++ b/src/validation/real_market_validation.py
@@ -108,9 +108,41 @@ class RealMarketValidationFramework:
             ],
         }
 
+    def _missing_real_adapters(
+        self,
+        require_market_data: bool = False,
+        require_anomaly: bool = False,
+        require_regime: bool = False,
+    ) -> List[str]:
+        missing: List[str] = []
+        if require_market_data and isinstance(self.market_data, NoOpMarketDataGateway):
+            missing.append("market_data_gateway")
+        if require_anomaly and isinstance(self.anomaly_detector, NoOpAnomalyDetector):
+            missing.append("anomaly_detector")
+        if require_regime and isinstance(self.regime_classifier, NoOpRegimeClassifier):
+            missing.append("regime_classifier")
+        return missing
+
     async def validate_anomaly_detection_accuracy(self) -> RealMarketValidationResult:
         """Validate anomaly detection against known market manipulation events"""
         try:
+            missing = self._missing_real_adapters(
+                require_market_data=True, require_anomaly=True
+            )
+            if missing:
+                return RealMarketValidationResult(
+                    test_name="anomaly_detection_accuracy",
+                    passed=False,
+                    value=0.0,
+                    threshold=0.7,
+                    unit="f1_score",
+                    details=(
+                        "Real market validation requires configured adapters: "
+                        + ", ".join(missing)
+                    ),
+                    historical_data={"missing_adapters": missing},
+                )
+
             total_events = 0
             detected_events = 0
             false_positives = 0
@@ -214,6 +246,23 @@ class RealMarketValidationFramework:
     async def validate_regime_classification_accuracy(self) -> RealMarketValidationResult:
         """Validate regime classification against known market regimes"""
         try:
+            missing = self._missing_real_adapters(
+                require_market_data=True, require_regime=True
+            )
+            if missing:
+                return RealMarketValidationResult(
+                    test_name="regime_classification_accuracy",
+                    passed=False,
+                    value=0.0,
+                    threshold=0.8,
+                    unit="accuracy",
+                    details=(
+                        "Real market validation requires configured adapters: "
+                        + ", ".join(missing)
+                    ),
+                    historical_data={"missing_adapters": missing},
+                )
+
             # Test with 2020 COVID crash data
             start_date = datetime(2020, 2, 1)
             end_date = datetime(2020, 5, 1)
@@ -305,6 +354,21 @@ class RealMarketValidationFramework:
     async def validate_real_performance_metrics(self) -> RealMarketValidationResult:
         """Validate actual performance metrics with real data"""
         try:
+            missing = self._missing_real_adapters(require_market_data=True)
+            if missing:
+                return RealMarketValidationResult(
+                    test_name="real_performance_metrics",
+                    passed=False,
+                    value=0.0,
+                    threshold=1.0,
+                    unit="boolean",
+                    details=(
+                        "Real market validation requires configured adapters: "
+                        + ", ".join(missing)
+                    ),
+                    historical_data={"missing_adapters": missing},
+                )
+
             # Test with recent EURUSD data
             end_date = datetime.now()
             start_date = end_date - timedelta(days=30)
@@ -400,6 +464,21 @@ class RealMarketValidationFramework:
     async def validate_sharpe_ratio_calculation(self) -> RealMarketValidationResult:
         """Validate Sharpe ratio calculation with real trading data"""
         try:
+            missing = self._missing_real_adapters(require_market_data=True)
+            if missing:
+                return RealMarketValidationResult(
+                    test_name="sharpe_ratio_calculation",
+                    passed=False,
+                    value=0.0,
+                    threshold=1.0,
+                    unit="sharpe_ratio",
+                    details=(
+                        "Real market validation requires configured adapters: "
+                        + ", ".join(missing)
+                    ),
+                    historical_data={"missing_adapters": missing},
+                )
+
             # Get 1 year of S&P 500 data
             end_date = datetime.now()
             start_date = end_date - timedelta(days=365)
@@ -464,6 +543,21 @@ class RealMarketValidationFramework:
     async def validate_max_drawdown_calculation(self) -> RealMarketValidationResult:
         """Validate maximum drawdown calculation with real data"""
         try:
+            missing = self._missing_real_adapters(require_market_data=True)
+            if missing:
+                return RealMarketValidationResult(
+                    test_name="max_drawdown_calculation",
+                    passed=False,
+                    value=0.0,
+                    threshold=-0.5,
+                    unit="percentage",
+                    details=(
+                        "Real market validation requires configured adapters: "
+                        + ", ".join(missing)
+                    ),
+                    historical_data={"missing_adapters": missing},
+                )
+
             # Get COVID crash data
             start_date = datetime(2020, 2, 1)
             end_date = datetime(2020, 5, 1)

--- a/tests/current/test_evolution_engine_basic.py
+++ b/tests/current/test_evolution_engine_basic.py
@@ -1,0 +1,14 @@
+from src.core.evolution.engine import EvolutionConfig, EvolutionEngine, EvolutionSummary
+
+
+def test_evolution_engine_emits_summary_and_tracks_generation():
+    engine = EvolutionEngine(EvolutionConfig(population_size=6, elite_count=2))
+
+    first_summary = engine.evolve()
+    assert isinstance(first_summary, EvolutionSummary)
+    assert first_summary.population_size == 6
+    assert first_summary.elite_count >= 0
+
+    second_summary = engine.evolve()
+    assert second_summary.generation == first_summary.generation + 1
+    assert second_summary.population_size == 6

--- a/tests/current/test_real_market_validation_noop.py
+++ b/tests/current/test_real_market_validation_noop.py
@@ -1,0 +1,16 @@
+import pytest
+
+from src.validation.real_market_validation import RealMarketValidationFramework
+
+
+@pytest.mark.asyncio
+async def test_real_market_validation_reports_missing_adapters():
+    framework = RealMarketValidationFramework()
+
+    result = await framework.validate_anomaly_detection_accuracy()
+
+    assert result.passed is False
+    missing = result.historical_data.get("missing_adapters")
+    assert missing is not None
+    assert "market_data_gateway" in missing
+    assert "anomaly_detector" in missing

--- a/tests/integration/test_component_integrator_impl.py
+++ b/tests/integration/test_component_integrator_impl.py
@@ -1,0 +1,33 @@
+import pytest
+
+from src.integration.component_integrator_impl import ComponentIntegratorImpl
+
+
+@pytest.mark.asyncio
+async def test_initialize_registers_sensory_aliases():
+    integrator = ComponentIntegratorImpl()
+
+    assert await integrator.initialize() is True
+
+    what_sensor = integrator.get_component("what_sensor")
+    when_sensor = integrator.get_component("when_sensor")
+    anomaly_sensor = integrator.get_component("anomaly_sensor")
+
+    assert what_sensor is not None
+    assert when_sensor is not None
+    assert anomaly_sensor is not None
+
+    # Legacy aliases should resolve to the same objects for downstream validators
+    assert integrator.get_component("what_organ") is what_sensor
+    assert integrator.get_component("when_organ") is when_sensor
+    assert integrator.get_component("anomaly_organ") is anomaly_sensor
+
+    # Data flow validation should reference whichever sensory key is available
+    validation = await integrator.validate_integration()
+    data_flow = validation["components"].get("data_flow")
+    assert data_flow is not None
+    assert data_flow["available"] is True
+    assert data_flow["test_passed"] is True
+    assert data_flow["source"] in {"what_sensor", "what_organ"}
+
+    await integrator.shutdown()

--- a/tests/integration/test_validation_framework_component_integration.py
+++ b/tests/integration/test_validation_framework_component_integration.py
@@ -1,0 +1,15 @@
+import pytest
+
+from src.validation.validation_framework import ValidationFramework
+
+
+@pytest.mark.asyncio
+async def test_validation_framework_component_integration_initializes_integrator():
+    framework = ValidationFramework()
+
+    result = await framework.validate_component_integration()
+
+    assert result.passed is True
+    assert result.value == pytest.approx(1.0)
+    assert not result.metadata.get("missing")
+    assert result.metadata.get("initialized") is True


### PR DESCRIPTION
## Summary
- implement a minimal EvolutionEngine cycle that returns an EvolutionSummary and provide a create_population_manager helper
- make the component integrator report alias metadata, propagate initialization failures, and update the system validator to await full initialization
- align the validation framework with the integrator wiring, add no-op adapter guards to the real-market validator, and cover the changes with new regression tests

## Testing
- pytest tests/integration/test_component_integrator_impl.py tests/integration/test_validation_framework_component_integration.py tests/current/test_evolution_engine_basic.py tests/current/test_real_market_validation_noop.py

------
https://chatgpt.com/codex/tasks/task_e_68cb853f1a88832c95341b54febab6d8