### PR TITLE
Implement real risk assessment and coverage

### DIFF
--- a/src/risk/real_risk_manager.py
+++ b/src/risk/real_risk_manager.py
@@ -1,20 +1,157 @@
 from __future__ import annotations
 
+import math
+from collections.abc import Mapping
 from dataclasses import dataclass
+from decimal import Decimal
+from typing import Dict
 
 
 @dataclass
 class RealRiskConfig:
-    max_position_risk: float = 0.0
-    max_drawdown: float = 0.0
+    """Configuration for the :class:`RealRiskManager` implementation.
+
+    The configuration mirrors the simplified knobs exposed by ``RiskManagerImpl``
+    and keeps defaults intentionally conservative so that the manager can be
+    instantiated without bespoke wiring during tests.
+    """
+
+    max_position_risk: float = 0.02
+    """Maximum allowed risk as a fraction of equity for any single position."""
+
+    max_drawdown: float = 0.25
+    """Maximum aggregate drawdown tolerated before flagging elevated risk."""
+
+    equity: float = 10000.0
+    """Baseline account equity used when computing risk budgets."""
 
 
 class RealRiskManager:
+    """Concrete portfolio risk assessor used by :class:`RiskManagerImpl`.
+
+    The implementation keeps track of account equity and evaluates incoming
+    position dictionaries against three simple guardrails:
+
+    * per-position exposure relative to ``max_position_risk``
+    * aggregate exposure relative to ``max_drawdown``
+    * gross leverage relative to current equity
+
+    The final risk score is the maximum of those ratios. A score ``> 1``
+    indicates that at least one guardrail has been breached.
+    """
+
     def __init__(self, config: RealRiskConfig) -> None:
         self.config = config
+        self.equity: float = max(float(config.equity), 0.0)
+        self._last_snapshot: Dict[str, float] = {
+            "total_exposure": 0.0,
+            "max_exposure": 0.0,
+            "position_ratio": 0.0,
+            "total_ratio": 0.0,
+            "gross_leverage": 0.0,
+            "risk_score": 0.0,
+        }
 
-    def assess_risk(self, positions: dict[str, float]) -> float:
-        return 0.0
+    def update_equity(self, equity: float | Decimal) -> None:
+        """Update the account equity used when computing risk budgets."""
+
+        try:
+            new_equity = float(equity)
+        except (TypeError, ValueError):
+            return
+
+        self.equity = max(new_equity, 0.0)
+        self.config.equity = self.equity
+
+    def assess_risk(self, positions: Mapping[str, float]) -> float:
+        """Return a scalar risk score for the supplied positions.
+
+        Args:
+            positions: Mapping of symbol to notional exposure.
+
+        Returns:
+            Maximum utilization of the configured risk budgets. ``0.0`` denotes
+            no risk, while values ``> 1`` indicate that at least one constraint
+            is currently violated.
+        """
+
+        exposures: list[float] = []
+        for raw_size in positions.values():
+            try:
+                size = float(raw_size)
+            except (TypeError, ValueError):
+                continue
+
+            if not math.isfinite(size):
+                continue
+
+            exposures.append(abs(size))
+
+        if not exposures:
+            self._last_snapshot = {
+                "total_exposure": 0.0,
+                "max_exposure": 0.0,
+                "position_ratio": 0.0,
+                "total_ratio": 0.0,
+                "gross_leverage": 0.0,
+                "risk_score": 0.0,
+            }
+            return 0.0
+
+        total_exposure = float(sum(exposures))
+        max_exposure = float(max(exposures))
+        equity = float(self.equity)
+
+        per_position_budget = self._resolve_budget(
+            self.config.max_position_risk, equity, max_exposure
+        )
+        total_budget = self._resolve_budget(
+            self.config.max_drawdown, equity, total_exposure
+        )
+
+        position_ratio = max_exposure / per_position_budget if per_position_budget else 0.0
+        total_ratio = total_exposure / total_budget if total_budget else 0.0
+        gross_leverage = total_exposure / equity if equity > 0 else total_exposure
+
+        risk_score = float(max(position_ratio, total_ratio, gross_leverage))
+
+        self._last_snapshot = {
+            "total_exposure": total_exposure,
+            "max_exposure": max_exposure,
+            "position_ratio": position_ratio,
+            "total_ratio": total_ratio,
+            "gross_leverage": gross_leverage,
+            "risk_score": risk_score,
+        }
+
+        return risk_score
+
+    @staticmethod
+    def _resolve_budget(percent: float, equity: float, fallback: float) -> float:
+        """Compute a positive budget based on the provided percentage and equity."""
+
+        try:
+            pct = float(percent)
+        except (TypeError, ValueError):
+            pct = 0.0
+
+        candidate = pct * equity
+        if candidate > 0:
+            return candidate
+
+        if equity > 0:
+            return equity
+
+        if fallback > 0:
+            return fallback
+
+        return 1.0
+
+    @property
+    def last_snapshot(self) -> Dict[str, float]:
+        """Return a copy of the most recent risk assessment snapshot."""
+
+        return dict(self._last_snapshot)
 
 
 __all__ = ["RealRiskConfig", "RealRiskManager"]

--- a/tests/current/test_real_risk_manager.py
+++ b/tests/current/test_real_risk_manager.py
@@ -1,0 +1,50 @@
+"""Unit tests for :mod:`src.risk.real_risk_manager`."""
+
+from __future__ import annotations
+
+import pytest
+
+from src.risk.real_risk_manager import RealRiskConfig, RealRiskManager
+
+
+def test_assess_risk_returns_zero_for_empty_positions() -> None:
+    manager = RealRiskManager(RealRiskConfig())
+
+    score = manager.assess_risk({})
+
+    assert score == pytest.approx(0.0)
+    assert manager.last_snapshot["risk_score"] == pytest.approx(0.0)
+    assert manager.last_snapshot["total_exposure"] == pytest.approx(0.0)
+
+
+def test_assess_risk_calculates_ratios() -> None:
+    config = RealRiskConfig(max_position_risk=0.02, max_drawdown=0.25, equity=50_000)
+    manager = RealRiskManager(config)
+
+    score = manager.assess_risk({"EURUSD": 1_000, "GBPUSD": 500})
+    snapshot = manager.last_snapshot
+
+    assert score == pytest.approx(1.0)
+    assert snapshot["position_ratio"] == pytest.approx(1.0)
+    assert snapshot["total_ratio"] == pytest.approx(0.12)
+    assert snapshot["gross_leverage"] == pytest.approx(0.03)
+
+
+def test_update_equity_rebalances_budgets() -> None:
+    manager = RealRiskManager(RealRiskConfig(equity=10_000))
+
+    initial = manager.assess_risk({"EURUSD": 1_000})
+    manager.update_equity(50_000)
+    updated = manager.assess_risk({"EURUSD": 1_000})
+
+    assert initial == pytest.approx(5.0)
+    assert updated == pytest.approx(1.0)
+
+
+def test_assess_risk_ignores_non_numeric_positions() -> None:
+    manager = RealRiskManager(RealRiskConfig(equity=20_000))
+
+    score = manager.assess_risk({"EURUSD": float("nan"), "GBPUSD": "oops", "USDJPY": 250})
+
+    # Only the valid USDJPY position should contribute to the risk calculation.
+    assert score == pytest.approx(250 / (0.02 * 20_000))

--- a/tests/current/test_risk_manager_impl.py
+++ b/tests/current/test_risk_manager_impl.py
@@ -151,6 +151,16 @@ def test_calculate_portfolio_risk_aggregates_and_delegates(monkeypatch: pytest.M
     assert snapshot["assessed_risk"] == pytest.approx(200.0)
 
 
+def test_calculate_portfolio_risk_uses_real_risk_manager_defaults() -> None:
+    manager = RiskManagerImpl(initial_balance=10_000)
+    manager.add_position("EURUSD", 1_000, 1.1)
+
+    snapshot = manager.calculate_portfolio_risk()
+
+    # RealRiskManager should surface the per-position breach (1000 vs 200 budget).
+    assert snapshot["assessed_risk"] == pytest.approx(5.0)
+
+
 def test_get_position_risk_handles_unknown_symbol() -> None:
     manager = RiskManagerImpl(initial_balance=10_000)
 


### PR DESCRIPTION
## Summary
- replace the stubbed `RealRiskManager` with an equity-aware risk scorer that tracks the latest assessment snapshot
- keep `RiskManagerImpl` in sync with the enhanced manager and add regression coverage for the default risk report path
- add dedicated unit tests covering the new risk calculations and equity update semantics

## Testing
- pytest tests/current/test_real_risk_manager.py tests/current/test_risk_manager_impl.py

------
https://chatgpt.com/codex/tasks/task_e_68cba24b43e4832ca9c5da813b4bbd0d