### PR TITLE
Fix mock FIX callback wiring and queue dispatch

### DIFF
--- a/src/operational/fix_connection_manager.py
+++ b/src/operational/fix_connection_manager.py
@@ -16,26 +16,114 @@ Responsibilities:
 from __future__ import annotations
 
 import asyncio
+import importlib
 import logging
 import os
-from typing import Any, Dict, Optional
+from collections.abc import Callable, Sequence
+from typing import Optional, Protocol, SupportsFloat, TypedDict, cast
 
-"""If genuine manager is available in the environment (installed as plugin or present
-in the source tree), import it lazily. Otherwise, we will fall back to mock when
-explicitly requested or when credentials are missing.
-"""
-try:
-    from src.operational.icmarkets_api import GenuineFIXManager  # type: ignore
-    from src.operational.icmarkets_config import ICMarketsConfig  # type: ignore
-except Exception:  # pragma: no cover
-    GenuineFIXManager = None  # type: ignore
-    ICMarketsConfig = None  # type: ignore
+from src.operational.mock_fix import MockFIXManager
 
-try:
-    from src.operational.mock_fix import MockFIXManager  # type: ignore
-except Exception:
-    MockFIXManager = None  # type: ignore
 
+class FIXMarketDataEntry(TypedDict):
+    """Normalized FIX-style market data entry."""
+
+    type: bytes
+    px: float
+    size: float
+
+
+FIXMessage = dict[int | bytes, bytes | list[FIXMarketDataEntry]]
+
+
+class OrderExecutionRecord(Protocol):
+    """Minimal mapping interface used when inspecting executions."""
+
+    def get(self, key: str, default: str | bytes | None = None) -> str | bytes | None: ...
+
+
+class OrderInfoProtocol(Protocol):
+    """Subset of ``OrderInfo`` attributes consumed by the connection manager."""
+
+    cl_ord_id: str
+    executions: Sequence[OrderExecutionRecord]
+
+
+class OrderBookLevelProtocol(Protocol):
+    """Expose price/size pairs from FIX managers."""
+
+    price: SupportsFloat
+    size: SupportsFloat
+
+
+class OrderBookProtocol(Protocol):
+    """Container for bid/ask ladders."""
+
+    bids: Sequence[OrderBookLevelProtocol]
+    asks: Sequence[OrderBookLevelProtocol]
+
+
+class FIXTradeConnectionProtocol(Protocol):
+    """Trade connection contract used for sending messages."""
+
+    def send_message_and_track(self, msg: object) -> bool: ...
+
+
+class FIXManagerProtocol(Protocol):
+    """Protocol implemented by both genuine and mock FIX managers."""
+
+    trade_connection: FIXTradeConnectionProtocol | None
+
+    def add_market_data_callback(self, cb: Callable[[str, OrderBookProtocol], None]) -> None: ...
+
+    def add_order_callback(self, cb: Callable[[OrderInfoProtocol], None]) -> None: ...
+
+    def start(self) -> bool: ...
+
+    def stop(self) -> None: ...
+
+
+class ICMarketsConfigLike(Protocol):
+    """Configuration interface required to construct the genuine FIX manager."""
+
+    def __init__(self, *, environment: str, account_number: str) -> None: ...
+
+    environment: str
+    account_number: str
+    password: str | None
+
+
+class FIXManagerFactory(Protocol):
+    def __call__(self, config: ICMarketsConfigLike) -> FIXManagerProtocol: ...
+
+
+class SystemConfigProtocol(Protocol):
+    """Subset of system config attributes referenced in this adapter."""
+
+    environment: str
+    account_number: str
+    password: str | None
+
+    def __getattr__(self, item: str) -> object: ...
+
+
+def _load_genuine_components() -> tuple[type[object] | None, type[object] | None]:
+    """Attempt to import the genuine FIX manager and config classes."""
+
+    try:
+        api_module = importlib.import_module("src.operational.icmarkets_api")
+        config_module = importlib.import_module("src.operational.icmarkets_config")
+    except Exception:  # pragma: no cover - optional dependency
+        return (None, None)
+
+    manager_cls = getattr(api_module, "GenuineFIXManager", None)
+    config_cls = getattr(config_module, "ICMarketsConfig", None)
+    if not isinstance(manager_cls, type) or not isinstance(config_cls, type):
+        return (None, None)
+    return manager_cls, config_cls
+
+
+_GENUINE_MANAGER_CLASS, _IC_CONFIG_CLASS = _load_genuine_components()
 
 logger = logging.getLogger(__name__)
 
@@ -43,41 +131,49 @@ logger = logging.getLogger(__name__)
 class _FIXApplicationAdapter:
     """Adapter that forwards incoming messages into an asyncio.Queue."""
 
-    def __init__(self, session_type: str):
+    def __init__(self, session_type: str) -> None:
         self._session_type = session_type
-        self._queue: Optional[asyncio.Queue] = None
+        self._queue: asyncio.Queue[FIXMessage] | None = None
 
-    def set_message_queue(self, queue: asyncio.Queue) -> None:
+    def set_message_queue(self, queue: asyncio.Queue[FIXMessage]) -> None:
         self._queue = queue
 
-    async def _put(self, message: Dict[str, Any]) -> None:
-        if self._queue is not None:
-            await self._queue.put(message)
+    def dispatch(self, message: FIXMessage) -> None:
+        queue = self._queue
+        if queue is None:
+            return
+
+        try:
+            queue.put_nowait(message)
+        except asyncio.QueueFull:
+            logger.warning(
+                "FIX %s queue is full; dropping message", self._session_type
+            )
 
 
 class _FIXInitiatorAdapter:
-    """Adapter exposing a `send_message` API to send trade messages."""
+    """Adapter exposing a ``send_message`` API to send trade messages."""
 
-    def __init__(self, manager: Any):
+    def __init__(self, manager: FIXManagerProtocol) -> None:
         self._manager = manager
 
-    def send_message(self, msg: Any) -> bool:
-        # Delegate to trade connection; `send_message_and_track` preserves headers
-        if not self._manager or not self._manager.trade_connection:
+    def send_message(self, msg: object) -> bool:
+        trade_connection = self._manager.trade_connection
+        if trade_connection is None:
             logger.error("Trade connection not initialized")
             return False
-        return self._manager.trade_connection.send_message_and_track(msg)
+        return trade_connection.send_message_and_track(msg)
 
 
 class FIXConnectionManager:
-    """Compatibility wrapper expected by `main.py`."""
+    """Compatibility wrapper expected by ``main.py``."""
 
-    def __init__(self, system_config) -> None:
+    def __init__(self, system_config: SystemConfigProtocol) -> None:
         self._system_config = system_config
-        self._manager: Optional[GenuineFIXManager] = None
+        self._manager: FIXManagerProtocol | None = None
         self._price_app = _FIXApplicationAdapter(session_type="quote")
         self._trade_app = _FIXApplicationAdapter(session_type="trade")
-        self._initiator: Optional[_FIXInitiatorAdapter] = None
+        self._initiator: _FIXInitiatorAdapter | None = None
 
     def start_sessions(self) -> bool:
         """Create and start genuine FIX sessions."""
@@ -96,94 +192,88 @@ class FIXConnectionManager:
                     "FIX_TRADE_PASSWORD",
                 )
             )
-            use_mock = bool(force_mock or (GenuineFIXManager is None) or (not creds_present))
+            use_mock = bool(
+                force_mock
+                or not creds_present
+                or _GENUINE_MANAGER_CLASS is None
+                or _IC_CONFIG_CLASS is None
+            )
 
+            manager: FIXManagerProtocol
             if use_mock:
-                if MockFIXManager is None:
-                    logger.error("MockFIXManager not available")
-                    return False
-                manager = MockFIXManager()
+                manager = cast(FIXManagerProtocol, MockFIXManager())
             else:
-                if ICMarketsConfig is None or GenuineFIXManager is None:
-                    logger.error("Genuine FIX components not available")
-                    return False
-                ic_cfg = ICMarketsConfig(
+                config_factory = cast(type[ICMarketsConfigLike], _IC_CONFIG_CLASS)
+                ic_cfg = config_factory(
                     environment=self._system_config.environment,
                     account_number=self._system_config.account_number,
                 )
-                # Inject password if present
-                ic_cfg.password = self._system_config.password
-                manager = GenuineFIXManager(ic_cfg)
+                ic_cfg.password = getattr(self._system_config, "password", None)
+                manager_factory = cast(FIXManagerFactory, _GENUINE_MANAGER_CLASS)
+                manager = manager_factory(ic_cfg)
 
             # Bridge market data: convert order book updates to queue-friendly messages
-            def on_market_data(symbol: str, order_book) -> None:
+            def on_market_data(symbol: str, order_book: OrderBookProtocol) -> None:
                 try:
-                    # Build a synthetic FIX-like message that the sensory organ can process
-                    entries = []
+                    entries: list[FIXMarketDataEntry] = []
                     for bid in getattr(order_book, "bids", [])[:10]:
-                        entries.append({"type": b"0", "px": bid.price, "size": bid.size})
+                        try:
+                            entries.append(
+                                FIXMarketDataEntry(
+                                    type=b"0",
+                                    px=float(bid.price),
+                                    size=float(bid.size),
+                                )
+                            )
+                        except (TypeError, ValueError, AttributeError):
+                            continue
                     for ask in getattr(order_book, "asks", [])[:10]:
-                        entries.append({"type": b"1", "px": ask.price, "size": ask.size})
+                        try:
+                            entries.append(
+                                FIXMarketDataEntry(
+                                    type=b"1",
+                                    px=float(ask.price),
+                                    size=float(ask.size),
+                                )
+                            )
+                        except (TypeError, ValueError, AttributeError):
+                            continue
 
-                    msg: Dict[Any, Any] = {
+                    msg: FIXMessage = {
                         35: b"W",  # Snapshot semantics for each full update
-                        55: symbol.encode("utf-8"),
+                        55: str(symbol).encode("utf-8"),
                         b"entries": entries,
                     }
 
-                    # Schedule put without blocking the FIX threads
-                    if self._price_app._queue is not None:
-                        try:
-                            loop = asyncio.get_running_loop()
-                        except RuntimeError:
-                            loop = None
-                        if loop and loop.is_running():
-                            loop.call_soon_threadsafe(
-                                lambda: asyncio.create_task(self._price_app._put(msg))
-                            )
-                        else:
-                            # Fallback: create a temporary loop to enqueue
-                            _loop = asyncio.new_event_loop()
-                            try:
-                                _loop.run_until_complete(self._price_app._put(msg))
-                            finally:
-                                _loop.close()
-                except Exception as e:
-                    logger.error(f"Error bridging market data: {e}")
+                    self._price_app.dispatch(msg)
+                except Exception as exc:
+                    logger.error("Error bridging market data: %s", exc)
 
             # Bridge order updates: push ExecutionReport-like messages
-            def on_order_update(order_info) -> None:
+            def on_order_update(order_info: OrderInfoProtocol) -> None:
                 try:
-                    exec_type = None
+                    exec_type_value: str | bytes | None = None
                     if order_info.executions:
-                        exec_type = order_info.executions[-1].get("exec_type")
+                        exec_type_value = order_info.executions[-1].get("exec_type")
 
-                    msg: Dict[Any, Any] = {
+                    exec_type_bytes: bytes | None
+                    if isinstance(exec_type_value, bytes):
+                        exec_type_bytes = exec_type_value
+                    elif isinstance(exec_type_value, str):
+                        exec_type_bytes = exec_type_value.encode("utf-8")
+                    else:
+                        exec_type_bytes = None
+
+                    msg: FIXMessage = {
                         35: b"8",  # ExecutionReport
                         11: order_info.cl_ord_id.encode("utf-8"),
                     }
-                    if exec_type:
-                        msg[150] = (
-                            exec_type.encode("utf-8") if isinstance(exec_type, str) else exec_type
-                        )
+                    if exec_type_bytes:
+                        msg[150] = exec_type_bytes
 
-                    if self._trade_app._queue is not None:
-                        try:
-                            loop = asyncio.get_running_loop()
-                        except RuntimeError:
-                            loop = None
-                        if loop and loop.is_running():
-                            loop.call_soon_threadsafe(
-                                lambda: asyncio.create_task(self._trade_app._put(msg))
-                            )
-                        else:
-                            _loop = asyncio.new_event_loop()
-                            try:
-                                _loop.run_until_complete(self._trade_app._put(msg))
-                            finally:
-                                _loop.close()
-                except Exception as e:
-                    logger.error(f"Error bridging order update: {e}")
+                    self._trade_app.dispatch(msg)
+                except Exception as exc:
+                    logger.error("Error bridging order update: %s", exc)
 
             manager.add_market_data_callback(on_market_data)
             manager.add_order_callback(on_order_update)
@@ -196,8 +286,8 @@ class FIXConnectionManager:
             self._initiator = _FIXInitiatorAdapter(manager)
             logger.info("FIXConnectionManager sessions started")
             return True
-        except Exception as e:
-            logger.error(f"Error starting FIX sessions: {e}")
+        except Exception as exc:  # pragma: no cover - defensive logging
+            logger.error("Error starting FIX sessions: %s", exc)
             return False
 
     def stop_sessions(self) -> None:


### PR DESCRIPTION
## Summary
- keep the mock trade connection wired to the live callback list so order events reach adapters
- simplify the FIX application adapter to use put_nowait, avoiding event-loop juggling that dropped messages

## Testing
- `pytest tests/current/test_fix_lifecycle.py`
- `pytest tests/current/test_fix_manager_failures.py`
- `pytest tests/current/test_fix_smoke.py`
- `mypy src/operational/mock_fix.py src/operational/fix_connection_manager.py`


------
https://chatgpt.com/codex/tasks/task_e_68cbd060bf2c832c9ba545799389d520