### PR TITLE
Add vision alignment reporting across bootstrap stack

### DIFF
--- a/src/core/base.py
+++ b/src/core/base.py
@@ -60,6 +60,7 @@ class DimensionalReading:
     signal_strength: float
     confidence: float = 0.0
     regime: MarketRegime = MarketRegime.UNKNOWN
+    timestamp: datetime | None = None
     context: dict[str, object] = field(default_factory=dict)
     data_quality: float = 1.0
     processing_time_ms: float = 0.0

--- a/src/core/evolution/engine.py
+++ b/src/core/evolution/engine.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
+import random
 from dataclasses import dataclass
 from time import time
-from typing import Callable, Optional, cast
+from typing import Callable, Dict, Mapping, Optional, Sequence, cast
 
 from src.core.genome import get_genome_provider
 from src.core.interfaces import DecisionGenome, PopulationManager as PopulationManagerProtocol
@@ -31,7 +32,7 @@ class EvolutionSummary:
 
 
 class EvolutionEngine:
-    """Consolidated evolution engine surface."""
+    """Consolidated evolution engine surface with crossover and mutation."""
 
     def __init__(
         self,
@@ -44,11 +45,12 @@ class EvolutionEngine:
         )
         self._initialized = False
         self._genome_counter = 0
+        self._rng = random.Random()
 
-    def evolve(
+    def ensure_population(
         self, genome_factory: Optional[Callable[[], DecisionGenome]] = None
-    ) -> EvolutionSummary:
-        """Run a minimal evolution cycle and return a summary of the results."""
+    ) -> Sequence[DecisionGenome]:
+        """Ensure a population exists and return a snapshot of it."""
 
         factory = genome_factory or self._default_genome_factory
 
@@ -56,21 +58,94 @@ class EvolutionEngine:
             self._population_manager.initialize_population(factory)
             self._initialized = True
 
-        if not self._population_manager.get_population():
-            self._population_manager.initialize_population(factory)
+        population = self._population_manager.get_population()
+        if not population:
+            seeds = [factory() for _ in range(self.config.population_size)]
+            self._population_manager.update_population(seeds)
+            population = self._population_manager.get_population()
 
-        elite_count = max(1, self.config.elite_count)
+        return list(population)
+
+    def get_population(self) -> Sequence[DecisionGenome]:
+        """Expose the current population for orchestration layers."""
+
+        return list(self._population_manager.get_population())
+
+    def get_population_statistics(self) -> Mapping[str, object]:
+        """Return the latest population statistics."""
+
+        return dict(self._population_manager.get_population_statistics())
+
+    def evolve(
+        self, genome_factory: Optional[Callable[[], DecisionGenome]] = None
+    ) -> EvolutionSummary:
+        """Run a full evolution cycle incorporating selection, crossover and mutation."""
+
+        factory = genome_factory or self._default_genome_factory
+
+        population = self.ensure_population(factory)
+
+        if not population:
+            stats = self._population_manager.get_population_statistics()
+            return EvolutionSummary(
+                generation=int(stats.get("generation", 0)),
+                population_size=0,
+                best_fitness=0.0,
+                average_fitness=0.0,
+                elite_count=0,
+                timestamp=time(),
+            )
+
+        stats_before = self._population_manager.get_population_statistics()
+        current_generation = int(stats_before.get("generation", 0))
+
+        elite_count = max(1, min(self.config.elite_count, len(population)))
         elites = list(self._population_manager.get_best_genomes(elite_count))
+        if not elites:
+            elites = [population[0]]
 
-        if elites:
-            new_population = list(elites)
-            while len(new_population) < self.config.population_size:
-                new_population.extend(elites)
-            new_population = new_population[: self.config.population_size]
-            self._population_manager.update_population(new_population)
-        else:
-            self._population_manager.initialize_population(factory)
+        new_population: list[DecisionGenome] = list(elites)
+        while len(new_population) < self.config.population_size:
+            parent1 = self._select_parent(population)
+            parent2 = self._select_parent(population) if len(population) > 1 else parent1
+            if parent2 is parent1 and len(population) > 1:
+                parent2 = self._select_alternate_parent(population, parent1)
 
+            params_a = self._extract_parameters(parent1)
+            params_b = self._extract_parameters(parent2)
+
+            if parent1 is parent2 or self._rng.random() >= self.config.crossover_rate:
+                child_params = dict(params_a)
+            else:
+                child_params = self._crossover_parameters(params_a, params_b)
+
+            child_params = self._mutate_parameters(child_params, self.config.mutation_rate)
+
+            species = (
+                getattr(parent1, "species_type", None)
+                or getattr(parent2, "species_type", None)
+                or "core_strategy"
+            )
+            child = self._spawn_genome(
+                parameters=child_params,
+                species=species,
+                parents=[parent for parent in (parent1, parent2) if parent is not None],
+                generation=current_generation + 1,
+            )
+
+            new_population.append(child)
+
+            # Periodically inject a fresh random genome to maintain diversity
+            if self._rng.random() < 0.05 and len(new_population) < self.config.population_size:
+                seed_child = self._spawn_genome(
+                    parameters=self._extract_parameters(factory()),
+                    species="core_strategy",
+                    parents=[],
+                    generation=current_generation + 1,
+                )
+                new_population.append(seed_child)
+
+        self._population_manager.update_population(new_population[: self.config.population_size])
         self._population_manager.advance_generation()
         stats = self._population_manager.get_population_statistics()
 
@@ -82,6 +157,110 @@ class EvolutionEngine:
             elite_count=len(elites),
             timestamp=time(),
         )
+
+    def _select_parent(self, population: Sequence[DecisionGenome]) -> DecisionGenome:
+        if len(population) == 1:
+            return population[0]
+        tournament = self._rng.sample(population, k=min(3, len(population)))
+        return max(tournament, key=lambda g: float(getattr(g, "fitness", 0.0) or 0.0))
+
+    def _select_alternate_parent(
+        self, population: Sequence[DecisionGenome], exclude: DecisionGenome
+    ) -> DecisionGenome:
+        candidates = [g for g in population if g is not exclude]
+        if not candidates:
+            return exclude
+        return self._select_parent(candidates)
+
+    def _extract_parameters(self, genome: DecisionGenome) -> Dict[str, float]:
+        params = getattr(genome, "parameters", {})
+        result: Dict[str, float] = {}
+        if isinstance(params, Mapping):
+            iterator = params.items()
+        else:
+            iterator = vars(params).items() if hasattr(params, "__dict__") else []
+        for key, value in iterator:
+            try:
+                result[str(key)] = float(value)
+            except Exception:
+                continue
+        return result
+
+    def _crossover_parameters(
+        self, params_a: Mapping[str, float], params_b: Mapping[str, float]
+    ) -> Dict[str, float]:
+        child: Dict[str, float] = {}
+        keys = set(params_a.keys()) | set(params_b.keys())
+        for key in keys:
+            a = float(params_a.get(key, params_b.get(key, 0.0)))
+            b = float(params_b.get(key, params_a.get(key, 0.0)))
+            weight = self._rng.random()
+            child[key] = weight * a + (1.0 - weight) * b
+        return child
+
+    def _mutate_parameters(
+        self, parameters: Mapping[str, float], mutation_rate: float
+    ) -> Dict[str, float]:
+        mutated = dict(parameters)
+        for key, value in list(mutated.items()):
+            if self._rng.random() < mutation_rate:
+                scale = abs(value) if value else 1.0
+                mutated[key] = float(value + self._rng.gauss(0.0, 0.15 * scale))
+        return mutated
+
+    def _spawn_genome(
+        self,
+        parameters: Mapping[str, float],
+        species: str,
+        parents: Sequence[DecisionGenome],
+        generation: int,
+    ) -> DecisionGenome:
+        provider = get_genome_provider()
+        self._genome_counter += 1
+        identifier = f"core-evo-{self._genome_counter:05d}"
+        genome = provider.new_genome(
+            id=identifier,
+            parameters=dict(parameters),
+            generation=generation,
+            species_type=species,
+        )
+        if not isinstance(genome, DecisionGenome):
+            genome = cast(DecisionGenome, provider.from_legacy(genome))
+
+        parent_ids = [getattr(parent, "id", "") for parent in parents if getattr(parent, "id", None)]
+        genome = self._apply_parent_metadata(genome, parent_ids, generation)
+        self._normalize_genome(genome)
+        try:
+            setattr(genome, "fitness", None)
+        except Exception:
+            pass
+        return genome
+
+    def _apply_parent_metadata(
+        self, genome: DecisionGenome, parent_ids: Sequence[str], generation: int
+    ) -> DecisionGenome:
+        try:
+            if hasattr(genome, "with_updated"):
+                genome = cast(
+                    DecisionGenome,
+                    genome.with_updated(parent_ids=list(parent_ids), generation=int(generation)),
+                )
+            else:
+                if parent_ids and hasattr(genome, "parent_ids"):
+                    setattr(genome, "parent_ids", list(parent_ids))
+                if hasattr(genome, "generation"):
+                    setattr(genome, "generation", int(generation))
+        except Exception:
+            pass
+        return genome
+
+    def _normalize_genome(self, genome: DecisionGenome) -> None:
+        try:
+            normalizer = getattr(genome, "_normalize_weights", None)
+            if callable(normalizer):
+                normalizer()
+        except Exception:
+            pass
 
     def _default_genome_factory(self) -> DecisionGenome:
         provider = get_genome_provider()

--- a/src/data_foundation/__init__.py
+++ b/src/data_foundation/__init__.py
@@ -1,3 +1,6 @@
 from __future__ import annotations
 
-__all__: list[str] = []
+from .fabric.historical_connector import HistoricalReplayConnector
+from .fabric.market_data_fabric import CallableConnector, MarketDataFabric
+
+__all__ = ["CallableConnector", "HistoricalReplayConnector", "MarketDataFabric"]

--- a/src/data_foundation/fabric/historical_connector.py
+++ b/src/data_foundation/fabric/historical_connector.py
@@ -1,0 +1,94 @@
+"""Historical replay connector for the market data fabric."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Iterable, Mapping, MutableMapping, Sequence
+
+from src.core.base import MarketData
+
+from .market_data_fabric import ConnectorResult
+
+
+def _normalise_timestamp(value: object) -> datetime:
+    if isinstance(value, datetime):
+        return value
+    raise TypeError(f"Unsupported timestamp type: {type(value)!r}")
+
+
+def _coerce_market_data(symbol: str, payload: object) -> MarketData:
+    if isinstance(payload, MarketData):
+        return payload
+    if isinstance(payload, Mapping):
+        data: MutableMapping[str, object] = dict(payload)
+        data.setdefault("symbol", symbol)
+        if "timestamp" in data:
+            try:
+                data["timestamp"] = _normalise_timestamp(data["timestamp"])
+            except TypeError:
+                data.pop("timestamp")
+        return MarketData(**data)
+    raise TypeError(f"Unsupported historical payload: {type(payload)!r}")
+
+
+@dataclass
+class HistoricalReplayConnector:
+    """Serve deterministic market data ticks from an in-memory sequence."""
+
+    name: str = "historical_replay"
+    priority: int = 100
+    forward_fill: bool = True
+    _series: dict[str, list[MarketData]] = field(default_factory=dict, init=False)
+    _indices: dict[str, int] = field(default_factory=dict, init=False)
+
+    def __init__(
+        self,
+        bars_by_symbol: Mapping[str, Sequence[object]] | Mapping[str, Iterable[object]],
+        *,
+        name: str = "historical_replay",
+        priority: int = 100,
+        forward_fill: bool = True,
+    ) -> None:
+        self.name = name
+        self.priority = priority
+        self.forward_fill = forward_fill
+        self._series = {}
+        self._indices = {}
+
+        for symbol, items in bars_by_symbol.items():
+            normalised: list[MarketData] = []
+            for payload in items:
+                normalised.append(_coerce_market_data(symbol, payload))
+            normalised.sort(key=lambda md: md.timestamp)
+            self._series[symbol] = normalised
+            self._indices[symbol] = 0
+
+    async def fetch(
+        self, symbol: str, *, as_of: datetime | None = None
+    ) -> ConnectorResult:
+        series = self._series.get(symbol)
+        if not series:
+            return None
+
+        if as_of is not None:
+            candidate = None
+            for item in series:
+                if item.timestamp <= as_of:
+                    candidate = item
+                else:
+                    break
+            if candidate is not None:
+                return candidate
+            return series[0] if self.forward_fill else None
+
+        index = self._indices.get(symbol, 0)
+        if index >= len(series):
+            return series[-1] if self.forward_fill and series else None
+
+        result = series[index]
+        self._indices[symbol] = index + 1
+        return result
+
+
+__all__ = ["HistoricalReplayConnector"]

--- a/src/data_foundation/fabric/market_data_fabric.py
+++ b/src/data_foundation/fabric/market_data_fabric.py
@@ -1,0 +1,227 @@
+from __future__ import annotations
+
+import asyncio
+import inspect
+import logging
+from collections import defaultdict
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta, timezone
+from typing import Any, Awaitable, Callable, Dict, Mapping, Optional, Protocol
+
+from src.core.base import MarketData
+
+__all__ = [
+    "ConnectorResult",
+    "MarketDataConnector",
+    "CallableConnector",
+    "MarketDataFabric",
+]
+
+logger = logging.getLogger(__name__)
+
+ConnectorResult = Optional[MarketData | Mapping[str, Any]]
+
+
+class MarketDataConnector(Protocol):
+    """Protocol describing the fabric connector contract."""
+
+    name: str
+    priority: int
+
+    async def fetch(
+        self, symbol: str, *, as_of: datetime | None = None
+    ) -> ConnectorResult: ...
+
+
+@dataclass
+class CallableConnector:
+    """Adapter that turns plain callables into :class:`MarketDataConnector` objects."""
+
+    name: str
+    func: Callable[
+        [str, datetime | None], ConnectorResult | Awaitable[ConnectorResult]
+    ] | Callable[[str], ConnectorResult | Awaitable[ConnectorResult]]
+    priority: int = 100
+    timeout: float | None = None
+
+    async def fetch(
+        self, symbol: str, *, as_of: datetime | None = None
+    ) -> ConnectorResult:
+        try:
+            result = self.func(symbol, as_of)  # type: ignore[arg-type]
+        except TypeError:
+            result = self.func(symbol)  # type: ignore[misc]
+        if inspect.isawaitable(result):
+            return await result
+        return result
+
+
+@dataclass
+class _CacheEntry:
+    data: MarketData
+    source: str
+    fetched_at: datetime
+
+    @property
+    def age(self) -> timedelta:
+        return datetime.now(timezone.utc) - self.fetched_at
+
+
+@dataclass
+class FabricTelemetry:
+    total_requests: int = 0
+    cache_hits: int = 0
+    connector_success: Dict[str, int] = field(default_factory=lambda: defaultdict(int))
+    connector_failures: Dict[str, int] = field(default_factory=lambda: defaultdict(int))
+    connector_latency_ms: Dict[str, float] = field(default_factory=dict)
+
+
+class MarketDataFabric:
+    """Asynchronous market data fabric with connector failover and caching."""
+
+    def __init__(
+        self,
+        connectors: Mapping[str, MarketDataConnector] | None = None,
+        *,
+        cache_ttl: timedelta | None = None,
+        default_timeout: float = 2.0,
+    ) -> None:
+        self._connectors: Dict[str, MarketDataConnector] = {}
+        if connectors:
+            for name, connector in connectors.items():
+                self.register_connector(connector)
+        self.cache_ttl = cache_ttl if cache_ttl is not None else timedelta(seconds=10)
+        self.default_timeout = default_timeout
+        self._cache: Dict[str, _CacheEntry] = {}
+        self.telemetry = FabricTelemetry()
+
+    def register_connector(self, connector: MarketDataConnector) -> None:
+        if connector.name in self._connectors:
+            logger.warning("Replacing existing connector %s", connector.name)
+        self._connectors[connector.name] = connector
+
+    @property
+    def connectors(self) -> Dict[str, MarketDataConnector]:
+        return dict(self._connectors)
+
+    async def fetch_latest(
+        self,
+        symbol: str,
+        *,
+        as_of: datetime | None = None,
+        timeout: float | None = None,
+        allow_stale: bool = True,
+        use_cache: bool = True,
+    ) -> MarketData:
+        now = datetime.now(timezone.utc)
+        self.telemetry.total_requests += 1
+        entry = self._cache.get(symbol)
+        if (
+            use_cache
+            and entry is not None
+            and now - entry.fetched_at <= self.cache_ttl
+        ):
+            self.telemetry.cache_hits += 1
+            return entry.data
+
+        ordered = sorted(self._connectors.values(), key=lambda c: getattr(c, "priority", 100))
+        last_error: Exception | None = None
+
+        for connector in ordered:
+            started = datetime.now(timezone.utc)
+            conn_timeout = timeout if timeout is not None else getattr(connector, "timeout", None)
+            if conn_timeout is None:
+                conn_timeout = self.default_timeout
+
+            try:
+                result = await asyncio.wait_for(
+                    connector.fetch(symbol, as_of=as_of), timeout=conn_timeout
+                )
+            except asyncio.TimeoutError as exc:
+                self.telemetry.connector_failures[connector.name] += 1
+                last_error = exc
+                logger.warning(
+                    "Connector %s timed out for %s after %.2fs",
+                    connector.name,
+                    symbol,
+                    conn_timeout,
+                )
+                continue
+            except Exception as exc:  # pragma: no cover - resilience guard
+                self.telemetry.connector_failures[connector.name] += 1
+                last_error = exc
+                logger.warning("Connector %s failed for %s: %s", connector.name, symbol, exc)
+                continue
+
+            latency = (datetime.now(timezone.utc) - started).total_seconds() * 1000.0
+            self.telemetry.connector_latency_ms[connector.name] = latency
+
+            market_data = self._coerce_market_data(result, symbol)
+            if market_data is None:
+                self.telemetry.connector_failures[connector.name] += 1
+                continue
+
+            self.telemetry.connector_success[connector.name] += 1
+            self._cache[symbol] = _CacheEntry(
+                data=market_data,
+                source=connector.name,
+                fetched_at=datetime.now(timezone.utc),
+            )
+            return market_data
+
+        if entry and allow_stale:
+            logger.warning(
+                "All connectors failed for %s, returning stale data fetched %.1fs ago",
+                symbol,
+                entry.age.total_seconds(),
+            )
+            return entry.data
+
+        raise RuntimeError(
+            f"No market data available for {symbol}: {last_error!r}" if last_error else f"No data for {symbol}"
+        )
+
+    def get_diagnostics(self) -> Dict[str, Any]:
+        cache_info = {
+            symbol: {
+                "source": entry.source,
+                "age_seconds": round(entry.age.total_seconds(), 3),
+            }
+            for symbol, entry in self._cache.items()
+        }
+        return {
+            "connectors": sorted(self._connectors.keys()),
+            "telemetry": {
+                "total_requests": self.telemetry.total_requests,
+                "cache_hits": self.telemetry.cache_hits,
+                "success": dict(self.telemetry.connector_success),
+                "failures": dict(self.telemetry.connector_failures),
+                "latency_ms": dict(self.telemetry.connector_latency_ms),
+            },
+            "cache": cache_info,
+        }
+
+    def invalidate_cache(self, symbol: str | None = None) -> None:
+        """Remove cached entries for ``symbol`` or clear the entire cache."""
+
+        if symbol is None:
+            self._cache.clear()
+            return
+        self._cache.pop(symbol, None)
+
+    @staticmethod
+    def _coerce_market_data(
+        result: ConnectorResult, symbol: str
+    ) -> MarketData | None:
+        if result is None:
+            return None
+        if isinstance(result, MarketData):
+            return result
+        if isinstance(result, Mapping):
+            payload = dict(result)
+            payload.setdefault("symbol", symbol)
+            if "timestamp" not in payload:
+                payload["timestamp"] = datetime.now(timezone.utc)
+            return MarketData(**payload)
+        logger.debug("Unsupported connector payload type %s", type(result))
+        return None

--- a/src/governance/vision_alignment.py
+++ b/src/governance/vision_alignment.py
@@ -1,0 +1,412 @@
+"""Governance helpers that track progress against the encyclopedia vision."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Iterable, Mapping
+
+__all__ = [
+    "LayerAssessment",
+    "VisionAlignmentReport",
+]
+
+
+def _status_from_coverage(coverage: float) -> str:
+    if coverage >= 0.85:
+        return "ready"
+    if coverage >= 0.45:
+        return "progressing"
+    return "gap"
+
+
+def _as_float(value: Any, default: float = 0.0) -> float:
+    try:
+        return float(value)
+    except Exception:
+        return default
+
+
+@dataclass(slots=True)
+class LayerAssessment:
+    """Snapshot describing how a single layer aligns with the roadmap."""
+
+    layer: str
+    coverage: float
+    strengths: list[str] = field(default_factory=list)
+    gaps: list[str] = field(default_factory=list)
+    evidence: Mapping[str, Any] = field(default_factory=dict)
+
+    def status(self) -> str:
+        return _status_from_coverage(self.coverage)
+
+    def as_payload(self) -> dict[str, Any]:
+        return {
+            "layer": self.layer,
+            "status": self.status(),
+            "coverage": round(self.coverage, 3),
+            "strengths": list(self.strengths),
+            "gaps": list(self.gaps),
+            "evidence": dict(self.evidence),
+        }
+
+
+class VisionAlignmentReport:
+    """Evaluate runtime components against the encyclopedia's five layers."""
+
+    def __init__(
+        self,
+        *,
+        fabric: Any | None,
+        pipeline: Any | None,
+        trading_manager: Any | None,
+        control_center: Any | None = None,
+        evolution_orchestrator: Any | None = None,
+        encyclopedia_version: str = "2.3",
+    ) -> None:
+        self.fabric = fabric
+        self.pipeline = pipeline
+        self.trading_manager = trading_manager
+        self.control_center = control_center
+        self.evolution_orchestrator = evolution_orchestrator
+        self.encyclopedia_version = encyclopedia_version
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+    def build(self) -> Mapping[str, Any]:
+        layers = [
+            self._assess_data_foundation(),
+            self._assess_sensory_cortex(),
+            self._assess_intelligence_engine(),
+            self._assess_evolutionary_layer(),
+            self._assess_trading_layer(),
+        ]
+
+        readiness = 0.0
+        if layers:
+            readiness = sum(layer.coverage for layer in layers) / len(layers)
+
+        summary_status = _status_from_coverage(readiness)
+
+        gaps = self._collect_unique(it.gaps for it in layers)
+        strengths = self._collect_unique(it.strengths for it in layers)
+
+        return {
+            "encyclopedia_version": self.encyclopedia_version,
+            "summary": {
+                "readiness": round(readiness, 3),
+                "status": summary_status,
+                "layers_ready": sum(1 for layer in layers if layer.status() == "ready"),
+                "layers_progressing": sum(
+                    1 for layer in layers if layer.status() == "progressing"
+                ),
+            },
+            "layers": [layer.as_payload() for layer in layers],
+            "strengths": strengths,
+            "gaps": gaps,
+        }
+
+    def summary(self) -> Mapping[str, Any]:
+        return self.build()["summary"]
+
+    # ------------------------------------------------------------------
+    # Layer assessors
+    # ------------------------------------------------------------------
+    def _assess_data_foundation(self) -> LayerAssessment:
+        fabric = self.fabric
+        connectors: list[str] = []
+        diagnostics: Mapping[str, Any] = {}
+        cache_ttl_seconds: float | None = None
+
+        if fabric is not None:
+            try:
+                registered = getattr(fabric, "connectors", {})
+                if isinstance(registered, Mapping):
+                    connectors = sorted(str(name) for name in registered)
+            except Exception:
+                connectors = []
+
+            try:
+                cache_ttl = getattr(fabric, "cache_ttl", None)
+                cache_ttl_seconds = getattr(cache_ttl, "total_seconds", lambda: None)()
+            except Exception:
+                cache_ttl_seconds = None
+
+            if hasattr(fabric, "get_diagnostics"):
+                try:
+                    diagnostics = fabric.get_diagnostics()
+                except Exception:
+                    diagnostics = {}
+
+        coverage = 0.0
+        strengths: list[str] = []
+        gaps: list[str] = []
+
+        connector_count = len(connectors)
+        if connector_count >= 2:
+            coverage = 0.92
+            strengths.append(f"{connector_count} market data connectors online")
+        elif connector_count == 1:
+            coverage = 0.62
+            strengths.append("single market data connector active")
+            gaps.append("Add redundant connectors for failover")
+        else:
+            coverage = 0.25
+            gaps.append("Register market data connectors to activate the fabric")
+
+        if diagnostics:
+            successes = diagnostics.get("telemetry", {}).get("success", {})
+            if isinstance(successes, Mapping) and any(successes.values()):
+                strengths.append("connectors returning live data")
+            failures = diagnostics.get("telemetry", {}).get("failures", {})
+            if isinstance(failures, Mapping) and sum(_as_float(v) for v in failures.values()) > 0:
+                gaps.append("Resolve failing data connectors")
+
+        evidence: dict[str, Any] = {"connectors": connectors}
+        if cache_ttl_seconds is not None:
+            evidence["cache_ttl_seconds"] = cache_ttl_seconds
+        if diagnostics:
+            evidence["diagnostics"] = diagnostics
+
+        return LayerAssessment(
+            layer="Layer 1 – Data Foundation",
+            coverage=coverage,
+            strengths=strengths,
+            gaps=gaps,
+            evidence=evidence,
+        )
+
+    def _assess_sensory_cortex(self) -> LayerAssessment:
+        pipeline = self.pipeline
+        history_samples = 0
+        fusion_readings = 0
+        recent_symbols: list[str] = []
+
+        if pipeline is not None:
+            history = getattr(pipeline, "history", {})
+            if isinstance(history, Mapping):
+                for symbol, entries in history.items():
+                    try:
+                        count = len(entries)
+                    except Exception:
+                        count = 0
+                    history_samples += count
+                    if count:
+                        recent_symbols.append(str(symbol))
+
+            fusion_engine = getattr(pipeline, "fusion_engine", None)
+            if fusion_engine is not None:
+                readings = getattr(fusion_engine, "current_readings", {})
+                if isinstance(readings, Mapping):
+                    fusion_readings = len(readings)
+
+        coverage = 0.2
+        strengths: list[str] = []
+        gaps: list[str] = []
+
+        if history_samples >= 10 and fusion_readings >= 5:
+            coverage = 0.9
+            strengths.append("4D+1 sensory engines producing fused snapshots")
+        elif history_samples > 0:
+            coverage = 0.55
+            strengths.append("sensory pipeline processing market ticks")
+            if fusion_readings < 5:
+                gaps.append("Complete dimensional coverage for all sensors")
+        else:
+            coverage = 0.25
+            gaps.append("Stream market ticks through the sensory pipeline")
+
+        evidence = {
+            "history_samples": history_samples,
+            "recent_symbols": recent_symbols,
+            "dimensions_active": fusion_readings,
+        }
+
+        return LayerAssessment(
+            layer="Layer 2 – 4D+1 Sensory Cortex",
+            coverage=coverage,
+            strengths=strengths,
+            gaps=gaps,
+            evidence=evidence,
+        )
+
+    def _assess_intelligence_engine(self) -> LayerAssessment:
+        fusion_engine = getattr(self.pipeline, "fusion_engine", None)
+        diagnostics: Mapping[str, Any] = {}
+        adaptive_weights: Mapping[str, Any] = {}
+        patterns: Iterable[Any] = ()
+
+        if fusion_engine is not None and hasattr(fusion_engine, "get_diagnostic_information"):
+            try:
+                diagnostics = fusion_engine.get_diagnostic_information()
+            except Exception:
+                diagnostics = {}
+
+        if isinstance(diagnostics, Mapping):
+            adaptive_weights = diagnostics.get("adaptive_weights", {})
+            patterns = diagnostics.get("patterns", ())
+
+        weight_count = len(adaptive_weights) if isinstance(adaptive_weights, Mapping) else 0
+        pattern_count = len(list(patterns)) if patterns else 0
+
+        coverage = 0.3
+        strengths: list[str] = []
+        gaps: list[str] = []
+
+        if weight_count >= 5 and pattern_count > 0:
+            coverage = 0.88
+            strengths.append("fusion engine adapting weights and spotting patterns")
+        elif weight_count >= 3:
+            coverage = 0.58
+            strengths.append("contextual fusion recalibrating weights")
+            gaps.append("Expand diagnostics to surface cross-dimensional patterns")
+        else:
+            coverage = 0.28
+            gaps.append("Enable adaptive fusion diagnostics")
+
+        evidence = {
+            "adaptive_weights": dict(adaptive_weights) if isinstance(adaptive_weights, Mapping) else {},
+            "pattern_count": pattern_count,
+        }
+        if isinstance(diagnostics, Mapping):
+            evidence["diagnostics"] = diagnostics
+
+        return LayerAssessment(
+            layer="Layer 3 – Intelligence Engine",
+            coverage=coverage,
+            strengths=strengths,
+            gaps=gaps,
+            evidence=evidence,
+        )
+
+    def _assess_evolutionary_layer(self) -> LayerAssessment:
+        orchestrator = self.evolution_orchestrator
+        telemetry: Mapping[str, Any] | None = None
+        champion_payload: Mapping[str, Any] | None = None
+
+        if orchestrator is not None:
+            telemetry_candidate = getattr(orchestrator, "telemetry", None)
+            if isinstance(telemetry_candidate, Mapping):
+                telemetry = telemetry_candidate
+
+            champion = getattr(orchestrator, "champion", None)
+            if champion is not None:
+                if hasattr(champion, "as_payload"):
+                    try:
+                        champion_payload = champion.as_payload()
+                    except Exception:
+                        champion_payload = {"genome_id": getattr(champion, "genome_id", None)}
+                elif isinstance(champion, Mapping):
+                    champion_payload = champion
+
+        total_generations = 0
+        if telemetry is not None:
+            total_generations = int(telemetry.get("total_generations", 0))
+
+        coverage = 0.35
+        strengths: list[str] = []
+        gaps: list[str] = [
+            "Wire evolutionary telemetry into governance reports"
+        ]
+
+        if orchestrator is None:
+            coverage = 0.3
+            gaps.append("Integrate EvolutionCycleOrchestrator to activate Layer 4")
+        elif total_generations > 0:
+            coverage = 0.86
+            strengths.append(f"{total_generations} generations evolved")
+            gaps = [gap for gap in gaps if "Wire" not in gap]
+        else:
+            coverage = 0.55
+            strengths.append("evolution orchestrator ready for evaluation")
+            gaps.append("Run evolution cycles to produce live champions")
+
+        evidence = {
+            "telemetry": telemetry or {},
+            "champion": champion_payload,
+        }
+
+        return LayerAssessment(
+            layer="Layer 4 – Evolutionary Strategy Engine",
+            coverage=coverage,
+            strengths=strengths,
+            gaps=gaps,
+            evidence=evidence,
+        )
+
+    def _assess_trading_layer(self) -> LayerAssessment:
+        trading_manager = self.trading_manager
+        control_center = self.control_center
+        coverage = 0.35
+        strengths: list[str] = []
+        gaps: list[str] = []
+        evidence: dict[str, Any] = {}
+
+        risk_gateway = getattr(trading_manager, "risk_gateway", None) if trading_manager else None
+        portfolio_monitor = getattr(trading_manager, "portfolio_monitor", None) if trading_manager else None
+        execution_engine = getattr(trading_manager, "execution_engine", None) if trading_manager else None
+
+        if risk_gateway is not None:
+            coverage += 0.25
+            strengths.append("risk gateway enforcing encyclopedia limits")
+            limits = (
+                risk_gateway.get_risk_limits()
+                if hasattr(risk_gateway, "get_risk_limits")
+                else None
+            )
+            if isinstance(limits, Mapping):
+                evidence["risk_limits"] = limits
+
+        if portfolio_monitor is not None and hasattr(portfolio_monitor, "get_state"):
+            coverage += 0.25
+            strengths.append("portfolio monitor tracking exposure")
+            try:
+                state = portfolio_monitor.get_state()
+            except Exception:
+                state = {}
+            if isinstance(state, Mapping):
+                evidence["portfolio_state"] = dict(state)
+        else:
+            gaps.append("Activate portfolio monitor for exposure tracking")
+
+        if execution_engine is not None:
+            coverage += 0.2
+            strengths.append("execution adapter processing fills")
+
+        if control_center is not None and hasattr(control_center, "recent_decisions"):
+            try:
+                recent = control_center.recent_decisions(limit=5)
+            except Exception:
+                recent = []
+            evidence["recent_decisions"] = recent
+            if not recent:
+                gaps.append("Route trade decisions into the control centre")
+
+        coverage = min(coverage, 0.95)
+        if coverage < 0.45 and not gaps:
+            gaps.append("Complete risk, portfolio, and execution wiring")
+
+        return LayerAssessment(
+            layer="Layer 5 – Trading, Risk & Execution",
+            coverage=coverage,
+            strengths=strengths,
+            gaps=gaps,
+            evidence=evidence,
+        )
+
+    # ------------------------------------------------------------------
+    # Utilities
+    # ------------------------------------------------------------------
+    @staticmethod
+    def _collect_unique(items: Iterable[Iterable[str]]) -> list[str]:
+        unique: list[str] = []
+        seen: set[str] = set()
+        for sequence in items:
+            for item in sequence:
+                if not item:
+                    continue
+                if item not in seen:
+                    seen.add(item)
+                    unique.append(item)
+        return unique
+

--- a/src/operations/__init__.py
+++ b/src/operations/__init__.py
@@ -1,0 +1,5 @@
+"""Operations layer utilities for runtime observability."""
+
+from .bootstrap_control_center import BootstrapControlCenter
+
+__all__ = ["BootstrapControlCenter"]

--- a/src/operations/bootstrap_control_center.py
+++ b/src/operations/bootstrap_control_center.py
@@ -1,0 +1,315 @@
+"""Operational control centre consolidating bootstrap telemetry."""
+
+from __future__ import annotations
+
+from collections import deque
+from datetime import datetime
+from itertools import islice
+from typing import Any, Deque, Iterable, Mapping
+
+from src.governance.vision_alignment import VisionAlignmentReport
+from src.orchestration.bootstrap_stack import SensorySnapshot
+
+
+def _as_float(value: object, default: float = 0.0) -> float:
+    try:
+        return float(value)
+    except Exception:
+        return default
+
+
+class BootstrapControlCenter:
+    """Aggregate portfolio, risk, intelligence, liquidity, and execution telemetry."""
+
+    def __init__(
+        self,
+        *,
+        pipeline: Any,
+        trading_manager: Any,
+        execution_adapter: Any | None = None,
+        liquidity_prober: Any | None = None,
+        evolution_orchestrator: Any | None = None,
+        history_limit: int = 256,
+    ) -> None:
+        self.pipeline = pipeline
+        self.trading_manager = trading_manager
+        self.portfolio_monitor = getattr(trading_manager, "portfolio_monitor", None)
+        self.risk_gateway = getattr(trading_manager, "risk_gateway", None)
+        self.execution_adapter = execution_adapter
+        self.liquidity_prober = liquidity_prober
+        self.evolution_orchestrator = evolution_orchestrator
+
+        self._history: Deque[dict[str, Any]] = deque(maxlen=max(16, history_limit))
+        self._last_snapshot: SensorySnapshot | None = None
+        self._last_liquidity_summary: dict[str, Any] | None = None
+
+    # ------------------------------------------------------------------
+    # Recording helpers
+    # ------------------------------------------------------------------
+    def record_tick(self, *, snapshot: SensorySnapshot, result: Mapping[str, Any]) -> None:
+        """Register a decision cycle for downstream reporting."""
+
+        decision = result.get("decision") if isinstance(result, Mapping) else None
+        liquidity_summary = result.get("liquidity_summary") if isinstance(result, Mapping) else None
+
+        record: dict[str, Any] = {
+            "symbol": snapshot.symbol,
+            "generated_at": snapshot.generated_at.isoformat(),
+            "status": result.get("status"),
+            "unified_score": float(snapshot.synthesis.unified_score),
+            "confidence": float(snapshot.synthesis.confidence),
+            "narrative": snapshot.synthesis.dominant_narrative.name,
+        }
+
+        if isinstance(decision, Mapping):
+            record["decision_status"] = decision.get("status")
+            record["decision_reason"] = decision.get("reason")
+            record["checks"] = list(decision.get("checks", ()))
+        else:
+            record["decision_status"] = None
+            record["decision_reason"] = None
+            record["checks"] = []
+
+        if isinstance(liquidity_summary, Mapping):
+            self._last_liquidity_summary = dict(liquidity_summary)
+
+        self._history.appendleft(record)
+        self._last_snapshot = snapshot
+
+    # ------------------------------------------------------------------
+    # Public reporting surfaces
+    # ------------------------------------------------------------------
+    def recent_decisions(self, limit: int = 5) -> list[Mapping[str, Any]]:
+        return [dict(item) for item in islice(self._history, 0, max(1, limit))]
+
+    def generate_report(self) -> Mapping[str, Any]:
+        """Build a detailed operations snapshot."""
+
+        portfolio = self._build_portfolio_section()
+        risk = self._build_risk_section()
+        intelligence = self._build_intelligence_section()
+        liquidity = self._build_liquidity_section()
+        performance = self._build_performance_section(portfolio)
+        evolution = self._build_evolution_section()
+        vision = self._build_vision_section()
+
+        return {
+            "generated_at": datetime.utcnow().isoformat(),
+            "portfolio": portfolio,
+            "risk": risk,
+            "intelligence": intelligence,
+            "liquidity": liquidity,
+            "performance": performance,
+            "evolution": evolution,
+            "vision_alignment": vision,
+            "decisions": {
+                "recent": self.recent_decisions(10),
+                "total_logged": len(self._history),
+            },
+        }
+
+    def overview(self) -> Mapping[str, Any]:
+        """Return a lightweight summary for runtime.status() consumers."""
+
+        portfolio_state = self._safe_portfolio_state()
+        open_positions = portfolio_state.get("open_positions_count")
+        if open_positions is None:
+            open_positions = len(portfolio_state.get("open_positions", {}))
+
+        latest = next(iter(self._history), None)
+
+        overview = {
+            "equity": _as_float(portfolio_state.get("equity"), default=0.0),
+            "realized_pnl": _as_float(portfolio_state.get("realized_pnl"), default=0.0),
+            "unrealized_pnl": _as_float(portfolio_state.get("unrealized_pnl"), default=0.0),
+            "open_positions": int(open_positions or 0),
+            "last_decision": dict(latest) if latest else None,
+        }
+
+        evolution_overview = self._build_evolution_overview()
+        if evolution_overview:
+            overview["evolution"] = evolution_overview
+
+        vision_summary = self._build_vision_summary()
+        if vision_summary:
+            overview["vision_alignment"] = vision_summary
+
+        return overview
+
+    # ------------------------------------------------------------------
+    # Section builders
+    # ------------------------------------------------------------------
+    def _build_portfolio_section(self) -> dict[str, Any]:
+        state = self._safe_portfolio_state()
+
+        exposures = {"long": 0.0, "short": 0.0}
+        open_positions = state.get("open_positions", {})
+        if isinstance(open_positions, Mapping):
+            for payload in open_positions.values():
+                if not isinstance(payload, Mapping):
+                    continue
+                quantity = _as_float(payload.get("quantity"), default=0.0)
+                value = _as_float(payload.get("current_value"), default=0.0)
+                if quantity >= 0:
+                    exposures["long"] += value
+                else:
+                    exposures["short"] += abs(value)
+
+        portfolio = dict(state)
+        portfolio["exposures"] = exposures
+        return portfolio
+
+    def _build_risk_section(self) -> Mapping[str, Any]:
+        gateway = self.risk_gateway
+        if gateway is None:
+            return {"limits": {}, "telemetry": {}, "last_decision": None}
+
+        limits = gateway.get_risk_limits() if hasattr(gateway, "get_risk_limits") else {}
+        last_decision = gateway.get_last_decision() if hasattr(gateway, "get_last_decision") else None
+
+        limits_payload = dict(limits) if isinstance(limits, Mapping) else {"limits": {}, "telemetry": {}}
+
+        return {
+            "limits": dict(limits_payload.get("limits", {})),
+            "telemetry": dict(limits_payload.get("telemetry", {})),
+            "last_decision": dict(last_decision) if isinstance(last_decision, Mapping) else last_decision,
+        }
+
+    def _build_intelligence_section(self) -> Mapping[str, Any]:
+        snapshot = self._last_snapshot
+        diagnostics = (
+            self.pipeline.fusion_engine.get_diagnostic_information()
+            if hasattr(self.pipeline, "fusion_engine")
+            else {}
+        )
+
+        if snapshot is None:
+            return {"diagnostics": diagnostics}
+
+        synthesis = snapshot.synthesis
+        return {
+            "symbol": snapshot.symbol,
+            "generated_at": snapshot.generated_at.isoformat(),
+            "unified_score": float(synthesis.unified_score),
+            "confidence": float(synthesis.confidence),
+            "narrative": synthesis.dominant_narrative.name,
+            "narrative_text": synthesis.narrative_text,
+            "coherence": float(synthesis.narrative_coherence),
+            "diagnostics": diagnostics,
+        }
+
+    def _build_liquidity_section(self) -> Mapping[str, Any]:
+        summary = dict(self._last_liquidity_summary) if self._last_liquidity_summary else {}
+        prober = self.liquidity_prober
+        config = {}
+        if prober is not None:
+            config = {
+                "decay": getattr(prober, "decay", None),
+                "max_history": getattr(prober, "max_history", None),
+                "min_quality": getattr(prober, "min_quality", None),
+            }
+        return {"summary": summary, "prober": config}
+
+    def _build_performance_section(self, portfolio: Mapping[str, Any]) -> Mapping[str, Any]:
+        fills: list[Any] = []
+        if self.execution_adapter is not None:
+            fills_attr = getattr(self.execution_adapter, "fills", None)
+            if isinstance(fills_attr, Iterable):
+                fills = list(fills_attr)
+
+        return {
+            "fills": len(fills),
+            "last_fill": fills[-1] if fills else None,
+            "realized_pnl": _as_float(portfolio.get("realized_pnl"), default=0.0),
+            "unrealized_pnl": _as_float(portfolio.get("unrealized_pnl"), default=0.0),
+            "total_pnl": _as_float(portfolio.get("total_pnl"), default=0.0),
+            "equity": _as_float(portfolio.get("equity"), default=0.0),
+        }
+
+    def _build_evolution_section(self) -> Mapping[str, Any]:
+        orchestrator = self.evolution_orchestrator
+        if orchestrator is None:
+            return {}
+
+        telemetry = getattr(orchestrator, "telemetry", {})
+        champion = getattr(orchestrator, "champion", None)
+        stats = getattr(orchestrator, "population_statistics", {})
+
+        if isinstance(telemetry, Mapping):
+            telemetry_payload = dict(telemetry)
+        else:
+            telemetry_payload = {"raw": telemetry}
+
+        if hasattr(champion, "as_payload"):
+            champion_payload = champion.as_payload()
+        elif isinstance(champion, Mapping):
+            champion_payload = dict(champion)
+        elif champion is None:
+            champion_payload = None
+        else:
+            champion_payload = {"genome_id": getattr(champion, "genome_id", None)}
+
+        population = dict(stats) if isinstance(stats, Mapping) else {}
+
+        return {
+            "telemetry": telemetry_payload,
+            "champion": champion_payload,
+            "population": population,
+        }
+
+    def _build_evolution_overview(self) -> Mapping[str, Any]:
+        orchestrator = self.evolution_orchestrator
+        if orchestrator is None:
+            return {}
+
+        champion = getattr(orchestrator, "champion", None)
+        if hasattr(champion, "as_payload"):
+            payload = champion.as_payload()
+        elif isinstance(champion, Mapping):
+            payload = dict(champion)
+        elif champion is None:
+            payload = {}
+        else:
+            payload = {"genome_id": getattr(champion, "genome_id", None)}
+
+        telemetry = getattr(orchestrator, "telemetry", {})
+        total_generations = None
+        if isinstance(telemetry, Mapping):
+            total_generations = telemetry.get("total_generations")
+
+        overview: dict[str, Any] = {"champion": payload}
+        if total_generations is not None:
+            overview["generations"] = total_generations
+        return overview
+
+    def _build_vision_section(self) -> Mapping[str, Any]:
+        reporter = VisionAlignmentReport(
+            fabric=getattr(self.pipeline, "fabric", None),
+            pipeline=self.pipeline,
+            trading_manager=self.trading_manager,
+            control_center=self,
+            evolution_orchestrator=self.evolution_orchestrator,
+        )
+        return reporter.build()
+
+    def _build_vision_summary(self) -> Mapping[str, Any]:
+        reporter = VisionAlignmentReport(
+            fabric=getattr(self.pipeline, "fabric", None),
+            pipeline=self.pipeline,
+            trading_manager=self.trading_manager,
+            control_center=self,
+            evolution_orchestrator=self.evolution_orchestrator,
+        )
+        return reporter.summary()
+
+    # ------------------------------------------------------------------
+    # Utilities
+    # ------------------------------------------------------------------
+    def _safe_portfolio_state(self) -> Mapping[str, Any]:
+        if self.portfolio_monitor is None:
+            return {}
+        state = self.portfolio_monitor.get_state()
+        return state if isinstance(state, Mapping) else {}
+
+
+__all__ = ["BootstrapControlCenter"]

--- a/src/orchestration/__init__.py
+++ b/src/orchestration/__init__.py
@@ -1,3 +1,19 @@
 from __future__ import annotations
 
-__all__: list[str] = []
+from .evolution_cycle import (
+    ChampionRecord,
+    EvaluationRecord,
+    EvolutionCycleOrchestrator,
+    EvolutionCycleResult,
+    FitnessReport,
+    SupportsChampionRegistry,
+)
+
+__all__ = [
+    "ChampionRecord",
+    "EvaluationRecord",
+    "EvolutionCycleOrchestrator",
+    "EvolutionCycleResult",
+    "FitnessReport",
+    "SupportsChampionRegistry",
+]

--- a/src/orchestration/bootstrap_stack.py
+++ b/src/orchestration/bootstrap_stack.py
@@ -1,0 +1,201 @@
+"""Bootstrap orchestration helpers that stitch the encyclopedia vision together."""
+
+from __future__ import annotations
+
+import inspect
+from dataclasses import dataclass, field
+from datetime import datetime
+from decimal import Decimal
+from typing import Any, Awaitable, Callable, Dict, List, Mapping, MutableMapping, Optional, TYPE_CHECKING
+
+from src.core.base import MarketData
+from src.data_foundation.fabric.market_data_fabric import MarketDataFabric
+from src.orchestration.enhanced_intelligence_engine import ContextualFusionEngine, Synthesis
+from src.trading.trading_manager import TradingManager
+
+if TYPE_CHECKING:
+    from src.operations.bootstrap_control_center import BootstrapControlCenter
+
+
+@dataclass
+class SensorySnapshot:
+    """Container representing a fused sensory observation."""
+
+    symbol: str
+    market_data: MarketData
+    synthesis: Synthesis
+    generated_at: datetime = field(default_factory=datetime.utcnow)
+
+
+class BootstrapSensoryPipeline:
+    """Stream symbols through the market data fabric and fusion engine."""
+
+    def __init__(
+        self,
+        fabric: MarketDataFabric,
+        fusion_engine: ContextualFusionEngine | None = None,
+    ) -> None:
+        self.fabric = fabric
+        self.fusion_engine = fusion_engine or ContextualFusionEngine()
+        self.history: Dict[str, List[SensorySnapshot]] = {}
+        self._listeners: list[Callable[[SensorySnapshot], Awaitable[None] | None]] = []
+
+    def register_listener(
+        self, listener: Callable[[SensorySnapshot], Awaitable[None] | None]
+    ) -> None:
+        self._listeners.append(listener)
+
+    async def process_tick(
+        self,
+        symbol: str,
+        *,
+        as_of: datetime | None = None,
+        allow_stale: bool = True,
+    ) -> SensorySnapshot:
+        market_data = await self.fabric.fetch_latest(
+            symbol, as_of=as_of, allow_stale=allow_stale, use_cache=False
+        )
+        synthesis = await self.fusion_engine.analyze_market_intelligence(market_data)
+        snapshot = SensorySnapshot(symbol=symbol, market_data=market_data, synthesis=synthesis)
+        self.history.setdefault(symbol, []).append(snapshot)
+
+        for listener in list(self._listeners):
+            try:
+                outcome = listener(snapshot)
+                if inspect.isawaitable(outcome):
+                    await outcome
+            except Exception:
+                # Observability callbacks should never break the pipeline
+                continue
+
+        return snapshot
+
+
+@dataclass
+class PaperTradeIntent:
+    """Simple trade intent compatible with the risk gateway and trading manager."""
+
+    strategy_id: str
+    symbol: str
+    side: str
+    quantity: Decimal
+    price: float
+    confidence: float
+    metadata: MutableMapping[str, Any] = field(default_factory=dict)
+    timestamp: datetime = field(default_factory=datetime.utcnow)
+
+
+class BootstrapTradingStack:
+    """Tie the sensory pipeline to the risk-aware trading manager."""
+
+    def __init__(
+        self,
+        pipeline: BootstrapSensoryPipeline,
+        trading_manager: TradingManager,
+        *,
+        strategy_id: str = "bootstrap-strategy",
+        buy_threshold: float = 0.35,
+        sell_threshold: float = 0.35,
+        requested_quantity: Decimal | float = Decimal("1"),
+        stop_loss_pct: float = 0.01,
+        liquidity_prober: Any | None = None,
+        control_center: "BootstrapControlCenter" | None = None,
+    ) -> None:
+        self.pipeline = pipeline
+        self.trading_manager = trading_manager
+        self.strategy_id = strategy_id
+        self.buy_threshold = float(buy_threshold)
+        self.sell_threshold = float(sell_threshold)
+        self.requested_quantity = (
+            requested_quantity
+            if isinstance(requested_quantity, Decimal)
+            else Decimal(str(requested_quantity))
+        )
+        self.stop_loss_pct = float(stop_loss_pct)
+        self.decisions: list[dict[str, Any]] = []
+        self.liquidity_prober = liquidity_prober
+        self.control_center = control_center
+
+        if liquidity_prober is not None:
+            async def _record(snapshot: SensorySnapshot) -> None:
+                try:
+                    liquidity_prober.record_snapshot(snapshot.symbol, snapshot.market_data)
+                except Exception:
+                    # Observability helpers must never break the decision loop
+                    pass
+
+            self.pipeline.register_listener(_record)
+
+    async def evaluate_tick(
+        self, symbol: str, *, as_of: datetime | None = None
+    ) -> dict[str, Any]:
+        snapshot = await self.pipeline.process_tick(symbol, as_of=as_of)
+        unified_score = float(snapshot.synthesis.unified_score)
+
+        side: Optional[str] = None
+        if unified_score >= self.buy_threshold:
+            side = "BUY"
+        elif unified_score <= -self.sell_threshold:
+            side = "SELL"
+
+        if side is None:
+            result = {"snapshot": snapshot, "intent": None, "decision": None, "status": "skipped"}
+            self.decisions.append(result)
+            self._notify_control_center(snapshot, result)
+            return result
+
+        market_price = float(getattr(snapshot.market_data, "close", snapshot.market_data.mid_price))
+        intent = PaperTradeIntent(
+            strategy_id=self.strategy_id,
+            symbol=symbol,
+            side=side,
+            quantity=self.requested_quantity,
+            price=market_price,
+            confidence=float(snapshot.synthesis.confidence),
+        )
+        intent.metadata.setdefault("stop_loss_pct", self.stop_loss_pct)
+        intent.metadata.setdefault(
+            "intelligence_snapshot",
+            {
+                "unified_score": unified_score,
+                "confidence": float(snapshot.synthesis.confidence),
+                "narrative": snapshot.synthesis.dominant_narrative.value,
+            },
+        )
+
+        await self.trading_manager.on_trade_intent(intent)
+        decision = self.trading_manager.risk_gateway.get_last_decision()
+
+        liquidity_summary = None
+        if isinstance(decision, Mapping):
+            for check in decision.get("checks", []):
+                if isinstance(check, Mapping) and check.get("name") == "liquidity_probe":
+                    liquidity_summary = check.get("summary")
+                    break
+
+        result = {
+            "snapshot": snapshot,
+            "intent": intent,
+            "decision": decision,
+            "status": "submitted",
+            "liquidity_summary": liquidity_summary,
+        }
+        self.decisions.append(result)
+        self._notify_control_center(snapshot, result)
+        return result
+
+    def _notify_control_center(self, snapshot: SensorySnapshot, result: Mapping[str, Any]) -> None:
+        if self.control_center is not None:
+            try:
+                self.control_center.record_tick(snapshot=snapshot, result=result)
+            except Exception:
+                # Telemetry hooks must never impact the trading decision flow
+                pass
+
+
+__all__ = [
+    "BootstrapSensoryPipeline",
+    "BootstrapTradingStack",
+    "PaperTradeIntent",
+    "SensorySnapshot",
+]

--- a/src/orchestration/evolution_cycle.py
+++ b/src/orchestration/evolution_cycle.py
@@ -1,0 +1,303 @@
+"""Evolution cycle orchestrator bridging the encyclopedia's governance loop."""
+
+from __future__ import annotations
+
+import asyncio
+import inspect
+from dataclasses import asdict, dataclass, field, is_dataclass
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Awaitable,
+    Callable,
+    Iterable,
+    Mapping,
+    MutableMapping,
+    Protocol,
+    Sequence,
+)
+
+from src.core.evolution.engine import EvolutionEngine, EvolutionSummary
+from src.core.interfaces import DecisionGenome
+
+if TYPE_CHECKING:  # pragma: no cover - import for typing only
+    from src.governance.strategy_registry import StrategyRegistry
+
+__all__ = [
+    "FitnessReport",
+    "EvaluationRecord",
+    "ChampionRecord",
+    "EvolutionCycleResult",
+    "EvolutionCycleOrchestrator",
+    "SupportsChampionRegistry",
+]
+
+FitnessCallback = Callable[[DecisionGenome], Awaitable[Any] | Any]
+
+
+class SupportsChampionRegistry(Protocol):
+    """Protocol for registries capable of storing champion genomes."""
+
+    def register_champion(
+        self, genome: DecisionGenome, fitness_report: Mapping[str, Any]
+    ) -> bool:
+        ...
+
+
+def _as_float(value: Any, default: float = 0.0) -> float:
+    try:
+        return float(value)
+    except Exception:
+        return default
+
+
+@dataclass(slots=True)
+class FitnessReport:
+    """Normalized view of a genome's fitness evaluation."""
+
+    fitness_score: float
+    max_drawdown: float = 0.0
+    sharpe_ratio: float = 0.0
+    total_return: float = 0.0
+    volatility: float = 0.0
+    metadata: MutableMapping[str, Any] = field(default_factory=dict)
+
+    def as_payload(self) -> dict[str, Any]:
+        payload = {
+            "fitness_score": float(self.fitness_score),
+            "max_drawdown": float(self.max_drawdown),
+            "sharpe_ratio": float(self.sharpe_ratio),
+            "total_return": float(self.total_return),
+            "volatility": float(self.volatility),
+        }
+        if self.metadata:
+            payload["metadata"] = dict(self.metadata)
+        return payload
+
+    def for_registry(self) -> dict[str, Any]:
+        payload = self.as_payload()
+        payload.setdefault("fitness_score", float(self.fitness_score))
+        return payload
+
+
+@dataclass(slots=True)
+class EvaluationRecord:
+    """Evaluation artefact stored for reporting and tests."""
+
+    genome_id: str
+    fitness: float
+    report: FitnessReport
+
+    def as_payload(self) -> dict[str, Any]:
+        return {
+            "genome_id": self.genome_id,
+            "fitness": float(self.fitness),
+            "report": self.report.as_payload(),
+        }
+
+
+@dataclass(slots=True)
+class ChampionRecord:
+    """Champion metadata tracked across generations."""
+
+    genome_id: str
+    fitness: float
+    report: FitnessReport
+    registered: bool
+
+    def as_payload(self) -> dict[str, Any]:
+        payload = {
+            "genome_id": self.genome_id,
+            "fitness": float(self.fitness),
+            "registered": bool(self.registered),
+        }
+        payload.update(self.report.as_payload())
+        return payload
+
+
+@dataclass(slots=True)
+class EvolutionCycleResult:
+    """Return type for orchestrated evolution runs."""
+
+    summary: EvolutionSummary
+    evaluations: list[EvaluationRecord]
+    champion: ChampionRecord | None
+
+    def as_payload(self) -> dict[str, Any]:
+        return {
+            "summary": asdict(self.summary),
+            "evaluations": [record.as_payload() for record in self.evaluations],
+            "champion": self.champion.as_payload() if self.champion else None,
+        }
+
+
+class EvolutionCycleOrchestrator:
+    """Coordinates evaluation, selection, and governance registration."""
+
+    def __init__(
+        self,
+        evolution_engine: EvolutionEngine,
+        evaluation_callback: FitnessCallback,
+        *,
+        strategy_registry: SupportsChampionRegistry | None = None,
+        genome_factory: Callable[[], DecisionGenome] | None = None,
+    ) -> None:
+        self._engine = evolution_engine
+        self._callback = evaluation_callback
+        self._registry = strategy_registry
+        self._genome_factory = genome_factory
+        self.telemetry: dict[str, Any] = {
+            "total_generations": 0,
+            "best_fitness": float("-inf"),
+            "champion": None,
+            "last_summary": None,
+        }
+        self._best_champion: ChampionRecord | None = None
+
+    async def run_cycle(self) -> EvolutionCycleResult:
+        """Evaluate the current population, evolve, and optionally register a champion."""
+
+        population = self._engine.ensure_population(self._genome_factory)
+        evaluations = await self._evaluate_population(population)
+        champion = self._promote_champion(population, evaluations)
+        summary = self._engine.evolve(self._genome_factory)
+
+        self.telemetry["total_generations"] += 1
+        self.telemetry["last_summary"] = asdict(summary)
+        if champion is not None:
+            self.telemetry["best_fitness"] = max(
+                _as_float(self.telemetry.get("best_fitness", 0.0)), champion.fitness
+            )
+            self.telemetry["champion"] = champion.as_payload()
+            self._best_champion = champion
+
+        return EvolutionCycleResult(summary=summary, evaluations=evaluations, champion=champion)
+
+    async def _evaluate_population(
+        self, population: Sequence[DecisionGenome]
+    ) -> list[EvaluationRecord]:
+        records: list[EvaluationRecord] = []
+        for genome in population:
+            report = await self._evaluate_genome(genome)
+            record = EvaluationRecord(
+                genome_id=str(getattr(genome, "id", "unknown")),
+                fitness=float(report.fitness_score),
+                report=report,
+            )
+            records.append(record)
+        return records
+
+    async def _evaluate_genome(self, genome: DecisionGenome) -> FitnessReport:
+        try:
+            result = self._callback(genome)
+            if inspect.isawaitable(result):
+                result = await asyncio.wait_for(result, timeout=30.0)
+        except Exception as exc:  # pragma: no cover - defensive guard
+            report = FitnessReport(fitness_score=0.0, metadata={"error": str(exc)})
+        else:
+            report = self._normalise_report(result)
+
+        self._apply_report_to_genome(genome, report)
+        return report
+
+    def _apply_report_to_genome(self, genome: DecisionGenome, report: FitnessReport) -> None:
+        try:
+            setattr(genome, "fitness", float(report.fitness_score))
+        except Exception:  # pragma: no cover - legacy genome compatibility
+            pass
+
+        metrics = report.as_payload()
+        metrics.pop("metadata", None)
+        try:
+            existing = getattr(genome, "performance_metrics", {}) or {}
+            merged = dict(existing)
+            merged.update(metrics)
+            setattr(genome, "performance_metrics", merged)
+        except Exception:  # pragma: no cover - optional attribute
+            pass
+
+        if report.metadata:
+            try:
+                meta = getattr(genome, "metadata", {}) or {}
+                if isinstance(meta, Mapping):
+                    updated = dict(meta)
+                else:
+                    updated = {}
+                updated.update(report.metadata)
+                setattr(genome, "metadata", updated)
+            except Exception:  # pragma: no cover - optional attribute
+                pass
+
+    def _promote_champion(
+        self,
+        population: Sequence[DecisionGenome],
+        evaluations: Iterable[EvaluationRecord],
+    ) -> ChampionRecord | None:
+        try:
+            best_record = max(evaluations, key=lambda r: r.fitness)
+        except ValueError:
+            return None
+
+        genome = next(
+            (g for g in population if str(getattr(g, "id", "")) == best_record.genome_id),
+            None,
+        )
+        if genome is None:
+            return None
+
+        registered = False
+        if self._registry is not None:
+            try:
+                registered = self._registry.register_champion(
+                    genome, best_record.report.for_registry()
+                )
+            except Exception:  # pragma: no cover - registry failure guard
+                registered = False
+
+        champion = ChampionRecord(
+            genome_id=best_record.genome_id,
+            fitness=best_record.fitness,
+            report=best_record.report,
+            registered=registered,
+        )
+        self._best_champion = champion
+        return champion
+
+    def _normalise_report(self, payload: Any) -> FitnessReport:
+        if isinstance(payload, FitnessReport):
+            return payload
+
+        data: Mapping[str, Any]
+        if is_dataclass(payload):
+            data = asdict(payload)
+        elif isinstance(payload, Mapping):
+            data = payload
+        else:
+            data = {}
+
+        metadata = data.get("metadata", {})
+        if not isinstance(metadata, Mapping):
+            metadata = {"raw_metadata": metadata}
+
+        return FitnessReport(
+            fitness_score=_as_float(
+                data.get("fitness_score", data.get("fitness", 0.0)), default=0.0
+            ),
+            max_drawdown=_as_float(data.get("max_drawdown", 0.0)),
+            sharpe_ratio=_as_float(data.get("sharpe_ratio", data.get("sharpe", 0.0))),
+            total_return=_as_float(data.get("total_return", data.get("return", 0.0))),
+            volatility=_as_float(data.get("volatility", data.get("sigma", 0.0))),
+            metadata=dict(metadata),
+        )
+
+    @property
+    def champion(self) -> ChampionRecord | None:
+        """Return the best champion observed so far."""
+
+        return self._best_champion
+
+    @property
+    def population_statistics(self) -> Mapping[str, object]:
+        """Expose population statistics for monitoring surfaces."""
+
+        return self._engine.get_population_statistics()

--- a/src/runtime/__init__.py
+++ b/src/runtime/__init__.py
@@ -1,5 +1,6 @@
 """Runtime assembly helpers for the EMP Professional Predator."""
 
+from .bootstrap_runtime import BootstrapRuntime
 from .predator_app import ProfessionalPredatorApp, build_professional_predator_app
 
-__all__ = ["ProfessionalPredatorApp", "build_professional_predator_app"]
+__all__ = ["BootstrapRuntime", "ProfessionalPredatorApp", "build_professional_predator_app"]

--- a/src/runtime/bootstrap_runtime.py
+++ b/src/runtime/bootstrap_runtime.py
@@ -1,0 +1,242 @@
+"""Bootstrap runtime bridging the sensory stack with the trading manager."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import math
+from datetime import datetime, timedelta, timezone
+from decimal import Decimal
+from typing import Any, Mapping, Sequence
+
+from src.core.base import MarketData
+from src.core.event_bus import EventBus
+from src.data_foundation.fabric.historical_connector import HistoricalReplayConnector
+from src.data_foundation.fabric.market_data_fabric import MarketDataConnector, MarketDataFabric
+from src.operations.bootstrap_control_center import BootstrapControlCenter
+from src.orchestration.bootstrap_stack import BootstrapSensoryPipeline, BootstrapTradingStack
+from src.trading.execution.paper_execution import ImmediateFillExecutionAdapter
+from src.trading.liquidity.depth_aware_prober import DepthAwareLiquidityProber
+from src.trading.monitoring.portfolio_monitor import InMemoryRedis, PortfolioMonitor
+from src.trading.trading_manager import TradingManager
+
+logger = logging.getLogger(__name__)
+
+
+def _generate_bootstrap_series(symbols: Sequence[str]) -> Mapping[str, list[MarketData]]:
+    """Build a deterministic synthetic price series for bootstrap deployments."""
+
+    now = datetime.now(timezone.utc)
+    series: dict[str, list[MarketData]] = {}
+
+    for idx, symbol in enumerate(symbols or ("EURUSD",)):
+        base = 1.10 + 0.002 * idx
+        amplitude = 0.0008 + 0.0002 * idx
+        drift = 0.0003 + 0.00005 * idx
+        depth_seed = 5200 + idx * 250
+        imbalance_bias = 0.15 + 0.05 * idx
+
+        bars: list[MarketData] = []
+        price = base
+        for step in range(24):
+            ts = now - timedelta(minutes=24 - step)
+            oscillation = amplitude * math.sin(step / 3.5)
+            price = price + drift + oscillation
+            open_price = price - 0.00025
+            high_price = max(open_price, price) + 0.00018
+            low_price = min(open_price, price) - 0.00018
+
+            bar = MarketData(
+                symbol=symbol,
+                timestamp=ts,
+                open=open_price,
+                high=high_price,
+                low=low_price,
+                close=price,
+                volume=1800 + step * 120 + idx * 200,
+                volatility=0.00035 + 0.00005 * abs(math.sin(step / 2.3)),
+                spread=0.00005 + 0.00001 * ((idx + step) % 4),
+                depth=depth_seed + step * 180,
+                order_imbalance=math.tanh((step - 12) / 9.0) * (0.4 + imbalance_bias),
+                macro_bias=0.25 + 0.05 * idx,
+                data_quality=0.85,
+            )
+            bars.append(bar)
+
+        series[symbol] = bars
+
+    return series
+
+
+class _AlwaysActiveRegistry:
+    """Minimal strategy registry returning an active strategy for bootstrap runs."""
+
+    def get_strategy(self, strategy_id: str) -> Mapping[str, Any] | None:
+        return {"strategy_id": strategy_id, "status": "active"}
+
+
+class BootstrapRuntime:
+    """Drive the bootstrap sensory, fusion, and trading loop on a schedule."""
+
+    def __init__(
+        self,
+        *,
+        event_bus: EventBus,
+        symbols: Sequence[str] | None = None,
+        connectors: Mapping[str, MarketDataConnector] | None = None,
+        tick_interval: float = 2.5,
+        max_ticks: int | None = None,
+        strategy_id: str = "bootstrap-strategy",
+        buy_threshold: float = 0.25,
+        sell_threshold: float = 0.25,
+        requested_quantity: Decimal | float = Decimal("1"),
+        stop_loss_pct: float = 0.01,
+        risk_per_trade: float = 0.02,
+        max_open_positions: int = 5,
+        max_daily_drawdown: float = 0.1,
+        initial_equity: float = 100_000.0,
+        min_intent_confidence: float = 0.05,
+        min_liquidity_confidence: float = 0.25,
+        liquidity_prober: DepthAwareLiquidityProber | None = None,
+        evolution_orchestrator: Any | None = None,
+    ) -> None:
+        self.event_bus = event_bus
+        self.symbols = [s.strip() for s in (symbols or ["EURUSD"]) if s and s.strip()]
+        if not self.symbols:
+            self.symbols = ["EURUSD"]
+        self.tick_interval = max(0.0, float(tick_interval))
+        self.max_ticks = None if max_ticks is None else max(0, int(max_ticks))
+        self._tick_counter = 0
+        self._stop_event = asyncio.Event()
+        self._run_task: asyncio.Task[None] | None = None
+        self._price_task: asyncio.Task[None] | None = None
+        self.running = False
+        self._last_error: Exception | None = None
+
+        resolved_connectors: dict[str, MarketDataConnector]
+        if connectors:
+            resolved_connectors = {str(k): v for k, v in connectors.items()}
+        else:
+            resolved_connectors = {
+                "historical_replay": HistoricalReplayConnector(_generate_bootstrap_series(self.symbols))
+            }
+
+        self.fabric = MarketDataFabric(resolved_connectors)
+        self.pipeline = BootstrapSensoryPipeline(self.fabric)
+
+        self.liquidity_prober = liquidity_prober or DepthAwareLiquidityProber()
+        self.evolution_orchestrator = evolution_orchestrator
+
+        self.trading_manager = TradingManager(
+            event_bus=event_bus,
+            strategy_registry=_AlwaysActiveRegistry(),
+            execution_engine=None,
+            initial_equity=initial_equity,
+            risk_per_trade=risk_per_trade,
+            max_open_positions=max_open_positions,
+            max_daily_drawdown=max_daily_drawdown,
+            redis_client=InMemoryRedis(),
+            liquidity_prober=self.liquidity_prober,
+            min_intent_confidence=min_intent_confidence,
+            min_liquidity_confidence=min_liquidity_confidence,
+        )
+        self.portfolio_monitor: PortfolioMonitor = self.trading_manager.portfolio_monitor
+        self.execution_engine = ImmediateFillExecutionAdapter(self.portfolio_monitor)
+        self.trading_manager.execution_engine = self.execution_engine
+
+        self.control_center = BootstrapControlCenter(
+            pipeline=self.pipeline,
+            trading_manager=self.trading_manager,
+            execution_adapter=self.execution_engine,
+            liquidity_prober=self.liquidity_prober,
+            evolution_orchestrator=self.evolution_orchestrator,
+        )
+
+        self.trading_stack = BootstrapTradingStack(
+            pipeline=self.pipeline,
+            trading_manager=self.trading_manager,
+            strategy_id=strategy_id,
+            buy_threshold=buy_threshold,
+            sell_threshold=sell_threshold,
+            requested_quantity=requested_quantity,
+            stop_loss_pct=stop_loss_pct,
+            liquidity_prober=self.liquidity_prober,
+            control_center=self.control_center,
+        )
+
+    @property
+    def decisions(self) -> list[dict[str, Any]]:
+        return self.trading_stack.decisions
+
+    def status(self) -> Mapping[str, Any]:
+        telemetry = self.control_center.overview()
+        status = {
+            "running": self.running,
+            "symbols": list(self.symbols),
+            "tick_interval": self.tick_interval,
+            "ticks_processed": self._tick_counter,
+            "decisions": len(self.trading_stack.decisions),
+            "fills": len(self.execution_engine.fills),
+            "last_error": self._last_error.__class__.__name__ if self._last_error else None,
+            "telemetry": telemetry,
+        }
+        vision_summary = telemetry.get("vision_alignment") if isinstance(telemetry, Mapping) else None
+        if isinstance(vision_summary, Mapping):
+            status["vision_alignment"] = vision_summary
+        return status
+
+    async def start(self) -> None:
+        if self.running:
+            return
+        self._stop_event = asyncio.Event()
+        self._tick_counter = 0
+        self.running = True
+        self._run_task = asyncio.create_task(self._run_loop(), name="bootstrap-runtime-loop")
+        self._price_task = self._run_task
+        logger.info(
+            "BootstrapRuntime started for %s (tick interval %.2fs)",
+            ",".join(self.symbols),
+            self.tick_interval,
+        )
+
+    async def stop(self) -> None:
+        if not self.running:
+            return
+        self._stop_event.set()
+        task = self._run_task
+        if task and not task.done():
+            await task
+        self.running = False
+        self._run_task = None
+        self._price_task = None
+        logger.info("BootstrapRuntime stopped after %s ticks", self._tick_counter)
+
+    async def _run_loop(self) -> None:
+        try:
+            while not self._stop_event.is_set():
+                for symbol in self.symbols:
+                    if self._stop_event.is_set():
+                        break
+                    try:
+                        await self.trading_stack.evaluate_tick(symbol)
+                    except Exception as exc:  # pragma: no cover - defensive guard
+                        self._last_error = exc
+                        logger.warning("BootstrapRuntime tick failure for %s: %s", symbol, exc)
+                self._tick_counter += 1
+                if self.max_ticks is not None and self._tick_counter >= self.max_ticks:
+                    break
+                if self.tick_interval == 0:
+                    await asyncio.sleep(0)
+                else:
+                    try:
+                        await asyncio.wait_for(self._stop_event.wait(), timeout=self.tick_interval)
+                    except asyncio.TimeoutError:
+                        continue
+        finally:
+            self.running = False
+            self._stop_event.set()
+            self._run_task = None
+            self._price_task = None
+
+
+__all__ = ["BootstrapRuntime"]

--- a/src/sensory/enhanced/_shared.py
+++ b/src/sensory/enhanced/_shared.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, Mapping
+
+from src.core.base import DimensionalReading, MarketData
+
+
+def ensure_market_data(payload: MarketData | Mapping[str, Any] | None) -> MarketData:
+    """Return a :class:`MarketData` instance for heterogeneous payloads."""
+    if isinstance(payload, MarketData):
+        return payload
+    if isinstance(payload, Mapping):
+        candidate: dict[str, Any] = {}
+        for key, value in payload.items():
+            try:
+                candidate[str(key)] = value
+            except Exception:
+                continue
+        return MarketData(**candidate)
+    return MarketData()
+
+
+def clamp(value: float, lower: float, upper: float) -> float:
+    """Clamp *value* to the inclusive ``[lower, upper]`` interval."""
+    if value < lower:
+        return lower
+    if value > upper:
+        return upper
+    return value
+
+
+def safe_timestamp(data: MarketData) -> datetime:
+    """Extract a timestamp from ``data`` falling back to ``datetime.utcnow``."""
+    ts = getattr(data, "timestamp", None)
+    if isinstance(ts, datetime):
+        return ts
+    return datetime.utcnow()
+
+
+class ReadingAdapter(dict):
+    """Hybrid container exposing dict semantics and awaitable access."""
+
+    __slots__ = ("_reading",)
+
+    def __init__(self, reading: DimensionalReading, payload: Mapping[str, Any]) -> None:
+        super().__init__(payload)
+        self._reading = reading
+
+    def __getattr__(self, name: str) -> Any:
+        try:
+            return getattr(self._reading, name)
+        except AttributeError as exc:  # pragma: no cover - defensive
+            raise AttributeError(name) from exc
+
+    def __await__(self):
+        async def _coro():
+            return self._reading
+
+        return _coro().__await__()
+
+    def __hash__(self) -> int:
+        return id(self)
+
+    @property
+    def reading(self) -> DimensionalReading:
+        return self._reading
+
+
+def build_legacy_payload(
+    reading: DimensionalReading,
+    *,
+    source: str,
+    extras: Mapping[str, Any] | None = None,
+) -> ReadingAdapter:
+    payload: dict[str, Any] = {
+        "signal": float(getattr(reading, "signal_strength", 0.0)),
+        "confidence": float(getattr(reading, "confidence", 0.0)),
+        "meta": {"source": source},
+        "context": dict(getattr(reading, "context", {}) or {}),
+    }
+    if extras:
+        payload.update(extras)
+    return ReadingAdapter(reading, payload)

--- a/src/sensory/enhanced/anomaly_dimension.py
+++ b/src/sensory/enhanced/anomaly_dimension.py
@@ -1,24 +1,109 @@
 from __future__ import annotations
 
-from typing import Iterable
+from math import tanh
+from datetime import datetime
+from statistics import fmean, pstdev
+from typing import Any, Iterable, Mapping, Sequence
+
+from src.core.base import DimensionalReading, MarketRegime
+from src.sensory.enhanced._shared import (
+    ReadingAdapter,
+    build_legacy_payload,
+    clamp,
+    ensure_market_data,
+    safe_timestamp,
+)
 
 __all__ = ["AnomalyIntelligenceEngine"]
 
 
 class AnomalyIntelligenceEngine:
     def analyze_anomaly_intelligence(
-        self, series: list[float] | Iterable[float] | None
-    ) -> dict[str, object]:
-        values = list(series or [])
-        try:
-            max_abs = max((abs(float(x)) for x in values), default=0.0)
-        except Exception:
-            max_abs = 0.0
-        # Clamp to [0, 1] for a minimal anomaly score
-        signal = float(max(0.0, min(1.0, max_abs)))
+        self, data: Mapping[str, Any] | Sequence[float] | Iterable[float] | Any | None = None
+    ) -> ReadingAdapter:
+        """Detect displacement from typical behaviour across recent samples."""
 
-        return {
-            "max_abs": float(max_abs),
-            "signal": signal,
-            "meta": {"source": "sensory.anomaly"},
+        if isinstance(data, (Sequence, Iterable)) and not isinstance(data, (Mapping, str, bytes)):
+            values = [float(x) for x in data]
+            baseline = fmean(values) if values else 0.0
+            dispersion = pstdev(values) if len(values) > 1 else 0.0
+            latest = values[-1] if values else 0.0
+            normalized = abs(latest - baseline) / (abs(baseline) + dispersion + 1e-9)
+            signal_strength = clamp(tanh(normalized), 0.0, 1.0)
+            confidence = clamp(0.2 + 0.6 * min(1.0, len(values) / 25.0), 0.0, 1.0)
+            context = {
+                "source": "sensory.anomaly",
+                "mode": "sequence",
+                "baseline": baseline,
+                "dispersion": dispersion,
+                "latest": latest,
+            }
+            timestamp = datetime.utcnow()
+            reading = DimensionalReading(
+                dimension="ANOMALY",
+                signal_strength=float(signal_strength),
+                confidence=float(confidence),
+                regime=MarketRegime.UNKNOWN,
+                context=context,
+                data_quality=1.0,
+                processing_time_ms=0.0,
+                timestamp=timestamp,
+            )
+            extras = {"baseline": float(baseline), "dispersion": float(dispersion), "latest": float(latest)}
+            return build_legacy_payload(reading, source="sensory.anomaly", extras=extras)
+
+        market_data = ensure_market_data(data)
+        price_base = abs(float(getattr(market_data, "open", 0.0))) or 1.0
+        move = abs(float(getattr(market_data, "close", price_base)) - float(getattr(market_data, "open", price_base)))
+        volume = float(getattr(market_data, "volume", 0.0))
+        volatility = float(getattr(market_data, "volatility", 0.0))
+        spread = float(getattr(market_data, "spread", 0.0))
+
+        move_ratio = move / price_base
+        volume_pressure = tanh(volume / max(1.0, price_base * 900.0))
+        volatility_pressure = tanh(max(0.0, volatility) * 8.0)
+        spread_penalty = tanh(max(0.0, spread) * 10000.0)
+
+        raw_anomaly = (
+            0.5 * tanh(move_ratio * 12.0)
+            + 0.3 * volume_pressure
+            + 0.2 * volatility_pressure
+            + 0.15 * spread_penalty
+        )
+        signal_strength = clamp(raw_anomaly, 0.0, 1.0)
+
+        confidence = clamp(
+            0.25
+            + 0.35 * (1.0 - spread_penalty)
+            + 0.25 * min(1.0, volume_pressure + 0.1)
+            + 0.15 * min(1.0, volatility_pressure + 0.1),
+            0.0,
+            1.0,
+        )
+
+        context = {
+            "source": "sensory.anomaly",
+            "mode": "market_data",
+            "move_ratio": float(move_ratio),
+            "volume_pressure": float(volume_pressure),
+            "volatility_pressure": float(volatility_pressure),
+            "spread_penalty": float(spread_penalty),
         }
+
+        reading = DimensionalReading(
+            dimension="ANOMALY",
+            signal_strength=float(signal_strength),
+            confidence=float(confidence),
+            regime=MarketRegime.UNKNOWN,
+            context=context,
+            data_quality=1.0,
+            processing_time_ms=0.0,
+            timestamp=safe_timestamp(market_data),
+        )
+        extras = {
+            "move_ratio": float(move_ratio),
+            "volume_pressure": float(volume_pressure),
+            "volatility_pressure": float(volatility_pressure),
+            "spread_penalty": float(spread_penalty),
+        }
+        return build_legacy_payload(reading, source="sensory.anomaly", extras=extras)

--- a/src/sensory/enhanced/how_dimension.py
+++ b/src/sensory/enhanced/how_dimension.py
@@ -1,22 +1,95 @@
 from __future__ import annotations
 
+import random
+from math import tanh
+from typing import Any, Mapping
+
+from src.core.base import DimensionalReading, MarketRegime
+from src.sensory.enhanced._shared import (
+    ReadingAdapter,
+    build_legacy_payload,
+    clamp,
+    ensure_market_data,
+    safe_timestamp,
+)
+
 __all__ = ["InstitutionalIntelligenceEngine"]
 
 
 class InstitutionalIntelligenceEngine:
     def analyze_institutional_intelligence(
-        self, data: dict[str, float] | None = None
-    ) -> dict[str, object]:
-        payload: dict[str, float] = dict(data or {})
-        participation = float(payload.get("participation", 0.0))
-        liquidity = float(payload.get("liquidity", 0.0))
-        # Normalize participation [0, 1] to [-1, 1]
-        p = max(0.0, min(1.0, participation))
-        signal = (p * 2.0) - 1.0
+        self, data: Mapping[str, Any] | Any | None = None
+    ) -> ReadingAdapter:
+        """Estimate institutional participation and liquidity dynamics."""
 
-        return {
-            "signal": float(signal),
-            "participation": float(participation),
+        market_data = ensure_market_data(data)
+        spread = float(getattr(market_data, "spread", 0.0))
+        volume = float(getattr(market_data, "volume", 0.0))
+        volatility = float(getattr(market_data, "volatility", 0.0))
+        depth = float(getattr(market_data, "depth", 0.0))
+        imbalance = float(getattr(market_data, "order_imbalance", 0.0))
+        quality_hint = float(getattr(market_data, "data_quality", 0.75) or 0.75)
+
+        liquidity = clamp(1.0 - tanh(max(0.0, spread) * 15000.0), 0.0, 1.0)
+        participation = tanh(volume / 1200.0 + depth / 5000.0)
+        imbalance_score = tanh(imbalance)
+        volatility_drag = tanh(max(0.0, volatility) * 4.0)
+
+        institutional_bias = (
+            0.5 * participation
+            + 0.25 * imbalance_score
+            + 0.2 * liquidity
+            - 0.15 * volatility_drag
+        )
+        signal_strength = clamp(institutional_bias, -1.0, 1.0)
+
+        confidence = clamp(
+            0.3
+            + 0.4 * liquidity
+            + 0.2 * abs(imbalance_score)
+            + 0.1 * clamp(quality_hint, 0.0, 1.0),
+            0.0,
+            1.0,
+        )
+
+        regime = MarketRegime.UNKNOWN
+        if signal_strength > 0.4 and liquidity > 0.6:
+            regime = MarketRegime.TRENDING_STRONG
+        elif signal_strength > 0.15:
+            regime = MarketRegime.TRENDING_WEAK
+        elif signal_strength < -0.35:
+            regime = MarketRegime.REVERSAL
+        elif liquidity < 0.3:
+            regime = MarketRegime.CONSOLIDATING
+
+        context: dict[str, Any] = {
+            "source": "sensory.how",
             "liquidity": float(liquidity),
-            "meta": {"source": "sensory.how"},
+            "participation": float(participation),
+            "imbalance": float(imbalance_score),
+            "volatility_drag": float(volatility_drag),
         }
+
+        # Introduce slight stochasticity to avoid lock-step behaviour when
+        # upstream data lacks variation.
+        if confidence > 0.6:
+            jitter = 0.02 * random.random()
+            signal_strength = clamp(signal_strength + jitter, -1.0, 1.0)
+
+        reading = DimensionalReading(
+            dimension="HOW",
+            signal_strength=float(signal_strength),
+            confidence=float(confidence),
+            regime=regime,
+            context=context,
+            data_quality=clamp(quality_hint, 0.0, 1.0),
+            processing_time_ms=0.0,
+            timestamp=safe_timestamp(market_data),
+        )
+        extras = {
+            "liquidity": float(liquidity),
+            "participation": float(participation),
+            "imbalance": float(imbalance_score),
+            "volatility_drag": float(volatility_drag),
+        }
+        return build_legacy_payload(reading, source="sensory.how", extras=extras)

--- a/src/sensory/enhanced/what_dimension.py
+++ b/src/sensory/enhanced/what_dimension.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import Any, Dict
 
 from src.core.base import DimensionalReading, MarketData
+from src.sensory.enhanced._shared import safe_timestamp
 from src.core.base import MarketRegime as MarketRegime
 
 __all__ = ["TechnicalRealityEngine"]
@@ -44,4 +45,5 @@ class TechnicalRealityEngine:
             context=context,
             data_quality=1.0,
             processing_time_ms=0.0,
+            timestamp=safe_timestamp(data),
         )

--- a/src/sensory/enhanced/when_dimension.py
+++ b/src/sensory/enhanced/when_dimension.py
@@ -1,47 +1,84 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Dict
+from typing import Any, Mapping
 
-from src.core.base import DimensionalReading, MarketData
-from src.core.base import MarketRegime as MarketRegime
-
-if TYPE_CHECKING:  # pragma: no cover
-    pass
+from src.core.base import DimensionalReading, MarketRegime
+from src.sensory.enhanced._shared import (
+    ReadingAdapter,
+    build_legacy_payload,
+    clamp,
+    ensure_market_data,
+    safe_timestamp,
+)
 
 __all__ = ["ChronalIntelligenceEngine"]
 
 
 class ChronalIntelligenceEngine:
-    def analyze_temporal_intelligence(self, data: MarketData) -> DimensionalReading:
-        ts = getattr(data, "timestamp", None)
-        minute_of_day = 0
-        is_weekend = False
-        if ts is not None:
-            try:
-                minute_of_day = int(getattr(ts, "hour", 0)) * 60 + int(getattr(ts, "minute", 0))
-                # weekday(): Monday=0 .. Sunday=6
-                is_weekend = int(getattr(ts, "weekday", lambda: 0)()) >= 5
-            except Exception:
-                minute_of_day = 0
-                is_weekend = False
+    def analyze_temporal_intelligence(
+        self, data: Mapping[str, Any] | Any | None = None
+    ) -> ReadingAdapter:
+        """Assess the temporal context of the market snapshot."""
 
-        # Normalize minutes since midnight to [-1, 1]
-        signal = (minute_of_day / 1440.0) * 2.0 - 1.0 if minute_of_day else 0.0
-        confidence = 0.5
+        market_data = ensure_market_data(data)
+        ts = safe_timestamp(market_data)
+        minute_of_day = ts.hour * 60 + ts.minute
+        weekday = ts.weekday()
+        is_weekend = weekday >= 5
 
-        context: Dict[str, Any] = {
+        # Model liquidity sessions (rough UTC approximations)
+        session_bias = 0.0
+        if 7 * 60 <= minute_of_day <= 10 * 60:
+            session = "asia-europe-overlap"
+            session_bias = 0.2
+        elif 12 * 60 <= minute_of_day <= 16 * 60:
+            session = "london-newyork-overlap"
+            session_bias = 0.35
+        elif 16 * 60 < minute_of_day <= 20 * 60:
+            session = "us-session"
+            session_bias = 0.15
+        else:
+            session = "off-peak"
+            session_bias = -0.05
+
+        weekend_penalty = 0.4 if is_weekend else 0.0
+        circadian = clamp((minute_of_day / 720.0) - 1.0, -1.0, 1.0)
+        signal_strength = clamp(session_bias + 0.5 * circadian - weekend_penalty, -1.0, 1.0)
+
+        confidence = clamp(
+            0.25
+            + 0.45 * (1.0 - weekend_penalty)
+            + 0.2 * (0.5 + 0.5 * abs(circadian))
+            - (0.15 if session == "off-peak" else 0.0),
+            0.0,
+            1.0,
+        )
+
+        regime = MarketRegime.UNKNOWN
+        if session == "london-newyork-overlap" and signal_strength > 0.2:
+            regime = MarketRegime.BREAKOUT
+        elif session_bias > 0.1:
+            regime = MarketRegime.TRENDING_WEAK
+        elif session == "off-peak":
+            regime = MarketRegime.CONSOLIDATING
+
+        context: dict[str, Any] = {
             "source": "sensory.when",
-            "meta": {"source": "sensory.when"},
             "minute_of_day": float(minute_of_day),
-            "is_weekend": bool(is_weekend),
+            "session": session,
+            "weekday": weekday,
+            "is_weekend": is_weekend,
         }
 
-        return DimensionalReading(
+        reading = DimensionalReading(
             dimension="WHEN",
-            signal_strength=float(max(-1.0, min(1.0, signal))),
-            confidence=float(max(0.0, min(1.0, confidence))),
-            regime=MarketRegime.UNKNOWN,
+            signal_strength=float(signal_strength),
+            confidence=float(confidence),
+            regime=regime,
             context=context,
             data_quality=1.0,
             processing_time_ms=0.0,
+            timestamp=ts,
         )
+        extras = {"session": session, "minute_of_day": float(minute_of_day)}
+        return build_legacy_payload(reading, source="sensory.when", extras=extras)

--- a/src/sensory/enhanced/why_dimension.py
+++ b/src/sensory/enhanced/why_dimension.py
@@ -1,20 +1,95 @@
 from __future__ import annotations
 
+from math import tanh
+from typing import Any, Mapping
+
+from src.core.base import DimensionalReading, MarketRegime
+from src.sensory.enhanced._shared import (
+    ReadingAdapter,
+    build_legacy_payload,
+    clamp,
+    ensure_market_data,
+    safe_timestamp,
+)
+
 __all__ = ["EnhancedFundamentalIntelligenceEngine"]
 
 
 class EnhancedFundamentalIntelligenceEngine:
     def analyze_fundamental_intelligence(
-        self, data: dict[str, float] | None = None
-    ) -> dict[str, object]:
-        payload: dict[str, float] = dict(data or {})
-        # Minimal heuristic: use provided features if any; otherwise default zeros
-        momentum = float(payload.get("momentum", 0.0))
-        volume = float(payload.get("volume", 0.0))
-        signal = max(-1.0, min(1.0, momentum))
+        self, data: Mapping[str, Any] | Any | None = None
+    ) -> ReadingAdapter:
+        """Generate a fundamentals-oriented reading for the WHY dimension.
 
-        return {
-            "signal": float(signal),
-            "volume": float(volume),
-            "meta": {"source": "sensory.why"},
+        The heuristic intentionally blends momentum, volume participation and
+        volatility drag to provide a stable yet reactive score.
+        """
+
+        market_data = ensure_market_data(data)
+        price_base = abs(float(getattr(market_data, "close", 0.0))) or 1.0
+        open_price = float(getattr(market_data, "open", price_base))
+        close_price = float(getattr(market_data, "close", open_price))
+        volume = float(getattr(market_data, "volume", 0.0))
+        volatility = float(getattr(market_data, "volatility", 0.0))
+        macro_bias = float(getattr(market_data, "macro_bias", 0.0) or 0.0)
+        quality_hint = float(getattr(market_data, "data_quality", 0.8) or 0.8)
+
+        momentum = (close_price - open_price) / price_base
+        # Participation saturates using tanh to keep values in [-1, 1]
+        participation = tanh(volume / max(1.0, price_base * 750.0))
+        volatility_penalty = tanh(max(0.0, volatility) * 6.0)
+
+        raw_signal = (
+            0.55 * tanh(momentum * 3.0)
+            + 0.30 * participation
+            + 0.20 * tanh(macro_bias)
+            - 0.25 * volatility_penalty
+        )
+        signal_strength = clamp(raw_signal, -1.0, 1.0)
+
+        confidence = clamp(
+            0.35
+            + 0.35 * abs(tanh(momentum * 2.5))
+            + 0.20 * (1.0 - volatility_penalty)
+            + 0.10 * clamp(quality_hint, 0.0, 1.0),
+            0.0,
+            1.0,
+        )
+
+        regime = MarketRegime.UNKNOWN
+        if signal_strength > 0.45:
+            regime = MarketRegime.TRENDING_STRONG
+        elif signal_strength > 0.15:
+            regime = MarketRegime.TRENDING_WEAK
+        elif signal_strength < -0.45:
+            regime = MarketRegime.REVERSAL
+        elif signal_strength < -0.15:
+            regime = MarketRegime.EXHAUSTED
+
+        context: dict[str, Any] = {
+            "source": "sensory.why",
+            "momentum": float(momentum),
+            "participation": float(participation),
+            "volatility_penalty": float(volatility_penalty),
+            "macro_bias": float(macro_bias),
+            "quality_hint": float(quality_hint),
         }
+
+        reading = DimensionalReading(
+            dimension="WHY",
+            signal_strength=float(signal_strength),
+            confidence=float(confidence),
+            regime=regime,
+            context=context,
+            data_quality=clamp(quality_hint, 0.0, 1.0),
+            processing_time_ms=0.0,
+            timestamp=safe_timestamp(market_data),
+        )
+        extras = {
+            "volume": float(volume),
+            "momentum": float(momentum),
+            "participation": float(participation),
+            "volatility_penalty": float(volatility_penalty),
+            "macro_bias": float(macro_bias),
+        }
+        return build_legacy_payload(reading, source="sensory.why", extras=extras)

--- a/src/trading/execution/paper_execution.py
+++ b/src/trading/execution/paper_execution.py
@@ -1,0 +1,80 @@
+"""Execution adapter for the bootstrap paper-trading stack."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from types import SimpleNamespace
+from typing import Any, Mapping, MutableMapping
+
+from src.trading.monitoring.portfolio_monitor import PortfolioMonitor
+
+
+def _extract(mapping: Any, *names: str, default: Any = None) -> Any:
+    if isinstance(mapping, Mapping):
+        for name in names:
+            if name in mapping:
+                return mapping[name]
+    for name in names:
+        if hasattr(mapping, name):
+            return getattr(mapping, name)
+    return default
+
+
+def _to_float(value: Any, default: float = 0.0) -> float:
+    try:
+        return float(value)
+    except Exception:
+        return default
+
+
+@dataclass
+class ImmediateFillExecutionAdapter:
+    """Process intents by immediately filling them against the portfolio monitor."""
+
+    portfolio_monitor: PortfolioMonitor
+    fills: list[dict[str, Any]] = field(default_factory=list)
+    _order_seq: int = 0
+
+    async def process_order(self, intent: Any) -> str:
+        symbol = str(_extract(intent, "symbol", default="UNKNOWN"))
+        side = str(_extract(intent, "side", "direction", default="BUY")).upper()
+        quantity = _to_float(_extract(intent, "quantity", "size", "volume", default=0.0), 0.0)
+        price = _to_float(_extract(intent, "price", "limit_price", "entry_price", default=0.0), 0.0)
+
+        self._order_seq += 1
+        order_id = f"PAPER-{self._order_seq:05d}"
+
+        # Remove optimistic reservation prior to issuing the execution report
+        if quantity:
+            self.portfolio_monitor.release_position(symbol, quantity)
+
+        report = SimpleNamespace(
+            symbol=symbol,
+            side=side,
+            quantity=quantity,
+            price=price,
+            order_id=order_id,
+        )
+        await self.portfolio_monitor.on_execution_report(report)
+
+        metadata: MutableMapping[str, Any]
+        meta_value = _extract(intent, "metadata", default={})
+        if isinstance(meta_value, MutableMapping):
+            metadata = meta_value
+        else:
+            metadata = {}
+
+        self.fills.append(
+            {
+                "order_id": order_id,
+                "symbol": symbol,
+                "side": side,
+                "quantity": quantity,
+                "price": price,
+                "metadata": dict(metadata),
+            }
+        )
+        return order_id
+
+
+__all__ = ["ImmediateFillExecutionAdapter"]

--- a/src/trading/liquidity/__init__.py
+++ b/src/trading/liquidity/__init__.py
@@ -1,0 +1,5 @@
+"""Liquidity analysis utilities supporting the trading risk gateway."""
+
+from .depth_aware_prober import DepthAwareLiquidityProber
+
+__all__ = ["DepthAwareLiquidityProber"]

--- a/src/trading/liquidity/depth_aware_prober.py
+++ b/src/trading/liquidity/depth_aware_prober.py
@@ -1,0 +1,188 @@
+from __future__ import annotations
+
+import math
+from collections import deque
+from dataclasses import dataclass
+from datetime import datetime
+from threading import RLock
+from typing import Deque, Dict, Iterable, Mapping
+
+from src.core.base import MarketData
+
+__all__ = ["DepthAwareLiquidityProber"]
+
+
+def _to_float(value: object, default: float = 0.0) -> float:
+    try:
+        return float(value)
+    except Exception:
+        return default
+
+
+@dataclass
+class _DepthSnapshot:
+    price: float
+    spread: float
+    depth: float
+    imbalance: float
+    volume: float
+    data_quality: float
+    timestamp: datetime
+
+
+class DepthAwareLiquidityProber:
+    """Estimate tradeable liquidity using recent market depth observations."""
+
+    def __init__(
+        self,
+        *,
+        max_history: int = 64,
+        decay: float = 0.65,
+        min_quality: float = 0.2,
+    ) -> None:
+        if max_history <= 0:
+            raise ValueError("max_history must be positive")
+        if not (0.0 < decay <= 1.0):
+            raise ValueError("decay must fall in (0, 1]")
+        self.max_history = int(max_history)
+        self.decay = float(decay)
+        self.min_quality = float(min_quality)
+        self._history: Dict[str, Deque[_DepthSnapshot]] = {}
+        self._lock = RLock()
+        self._last_probe_meta: dict[str, float | int | str] | None = None
+
+    def record_snapshot(self, symbol: str, market_data: MarketData) -> None:
+        """Store a lightweight depth snapshot for later liquidity estimation."""
+
+        price = _to_float(getattr(market_data, "mid_price", None), default=market_data.mid_price)
+        spread = _to_float(getattr(market_data, "spread", None), default=market_data.spread)
+        depth = _to_float(getattr(market_data, "depth", None), default=0.0)
+        volume = _to_float(getattr(market_data, "volume", None), default=0.0)
+        imbalance = _to_float(getattr(market_data, "order_imbalance", None), default=0.0)
+        quality = _to_float(getattr(market_data, "data_quality", None), default=1.0)
+
+        if depth <= 0.0:
+            # Fall back to a volume-derived estimate if explicit depth is missing
+            depth = max(volume * 0.2, 0.0)
+        if spread <= 0.0:
+            spread = max(price * 0.0001, 1e-6)
+
+        snapshot = _DepthSnapshot(
+            price=price if price else _to_float(getattr(market_data, "close", None), default=0.0),
+            spread=spread,
+            depth=depth,
+            imbalance=max(-1.0, min(1.0, imbalance)),
+            volume=volume,
+            data_quality=max(self.min_quality, min(1.0, quality if quality else 0.0)),
+            timestamp=getattr(market_data, "timestamp", datetime.utcnow()),
+        )
+
+        with self._lock:
+            history = self._history.setdefault(symbol, deque(maxlen=self.max_history))
+            history.append(snapshot)
+
+    async def probe_liquidity(
+        self, symbol: str, price_levels: Iterable[float], side: str
+    ) -> Mapping[float, float]:
+        """Estimate available liquidity at the requested price levels."""
+
+        levels = [float(level) for level in price_levels]
+        if not levels:
+            return {}
+
+        side_key = side.lower()
+
+        with self._lock:
+            history = list(self._history.get(symbol, ()))
+
+        results: dict[float, float] = {level: 0.0 for level in levels}
+        if not history:
+            self._last_probe_meta = {
+                "symbol": symbol,
+                "observations_used": 0,
+                "average_quality": 0.0,
+                "average_depth": 0.0,
+                "average_spread": 0.0,
+            }
+            return results
+
+        total_quality = 0.0
+        total_depth = 0.0
+        total_spread = 0.0
+
+        for idx, snapshot in enumerate(reversed(history)):
+            weight = self.decay**idx
+            total_quality += snapshot.data_quality
+            total_depth += snapshot.depth
+            total_spread += snapshot.spread
+            for level in levels:
+                results[level] += weight * self._estimate_volume(snapshot, level, side_key)
+
+        count = len(history)
+        self._last_probe_meta = {
+            "symbol": symbol,
+            "observations_used": count,
+            "average_quality": total_quality / count if count else 0.0,
+            "average_depth": total_depth / count if count else 0.0,
+            "average_spread": total_spread / count if count else 0.0,
+        }
+        return results
+
+    def calculate_liquidity_confidence_score(
+        self, probe_results: Mapping[float, float], intended_volume: float
+    ) -> float:
+        if not probe_results:
+            return 0.0
+
+        total_liquidity = sum(max(0.0, _to_float(v, default=0.0)) for v in probe_results.values())
+        if intended_volume <= 0:
+            return 1.0
+
+        coverage = max(0.0, total_liquidity / max(intended_volume, 1e-9))
+        score = 1.0 - math.exp(-coverage)
+
+        meta = self._last_probe_meta or {}
+        quality = _to_float(meta.get("average_quality"), default=1.0)
+        quality_modifier = 0.7 + 0.3 * max(self.min_quality, min(1.0, quality))
+        score *= quality_modifier
+
+        return max(0.0, min(1.0, score))
+
+    def get_probe_summary(self, probe_results: Mapping[float, float]) -> Mapping[str, float | int | str | None]:
+        total = sum(_to_float(v, default=0.0) for v in probe_results.values())
+        levels = list(probe_results.keys())
+        peak_level = None
+        peak_liquidity = 0.0
+        if levels:
+            peak_level = max(levels, key=lambda lvl: _to_float(probe_results[lvl], default=0.0))
+            peak_liquidity = _to_float(probe_results[peak_level], default=0.0)
+
+        summary: dict[str, float | int | str | None] = {
+            "evaluated_levels": len(levels),
+            "total_liquidity": total,
+            "peak_level": peak_level,
+            "peak_liquidity": peak_liquidity,
+            "average_liquidity": (total / len(levels)) if levels else 0.0,
+        }
+        if self._last_probe_meta:
+            summary.update(self._last_probe_meta)
+        return summary
+
+    def _estimate_volume(self, snapshot: _DepthSnapshot, level: float, side_key: str) -> float:
+        price_distance = abs(level - snapshot.price)
+        spread_band = max(snapshot.spread * 6.0, 1e-6)
+        distance_factor = max(0.0, 1.0 - price_distance / spread_band)
+
+        if side_key.startswith("buy"):
+            bias = snapshot.imbalance
+        elif side_key.startswith("sell"):
+            bias = -snapshot.imbalance
+        else:
+            bias = 0.0
+        imbalance_factor = max(0.3, 1.0 + 0.5 * bias)
+
+        quality_factor = max(self.min_quality, min(1.0, snapshot.data_quality))
+        base_depth = max(snapshot.depth, snapshot.volume * 0.1)
+
+        estimate = base_depth * distance_factor * imbalance_factor * quality_factor
+        return max(0.0, estimate)

--- a/src/trading/risk/risk_gateway.py
+++ b/src/trading/risk/risk_gateway.py
@@ -1,0 +1,442 @@
+"""Risk gateway coordinating multi-layer trade validation.
+
+This module gives the trading runtime a concrete implementation of the
+"risk gateway" promised in the encyclopaedia.  It fuses portfolio context,
+strategy governance, capital-at-risk guards, and optional liquidity probing
+before an order is allowed to reach execution.
+
+The implementation favours defensive programming so that it can work with
+the heterogeneous TradeIntent representations that already exist across the
+codebase (dict-based legacy payloads, dataclasses, and Pydantic-style
+objects).
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import asdict, is_dataclass
+from datetime import datetime
+from decimal import Decimal
+from typing import Any, Callable, Mapping, MutableMapping, Optional, Protocol, cast
+
+
+logger = logging.getLogger(__name__)
+
+
+class SupportsLiquidityProbing(Protocol):
+    """Protocol for optional liquidity probing capabilities."""
+
+    async def probe_liquidity(
+        self, symbol: str, price_levels: list[float], side: str
+    ) -> Mapping[float, float]:
+        ...
+
+    def calculate_liquidity_confidence_score(
+        self, probe_results: Mapping[float, float], intended_volume: float
+    ) -> float:
+        ...
+
+    def get_probe_summary(self, probe_results: Mapping[float, float]) -> Mapping[str, Any]:
+        ...
+
+
+class SupportsStrategyRegistry(Protocol):
+    """Protocol capturing the single method RiskGateway relies on."""
+
+    def get_strategy(self, strategy_id: str) -> Mapping[str, Any] | None: ...
+
+
+PositionSizer = Callable[[Decimal, Decimal, Decimal], Decimal]
+
+
+def _to_decimal(value: Any, *, default: Decimal = Decimal("0")) -> Decimal:
+    if isinstance(value, Decimal):
+        return value
+    try:
+        return Decimal(str(value))
+    except Exception:
+        return default
+
+
+def _as_float(value: Any, default: float = 0.0) -> float:
+    try:
+        return float(value)
+    except Exception:
+        return default
+
+
+def _ensure_metadata(intent: Any) -> MutableMapping[str, Any]:
+    """Return a mutable metadata mapping for ``intent`` and attach one if needed."""
+
+    if isinstance(intent, MutableMapping):
+        meta = intent.get("metadata")
+        if isinstance(meta, MutableMapping):
+            return meta
+        meta = {}
+        intent["metadata"] = meta
+        return meta
+
+    meta = getattr(intent, "metadata", None)
+    if isinstance(meta, MutableMapping):
+        return meta
+
+    # Attach a new metadata mapping for objects lacking one
+    meta_map: dict[str, Any] = {}
+    try:
+        setattr(intent, "metadata", meta_map)
+    except Exception:  # pragma: no cover - best effort when attribute blocked
+        pass
+    return meta_map
+
+
+def _extract_attr(intent: Any, *names: str, default: Any = None) -> Any:
+    """Return the first attribute/key found on ``intent`` from ``names``."""
+
+    if isinstance(intent, Mapping):
+        for name in names:
+            if name in intent:
+                return intent[name]
+        return default
+
+    for name in names:
+        if hasattr(intent, name):
+            return getattr(intent, name)
+    return default
+
+
+def _set_attr(intent: Any, value: Any, *names: str) -> None:
+    for name in names:
+        if isinstance(intent, MutableMapping) and name in intent:
+            intent[name] = value
+            return
+        if hasattr(intent, name):
+            try:
+                setattr(intent, name, value)
+            except Exception:  # pragma: no cover - best effort
+                pass
+            return
+
+    # Attribute was missing entirely; fall back to first candidate for dicts
+    if isinstance(intent, MutableMapping) and names:
+        intent[names[0]] = value
+
+
+class RiskGateway:
+    """Central risk gate that validates intents before execution."""
+
+    def __init__(
+        self,
+        strategy_registry: SupportsStrategyRegistry | None,
+        position_sizer: PositionSizer | None,
+        portfolio_monitor: Any,
+        *,
+        risk_per_trade: Decimal | float = Decimal("0.01"),
+        max_open_positions: int = 5,
+        max_daily_drawdown: float = 0.05,
+        min_intent_confidence: float = 0.2,
+        stop_loss_floor: float = 0.005,
+        liquidity_prober: SupportsLiquidityProbing | None = None,
+        liquidity_probe_threshold: float = 1.0,
+        min_liquidity_confidence: float = 0.3,
+    ) -> None:
+        self.strategy_registry = strategy_registry
+        self.position_sizer = position_sizer
+        self.portfolio_monitor = portfolio_monitor
+        self.risk_per_trade = _to_decimal(risk_per_trade, default=Decimal("0.01"))
+        self.max_open_positions = int(max_open_positions)
+        self.max_daily_drawdown = float(max_daily_drawdown)
+        self.min_intent_confidence = float(min_intent_confidence)
+        self.stop_loss_floor = float(stop_loss_floor)
+        self.liquidity_prober = liquidity_prober
+        self.liquidity_probe_threshold = float(liquidity_probe_threshold)
+        self.min_liquidity_confidence = float(min_liquidity_confidence)
+
+        self.telemetry: dict[str, Any] = {
+            "total_checks": 0,
+            "approved": 0,
+            "rejected": 0,
+            "last_decision": None,
+        }
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+    async def validate_trade_intent(
+        self, intent: Any, portfolio_state: Mapping[str, Any] | None
+    ) -> Any | None:
+        """Return an enriched intent if all risk checks pass, otherwise ``None``."""
+
+        self.telemetry["total_checks"] += 1
+        decision: dict[str, Any] = {
+            "timestamp": datetime.utcnow().isoformat(),
+            "symbol": _extract_attr(intent, "symbol", default="UNKNOWN"),
+            "strategy_id": _extract_attr(intent, "strategy_id", "strategy", default=""),
+            "checks": [],
+        }
+
+        try:
+            if not self._check_strategy(decision["strategy_id"]):
+                decision.update(status="rejected", reason="strategy_disabled")
+                return self._reject(decision)
+
+            quantity = self._extract_quantity(intent)
+            confidence = _as_float(
+                _extract_attr(intent, "confidence", "score", default=1.0), default=1.0
+            )
+            if confidence < self.min_intent_confidence:
+                decision.update(status="rejected", reason="low_confidence")
+                decision["checks"].append({
+                    "name": "confidence_floor",
+                    "value": confidence,
+                    "threshold": self.min_intent_confidence,
+                })
+                return self._reject(decision)
+
+            portfolio_state = portfolio_state or {}
+            if not self._check_drawdown(portfolio_state, decision):
+                decision.update(status="rejected", reason="max_drawdown_exceeded")
+                return self._reject(decision)
+
+            if not self._check_open_positions(portfolio_state, decision):
+                decision.update(status="rejected", reason="too_many_open_positions")
+                return self._reject(decision)
+
+            adjusted_quantity = self._apply_position_sizing(intent, portfolio_state, decision)
+
+            liquidity_summary: Mapping[str, Any] | None = None
+            liquidity_score: float | None = None
+            if self.liquidity_prober and adjusted_quantity >= self.liquidity_probe_threshold:
+                liquidity_score, liquidity_summary = await self._run_liquidity_probe(
+                    intent, adjusted_quantity, decision
+                )
+                if liquidity_score is not None and liquidity_score < self.min_liquidity_confidence:
+                    decision.update(status="rejected", reason="insufficient_liquidity")
+                    return self._reject(decision)
+
+            self._enrich_intent(intent, adjusted_quantity, liquidity_score, decision)
+
+            if liquidity_summary:
+                decision["checks"].append({
+                    "name": "liquidity_probe",
+                    "summary": dict(liquidity_summary),
+                })
+
+            decision.update(status="approved", quantity=float(adjusted_quantity))
+            self.telemetry["approved"] += 1
+            self.telemetry["last_decision"] = decision
+            return intent
+
+        except Exception as exc:  # pragma: no cover - defensive logging path
+            logger.exception("RiskGateway encountered unexpected error: %s", exc)
+            decision.update(status="rejected", reason="exception", error=str(exc))
+            return self._reject(decision)
+
+    def get_risk_limits(self) -> dict[str, Any]:
+        """Return a snapshot of configured limits and recent telemetry."""
+
+        limits = {
+            "max_open_positions": self.max_open_positions,
+            "max_daily_drawdown": self.max_daily_drawdown,
+            "min_intent_confidence": self.min_intent_confidence,
+            "liquidity_probe_threshold": self.liquidity_probe_threshold,
+            "min_liquidity_confidence": self.min_liquidity_confidence,
+            "risk_per_trade": float(self.risk_per_trade),
+        }
+        return {"limits": limits, "telemetry": dict(self.telemetry)}
+
+    def get_last_decision(self) -> Mapping[str, Any] | None:
+        """Expose the most recent risk decision record."""
+
+        return cast(Optional[Mapping[str, Any]], self.telemetry.get("last_decision"))
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+    def _reject(self, decision: Mapping[str, Any]) -> None:
+        self.telemetry["rejected"] += 1
+        self.telemetry["last_decision"] = dict(decision)
+        logger.info("RiskGateway rejected trade: %s", decision)
+        return None
+
+    def _check_strategy(self, strategy_id: str | None) -> bool:
+        if not strategy_id or self.strategy_registry is None:
+            return True
+        try:
+            record = self.strategy_registry.get_strategy(strategy_id)
+        except Exception as exc:  # pragma: no cover - defensive
+            logger.warning("Strategy registry lookup failed for %s: %s", strategy_id, exc)
+            return True
+
+        if not record:
+            return True
+
+        status = str(record.get("status", "")).lower()
+        return status in {"active", "approved"}
+
+    def _check_drawdown(self, portfolio_state: Mapping[str, Any], decision: dict[str, Any]) -> bool:
+        current = _as_float(portfolio_state.get("current_daily_drawdown"), default=0.0)
+        decision["checks"].append(
+            {
+                "name": "daily_drawdown",
+                "value": current,
+                "threshold": self.max_daily_drawdown,
+            }
+        )
+        return current <= self.max_daily_drawdown
+
+    def _check_open_positions(
+        self, portfolio_state: Mapping[str, Any], decision: dict[str, Any]
+    ) -> bool:
+        # Portfolio monitor exposes helper, otherwise rely on supplied state
+        try:
+            count = _as_float(self.portfolio_monitor.get_open_position_count())
+        except Exception:
+            count = _as_float(portfolio_state.get("open_positions_count"), default=0.0)
+
+        decision["checks"].append(
+            {
+                "name": "open_positions",
+                "value": count,
+                "threshold": self.max_open_positions,
+            }
+        )
+        return count < self.max_open_positions
+
+    def _extract_quantity(self, intent: Any) -> Decimal:
+        quantity = _extract_attr(intent, "quantity", "size", "volume", default=0)
+        return _to_decimal(quantity)
+
+    def _extract_price(self, intent: Any, portfolio_state: Mapping[str, Any]) -> float:
+        price = _extract_attr(intent, "price", "limit_price", "entry_price")
+        if price is None:
+            price = portfolio_state.get("current_price")
+        return _as_float(price, default=0.0)
+
+    def _extract_stop_loss_pct(
+        self, intent: Any, portfolio_state: Mapping[str, Any], market_price: float
+    ) -> float:
+        metadata = _ensure_metadata(intent)
+        if "stop_loss_pct" in metadata:
+            return float(metadata["stop_loss_pct"])
+
+        if "stop_loss_pips" in metadata:
+            pip_value = _as_float(portfolio_state.get("pip_value"), default=0.0001)
+            pips = _as_float(metadata.get("stop_loss_pips"), default=0.0)
+            if pip_value and market_price:
+                return max(self.stop_loss_floor, abs(pips * pip_value) / market_price)
+
+        return self.stop_loss_floor
+
+    def _apply_position_sizing(
+        self, intent: Any, portfolio_state: Mapping[str, Any], decision: dict[str, Any]
+    ) -> Decimal:
+        quantity = self._extract_quantity(intent)
+        if not self.position_sizer:
+            return quantity
+
+        balance = _to_decimal(portfolio_state.get("equity"), default=Decimal("0"))
+        if balance <= 0:
+            return quantity
+
+        market_price = self._extract_price(intent, portfolio_state)
+        stop_loss_pct = self._extract_stop_loss_pct(intent, portfolio_state, market_price)
+        recommended = self.position_sizer(balance, self.risk_per_trade, Decimal(str(stop_loss_pct)))
+
+        decision["checks"].append(
+            {
+                "name": "position_sizer",
+                "recommended": float(recommended),
+                "requested": float(quantity),
+            }
+        )
+
+        if quantity <= recommended:
+            return quantity
+
+        logger.info(
+            "RiskGateway clipping position size from %s to %s", quantity, recommended
+        )
+        return recommended
+
+    async def _run_liquidity_probe(
+        self, intent: Any, quantity: Decimal, decision: dict[str, Any]
+    ) -> tuple[float | None, Mapping[str, Any] | None]:
+        if not self.liquidity_prober:
+            return None, None
+
+        symbol = _extract_attr(intent, "symbol", default="UNKNOWN")
+        side = str(_extract_attr(intent, "side", "direction", default="buy")).lower()
+        market_price = self._extract_price(intent, {}) or 0.0
+        spread = max(market_price * 0.001, 0.0005)
+        price_levels = [
+            market_price + spread * offset if side.startswith("buy") else market_price - spread * offset
+            for offset in range(-2, 3)
+        ] if market_price else []
+
+        if not price_levels:
+            price_levels = [0.0]
+
+        probe_results = await self.liquidity_prober.probe_liquidity(symbol, price_levels, side)
+        score = self.liquidity_prober.calculate_liquidity_confidence_score(
+            probe_results, float(quantity)
+        )
+        summary = self.liquidity_prober.get_probe_summary(probe_results)
+
+        decision["checks"].append(
+            {
+                "name": "liquidity_confidence",
+                "value": score,
+                "threshold": self.min_liquidity_confidence,
+            }
+        )
+        return score, summary
+
+    def _enrich_intent(
+        self,
+        intent: Any,
+        quantity: Decimal,
+        liquidity_score: float | None,
+        decision: Mapping[str, Any],
+    ) -> None:
+        _set_attr(intent, quantity, "quantity", "size", "volume")
+
+        metadata = _ensure_metadata(intent)
+        metadata.setdefault("risk_assessment", {})
+        assessment = metadata["risk_assessment"]
+        if isinstance(assessment, Mapping):
+            assessment = dict(assessment)
+            metadata["risk_assessment"] = assessment
+
+        assessment.update({
+            "checks": list(decision.get("checks", [])),
+            "final_quantity": float(quantity),
+        })
+        if liquidity_score is not None:
+            assessment["liquidity_confidence"] = float(liquidity_score)
+
+        if hasattr(intent, "liquidity_confidence_score"):
+            try:
+                setattr(intent, "liquidity_confidence_score", liquidity_score)
+            except Exception:  # pragma: no cover - attribute blocked
+                pass
+
+        if is_dataclass(intent):
+            try:
+                # Persist enrichment for frozen dataclasses by rebuilding
+                if getattr(intent, "__dataclass_params__", None).frozen:  # type: ignore[attr-defined]
+                    data = asdict(intent)
+                    data.update({
+                        "metadata": metadata,
+                        "liquidity_confidence_score": liquidity_score,
+                        "quantity": quantity,
+                        "size": quantity,
+                    })
+                    # dataclasses.replace would be cleaner but may not support arbitrary attrs
+                    for field, value in data.items():
+                        try:
+                            setattr(intent, field, value)
+                        except Exception:
+                            pass
+            except Exception:  # pragma: no cover
+                pass
+

--- a/src/trading/trading_manager.py
+++ b/src/trading/trading_manager.py
@@ -1,16 +1,16 @@
-"""
-Trading Manager v1.0 - Risk-Aware Trade Execution Coordinator
-
-Implements TRADING-05: Integrates risk management into the trading flow,
-ensuring no un-validated trade intent reaches the execution engine.
-"""
+"""Trading Manager v1.0 - Risk-Aware Trade Execution Coordinator."""
 
 import logging
 from decimal import Decimal
-from typing import Any, Callable, Optional, cast
+from typing import Any, Callable, Mapping, Optional, cast
 
-import redis
-from src.trading.monitoring.portfolio_monitor import PortfolioMonitor
+try:  # pragma: no cover - redis optional in bootstrap deployments
+    import redis
+except Exception:  # pragma: no cover
+    redis = None  # type: ignore
+
+from src.trading.monitoring.portfolio_monitor import InMemoryRedis, PortfolioMonitor
+from src.trading.risk.risk_gateway import RiskGateway
 
 try:
     from src.core.events import TradeIntent  # legacy
@@ -21,11 +21,7 @@ try:
 except Exception:  # pragma: no cover
     _PositionSizer = None  # type: ignore[assignment]
 # Provide precise callable typing for the sizer (Optional at runtime)
-PositionSizer: Optional[Callable[[Decimal, Decimal, Decimal], Decimal]] = cast(
-    Optional[Callable[[Decimal, Decimal, Decimal], Decimal]], _PositionSizer
-)
-
-RiskGateway = None  # deprecated path removed; use core risk flows directly
+PositionSizer = cast(Optional[Callable[[Decimal, Decimal, Decimal], Decimal]], _PositionSizer)
 
 logger = logging.getLogger(__name__)
 
@@ -47,6 +43,11 @@ class TradingManager:
         risk_per_trade: float = 0.01,
         max_open_positions: int = 5,
         max_daily_drawdown: float = 0.05,
+        *,
+        redis_client: Any | None = None,
+        liquidity_prober: Any | None = None,
+        min_intent_confidence: float = 0.2,
+        min_liquidity_confidence: float = 0.3,
     ) -> None:
         """
         Initialize the TradingManager with risk management components.
@@ -65,26 +66,20 @@ class TradingManager:
         self.execution_engine = execution_engine
 
         # Initialize risk management components
-        self.portfolio_monitor = PortfolioMonitor(
-            event_bus, redis.Redis(host="localhost", port=6379, db=0)
-        )
-        # Provide required numeric args as Decimals (safe coercion)
-        self.position_sizer = (
-            PositionSizer(
-                Decimal(str(risk_per_trade)),
-                Decimal("0.02"),
-                Decimal("0.02"),
-            )
-            if PositionSizer is not None
-            else None
-        )
-        # Treat RiskGateway as Any to avoid "None not callable" type error in typing; runtime DI expected
-        self.risk_gateway = cast(Any, RiskGateway)(
+        resolved_client = self._resolve_redis_client(redis_client)
+        self.portfolio_monitor = PortfolioMonitor(event_bus, resolved_client)
+        self.position_sizer = PositionSizer
+        risk_per_trade_decimal = Decimal(str(risk_per_trade))
+        self.risk_gateway = RiskGateway(
             strategy_registry=strategy_registry,
             position_sizer=self.position_sizer,
             portfolio_monitor=self.portfolio_monitor,
+            risk_per_trade=risk_per_trade_decimal,
             max_open_positions=max_open_positions,
             max_daily_drawdown=max_daily_drawdown,
+            liquidity_prober=liquidity_prober,
+            min_intent_confidence=min_intent_confidence,
+            min_liquidity_confidence=min_liquidity_confidence,
         )
 
         logger.info(
@@ -105,8 +100,9 @@ class TradingManager:
         Args:
             event: The trade intent event to process
         """
+        event_id = getattr(event, "event_id", getattr(event, "id", "unknown"))
         try:
-            logger.info(f"Received trade intent: {event.event_id}")
+            logger.info(f"Received trade intent: {event_id}")
 
             # Get current portfolio state
             portfolio_state = cast(Any, self.portfolio_monitor).get_state()
@@ -119,22 +115,26 @@ class TradingManager:
             if validated_intent:
                 # Trade passed validation - proceed to execution
                 logger.info(
-                    f"Trade intent {event.event_id} validated successfully. "
-                    f"Calculated size: {validated_intent.quantity}"
+                    f"Trade intent {event_id} validated successfully. "
+                    f"Calculated size: {self._extract_quantity(validated_intent)}"
                 )
 
-                # Update portfolio state (mock implementation)
-                cast(Any, self.portfolio_monitor).increment_positions()
+                symbol = self._extract_symbol(validated_intent)
+                quantity = self._extract_quantity(validated_intent)
+                price = self._extract_price(validated_intent, portfolio_state)
+                cast(Any, self.portfolio_monitor).reserve_position(
+                    symbol, float(quantity), price
+                )
 
                 # Send to execution engine
                 await self.execution_engine.process_order(validated_intent)
 
             else:
                 # Trade was rejected by RiskGateway
-                logger.warning(f"Trade intent {event.event_id} was rejected by the Risk Gateway")
+                logger.warning(f"Trade intent {event_id} was rejected by the Risk Gateway")
 
         except Exception as e:
-            logger.error(f"Error processing trade intent {event.event_id}: {e}")
+            logger.error(f"Error processing trade intent {event_id}: {e}")
 
     async def start(self) -> None:
         """Start the TradingManager and subscribe to trade intents."""
@@ -157,3 +157,61 @@ class TradingManager:
             "risk_limits": cast(Any, self.risk_gateway).get_risk_limits(),
             "portfolio_state": cast(Any, self.portfolio_monitor).get_state(),
         }
+
+    def _resolve_redis_client(self, provided: Any | None) -> Any:
+        if provided is not None:
+            return provided
+
+        if redis is not None:
+            try:
+                client = redis.Redis(host="localhost", port=6379, db=0)
+                client.ping()
+                return client
+            except Exception:
+                logger.warning(
+                    "Redis connection unavailable, reverting to in-memory portfolio store"
+                )
+        return InMemoryRedis()
+
+    @staticmethod
+    def _extract_symbol(intent: Any) -> str:
+        for attr in ("symbol", "instrument", "asset"):
+            value = getattr(intent, attr, None)
+            if value:
+                return str(value)
+        if isinstance(intent, dict) and "symbol" in intent:
+            return str(intent["symbol"])
+        return "UNKNOWN"
+
+    @staticmethod
+    def _extract_quantity(intent: Any) -> Decimal:
+        for attr in ("quantity", "size", "volume"):
+            value = getattr(intent, attr, None)
+            if value is not None:
+                return Decimal(str(value))
+        if isinstance(intent, dict):
+            for key in ("quantity", "size", "volume"):
+                if key in intent:
+                    return Decimal(str(intent[key]))
+        return Decimal("0")
+
+    @staticmethod
+    def _extract_price(intent: Any, portfolio_state: Mapping[str, Any]) -> float:
+        for attr in ("price", "limit_price", "entry_price"):
+            value = getattr(intent, attr, None)
+            if value is not None:
+                try:
+                    return float(value)
+                except Exception:
+                    continue
+        if isinstance(intent, dict):
+            for key in ("price", "limit_price", "entry_price"):
+                if key in intent:
+                    try:
+                        return float(intent[key])
+                    except Exception:
+                        continue
+        try:
+            return float(portfolio_state.get("current_price", 0.0))
+        except Exception:
+            return 0.0

--- a/tests/current/test_bootstrap_control_center.py
+++ b/tests/current/test_bootstrap_control_center.py
@@ -1,0 +1,158 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from decimal import Decimal
+from typing import Any, Mapping
+
+import pytest
+
+from src.core.event_bus import EventBus
+from src.data_foundation import HistoricalReplayConnector, MarketDataFabric
+from src.operations.bootstrap_control_center import BootstrapControlCenter
+from src.orchestration.bootstrap_stack import BootstrapSensoryPipeline, BootstrapTradingStack
+from src.orchestration.enhanced_intelligence_engine import ContextualFusionEngine
+from src.trading.execution.paper_execution import ImmediateFillExecutionAdapter
+from src.trading.liquidity.depth_aware_prober import DepthAwareLiquidityProber
+from src.trading.monitoring.portfolio_monitor import InMemoryRedis, PortfolioMonitor
+from src.trading.trading_manager import TradingManager
+
+
+def _build_replay_connector() -> HistoricalReplayConnector:
+    now = datetime.now(timezone.utc)
+    bars: Mapping[str, list[Mapping[str, Any]]] = {
+        "EURUSD": [
+            {
+                "timestamp": now - timedelta(minutes=2),
+                "open": 1.1000,
+                "high": 1.1030,
+                "low": 1.0990,
+                "close": 1.1025,
+                "volume": 1800,
+                "volatility": 0.0004,
+                "spread": 0.00005,
+                "depth": 5500,
+                "order_imbalance": 0.2,
+                "macro_bias": 0.35,
+                "data_quality": 0.9,
+            },
+            {
+                "timestamp": now - timedelta(minutes=1),
+                "open": 1.1025,
+                "high": 1.1060,
+                "low": 1.1020,
+                "close": 1.1055,
+                "volume": 2200,
+                "volatility": 0.00045,
+                "spread": 0.00005,
+                "depth": 6000,
+                "order_imbalance": 0.28,
+                "macro_bias": 0.4,
+                "data_quality": 0.92,
+            },
+            {
+                "timestamp": now,
+                "open": 1.1055,
+                "high": 1.1080,
+                "low": 1.1045,
+                "close": 1.1075,
+                "volume": 2400,
+                "volatility": 0.0005,
+                "spread": 0.00005,
+                "depth": 6400,
+                "order_imbalance": 0.3,
+                "macro_bias": 0.45,
+                "data_quality": 0.94,
+            },
+        ]
+    }
+    return HistoricalReplayConnector(bars)
+
+
+class DummyStrategyRegistry:
+    def get_strategy(self, strategy_id: str) -> Mapping[str, Any] | None:
+        return {"status": "active", "strategy_id": strategy_id}
+
+
+class DummyChampion:
+    def __init__(self) -> None:
+        self.genome_id = "core-evo-00001"
+        self.fitness = 0.87
+
+    def as_payload(self) -> Mapping[str, Any]:
+        return {"genome_id": self.genome_id, "fitness": self.fitness}
+
+
+class DummyEvolutionOrchestrator:
+    def __init__(self) -> None:
+        self.telemetry = {"total_generations": 3, "champion": {"genome_id": "core-evo-00001"}}
+        self.population_statistics = {"population_size": 12, "best_fitness": 0.87}
+        self.champion = DummyChampion()
+
+
+@pytest.mark.asyncio()
+async def test_control_center_compiles_telemetry_report() -> None:
+    connector = _build_replay_connector()
+    fabric = MarketDataFabric({"replay": connector})
+    fusion_engine = ContextualFusionEngine()
+    pipeline = BootstrapSensoryPipeline(fabric, fusion_engine)
+
+    event_bus = EventBus()
+    portfolio_monitor = PortfolioMonitor(event_bus, InMemoryRedis())
+    execution_adapter = ImmediateFillExecutionAdapter(portfolio_monitor)
+    liquidity_prober = DepthAwareLiquidityProber()
+    trading_manager = TradingManager(
+        event_bus=event_bus,
+        strategy_registry=DummyStrategyRegistry(),
+        execution_engine=execution_adapter,
+        initial_equity=100000.0,
+        risk_per_trade=0.02,
+        max_open_positions=5,
+        max_daily_drawdown=0.1,
+        redis_client=InMemoryRedis(),
+        liquidity_prober=liquidity_prober,
+        min_intent_confidence=0.0,
+    )
+
+    orchestrator = DummyEvolutionOrchestrator()
+
+    control_center = BootstrapControlCenter(
+        pipeline=pipeline,
+        trading_manager=trading_manager,
+        execution_adapter=execution_adapter,
+        liquidity_prober=liquidity_prober,
+        evolution_orchestrator=orchestrator,
+    )
+
+    stack = BootstrapTradingStack(
+        pipeline,
+        trading_manager,
+        strategy_id="bootstrap-alpha",
+        buy_threshold=0.05,
+        sell_threshold=0.05,
+        requested_quantity=Decimal("1.5"),
+        stop_loss_pct=0.01,
+        liquidity_prober=liquidity_prober,
+        control_center=control_center,
+    )
+
+    await stack.evaluate_tick("EURUSD")  # warm-up
+    await stack.evaluate_tick("EURUSD")
+
+    report = control_center.generate_report()
+
+    assert report["portfolio"]["equity"] > 0
+    assert report["risk"]["limits"]["max_open_positions"] == 5
+    assert report["performance"]["fills"] >= 1
+    assert report["decisions"]["recent"]
+    assert report["intelligence"]["narrative"] in {"BULLISH", "BEARISH", "NEUTRAL", "VOLATILE"}
+    assert report["liquidity"]["summary"].get("evaluated_levels") is not None
+    assert report["evolution"]["champion"]["genome_id"] == orchestrator.champion.genome_id
+    assert report["evolution"]["population"]["population_size"] == 12
+    assert report["vision_alignment"]["summary"]["status"] in {"ready", "progressing", "gap"}
+    assert report["vision_alignment"]["layers"]
+
+    overview = control_center.overview()
+    assert overview["equity"] == report["performance"]["equity"]
+    assert overview["last_decision"] is not None
+    assert overview["evolution"]["generations"] == orchestrator.telemetry["total_generations"]
+    assert overview["vision_alignment"]["status"] in {"ready", "progressing", "gap"}

--- a/tests/current/test_bootstrap_runtime_integration.py
+++ b/tests/current/test_bootstrap_runtime_integration.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from src.governance.system_config import ConnectionProtocol, EmpEnvironment, EmpTier, RunMode, SystemConfig
+from src.runtime import build_professional_predator_app
+from src.runtime.bootstrap_runtime import BootstrapRuntime
+
+
+@pytest.mark.asyncio()
+async def test_bootstrap_runtime_build_and_run() -> None:
+    cfg = SystemConfig(
+        run_mode=RunMode.paper,
+        environment=EmpEnvironment.demo,
+        tier=EmpTier.tier_0,
+        confirm_live=False,
+        connection_protocol=ConnectionProtocol.bootstrap,
+        extras={
+            "BOOTSTRAP_SYMBOLS": "EURUSD",
+            "BOOTSTRAP_TICK_INTERVAL": "0.01",
+            "BOOTSTRAP_MAX_TICKS": "3",
+            "BOOTSTRAP_BUY_THRESHOLD": "0.05",
+            "BOOTSTRAP_SELL_THRESHOLD": "0.05",
+            "BOOTSTRAP_ORDER_SIZE": "2",
+            "BOOTSTRAP_MIN_CONFIDENCE": "0.0",
+        },
+    )
+
+    app = await build_professional_predator_app(config=cfg)
+    assert isinstance(app.sensory_organ, BootstrapRuntime)
+    runtime = app.sensory_organ
+
+    async with app:
+        await asyncio.sleep(0.1)
+        status = runtime.status()
+        assert status["ticks_processed"] >= 1
+        assert status["decisions"] >= 1
+        assert runtime.execution_engine.fills
+        assert "telemetry" in status
+        assert status["telemetry"]["equity"] >= 0
+        assert status["telemetry"]["last_decision"] is not None
+        assert status["vision_alignment"]["status"] in {"ready", "progressing", "gap"}
+
+        summary = app.summary()
+        assert summary["status"] == "RUNNING"
+        sensory_status = summary["components"].get("sensory_status")
+        assert sensory_status is not None
+        assert sensory_status["ticks_processed"] >= 1
+
+    assert runtime.status()["running"] is False
+    assert app.summary()["status"] == "STOPPED"

--- a/tests/current/test_bootstrap_stack.py
+++ b/tests/current/test_bootstrap_stack.py
@@ -1,0 +1,129 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from decimal import Decimal
+from typing import Any, Mapping
+
+import pytest
+
+from src.core.event_bus import EventBus
+from src.data_foundation import HistoricalReplayConnector, MarketDataFabric
+from src.orchestration.bootstrap_stack import (
+    BootstrapSensoryPipeline,
+    BootstrapTradingStack,
+)
+from src.orchestration.enhanced_intelligence_engine import ContextualFusionEngine
+from src.trading.execution.paper_execution import ImmediateFillExecutionAdapter
+from src.trading.liquidity.depth_aware_prober import DepthAwareLiquidityProber
+from src.trading.monitoring.portfolio_monitor import InMemoryRedis, PortfolioMonitor
+from src.trading.trading_manager import TradingManager
+
+
+def _build_replay_connector() -> HistoricalReplayConnector:
+    now = datetime.now(timezone.utc)
+    bars: Mapping[str, list[Mapping[str, Any]]] = {
+        "EURUSD": [
+            {
+                "timestamp": now - timedelta(minutes=2),
+                "open": 1.1000,
+                "high": 1.1030,
+                "low": 1.0990,
+                "close": 1.1025,
+                "volume": 1800,
+                "volatility": 0.0004,
+                "spread": 0.00005,
+                "depth": 5500,
+                "order_imbalance": 0.2,
+                "macro_bias": 0.35,
+                "data_quality": 0.9,
+            },
+            {
+                "timestamp": now - timedelta(minutes=1),
+                "open": 1.1025,
+                "high": 1.1060,
+                "low": 1.1020,
+                "close": 1.1055,
+                "volume": 2200,
+                "volatility": 0.00045,
+                "spread": 0.00005,
+                "depth": 6000,
+                "order_imbalance": 0.28,
+                "macro_bias": 0.4,
+                "data_quality": 0.92,
+            },
+        ]
+    }
+    return HistoricalReplayConnector(bars)
+
+
+class DummyStrategyRegistry:
+    def get_strategy(self, strategy_id: str) -> Mapping[str, Any] | None:
+        return {"status": "active", "strategy_id": strategy_id}
+
+
+@pytest.mark.asyncio()
+async def test_historical_replay_connector_iterates() -> None:
+    connector = _build_replay_connector()
+    fabric = MarketDataFabric({"replay": connector})
+
+    first = await fabric.fetch_latest("EURUSD", use_cache=False)
+    second = await fabric.fetch_latest("EURUSD", use_cache=False)
+
+    assert second.timestamp > first.timestamp
+    assert second.close != first.close
+
+
+@pytest.mark.asyncio()
+async def test_bootstrap_pipeline_generates_snapshots() -> None:
+    connector = _build_replay_connector()
+    fabric = MarketDataFabric({"replay": connector})
+    pipeline = BootstrapSensoryPipeline(fabric, ContextualFusionEngine())
+
+    snapshot = await pipeline.process_tick("EURUSD")
+    assert snapshot.symbol == "EURUSD"
+    assert isinstance(snapshot.synthesis.unified_score, float)
+    assert pipeline.history["EURUSD"]
+
+
+@pytest.mark.asyncio()
+async def test_bootstrap_trading_stack_executes_trade() -> None:
+    connector = _build_replay_connector()
+    fabric = MarketDataFabric({"replay": connector})
+    pipeline = BootstrapSensoryPipeline(fabric, ContextualFusionEngine())
+
+    event_bus = EventBus()
+    portfolio_monitor = PortfolioMonitor(event_bus, InMemoryRedis())
+    execution_adapter = ImmediateFillExecutionAdapter(portfolio_monitor)
+    liquidity_prober = DepthAwareLiquidityProber()
+    trading_manager = TradingManager(
+        event_bus=event_bus,
+        strategy_registry=DummyStrategyRegistry(),
+        execution_engine=execution_adapter,
+        initial_equity=100000.0,
+        risk_per_trade=0.02,
+        max_open_positions=5,
+        max_daily_drawdown=0.1,
+        redis_client=InMemoryRedis(),
+        liquidity_prober=liquidity_prober,
+    )
+
+    stack = BootstrapTradingStack(
+        pipeline,
+        trading_manager,
+        strategy_id="bootstrap-alpha",
+        buy_threshold=0.15,
+        sell_threshold=0.15,
+        requested_quantity=Decimal("2"),
+        stop_loss_pct=0.01,
+        liquidity_prober=liquidity_prober,
+    )
+
+    await stack.evaluate_tick("EURUSD")  # warm-up tick
+    result = await stack.evaluate_tick("EURUSD")
+    assert result["decision"] is not None
+    assert result["decision"]["status"] == "approved"
+    assert execution_adapter.fills
+    position_state = portfolio_monitor.get_state()["open_positions"].get("EURUSD")
+    assert position_state is not None
+    assert position_state["quantity"] > 0
+    assert result["liquidity_summary"] is not None

--- a/tests/current/test_evolution_orchestrator.py
+++ b/tests/current/test_evolution_orchestrator.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import pytest
+
+from src.core.evolution.engine import EvolutionConfig, EvolutionEngine
+from src.governance.strategy_registry import StrategyRegistry
+from src.orchestration.evolution_cycle import EvolutionCycleOrchestrator
+
+
+def _score_parameters(genome: object) -> float:
+    params = getattr(genome, "parameters", {}) or {}
+    try:
+        values = [float(value) for value in params.values()]
+    except Exception:  # pragma: no cover - defensive guard
+        values = []
+    if not values:
+        return 0.0
+    return sum(values) / float(len(values))
+
+
+@pytest.mark.asyncio
+async def test_orchestrator_registers_champion_and_updates_registry(tmp_path):
+    engine = EvolutionEngine(
+        EvolutionConfig(population_size=6, elite_count=2, crossover_rate=0.55, mutation_rate=0.15)
+    )
+    engine._rng.seed(7)  # type: ignore[attr-defined]
+
+    registry = StrategyRegistry(db_path=str(tmp_path / "governance.db"))
+
+    async def evaluator(genome):
+        score = _score_parameters(genome)
+        return {
+            "fitness_score": score,
+            "max_drawdown": 0.05 + 0.001 * len(getattr(genome, "mutation_history", [])),
+            "sharpe_ratio": 1.2,
+            "total_return": score * 0.25,
+            "volatility": 0.15,
+            "metadata": {"evaluated": True, "genome": getattr(genome, "id", "")},
+        }
+
+    orchestrator = EvolutionCycleOrchestrator(
+        engine,
+        evaluator,
+        strategy_registry=registry,
+    )
+
+    result = await orchestrator.run_cycle()
+
+    assert len(result.evaluations) == 6
+    assert all(record.fitness >= 0.0 for record in result.evaluations)
+
+    champion = result.champion
+    assert champion is not None
+    assert champion.fitness == max(record.fitness for record in result.evaluations)
+    assert champion.registered is True
+
+    stored = registry.get_strategy(champion.genome_id)
+    assert stored is not None
+    assert pytest.approx(float(stored["fitness_score"])) == pytest.approx(champion.fitness)
+
+    telemetry = orchestrator.telemetry
+    assert telemetry["total_generations"] == 1
+    assert telemetry["champion"]["genome_id"] == champion.genome_id
+    assert orchestrator.population_statistics["population_size"] == 6
+
+
+@dataclass
+class SimpleReport:
+    fitness_score: float
+    sharpe_ratio: float
+    metadata: dict[str, float] | None = None
+
+
+@pytest.mark.asyncio
+async def test_orchestrator_supports_sync_evaluators_and_dataclass_reports():
+    engine = EvolutionEngine(
+        EvolutionConfig(population_size=3, elite_count=1, crossover_rate=0.6, mutation_rate=0.2)
+    )
+    engine._rng.seed(11)  # type: ignore[attr-defined]
+
+    def evaluator(genome):
+        base = _score_parameters(genome)
+        return SimpleReport(fitness_score=0.1 + base, sharpe_ratio=1.5)
+
+    orchestrator = EvolutionCycleOrchestrator(engine, evaluator)
+
+    first = await orchestrator.run_cycle()
+    second = await orchestrator.run_cycle()
+
+    assert first.champion is not None
+    assert second.champion is not None
+    assert orchestrator.champion is second.champion
+    assert orchestrator.telemetry["total_generations"] == 2
+    assert orchestrator.telemetry["champion"]["registered"] is False
+
+    # Ensure metadata normalization handled the None metadata gracefully
+    assert all("fitness_score" in record.report.as_payload() for record in second.evaluations)
+    assert orchestrator.population_statistics["population_size"] == 3

--- a/tests/current/test_fix_lifecycle.py
+++ b/tests/current/test_fix_lifecycle.py
@@ -1,14 +1,16 @@
 import asyncio
 import os
 
-from src.governance.system_config import SystemConfig
+from src.governance.system_config import ConnectionProtocol, SystemConfig
 from src.operational.fix_connection_manager import FIXConnectionManager
 from src.operational.mock_fix import MockExecutionStep
 
 
 def test_fix_only_protocol_enforced():
     cfg = SystemConfig()
-    assert cfg.connection_protocol == "fix"
+    assert cfg.connection_protocol == ConnectionProtocol.bootstrap
+    cfg_fix = cfg.with_updated(connection_protocol="fix")
+    assert cfg_fix.connection_protocol is ConnectionProtocol.fix
 
 
 async def _drain(q: asyncio.Queue, timeout=1.0):

--- a/tests/current/test_liquidity_prober.py
+++ b/tests/current/test_liquidity_prober.py
@@ -1,0 +1,65 @@
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from src.core.base import MarketData
+from src.trading.liquidity.depth_aware_prober import DepthAwareLiquidityProber
+
+
+@pytest.mark.asyncio()
+async def test_depth_prober_generates_positive_liquidity() -> None:
+    prober = DepthAwareLiquidityProber(max_history=5)
+    now = datetime.now(timezone.utc)
+    market_data = MarketData(
+        symbol="EURUSD",
+        timestamp=now,
+        close=1.1010,
+        volume=5000,
+        depth=4200,
+        spread=0.00005,
+        order_imbalance=0.25,
+        data_quality=0.92,
+    )
+    prober.record_snapshot("EURUSD", market_data)
+
+    levels = [1.1010, 1.1012]
+    results = await prober.probe_liquidity("EURUSD", levels, "BUY")
+
+    assert results[levels[0]] > 0
+    assert results[levels[0]] >= results[levels[1]]
+
+    score = prober.calculate_liquidity_confidence_score(results, intended_volume=2000)
+    assert 0.0 < score <= 1.0
+
+    summary = prober.get_probe_summary(results)
+    assert summary["evaluated_levels"] == len(levels)
+    assert summary["total_liquidity"] >= results[levels[0]]
+    assert summary["symbol"] == "EURUSD"
+
+
+@pytest.mark.asyncio()
+async def test_depth_prober_detects_liquidity_shortfall() -> None:
+    prober = DepthAwareLiquidityProber(max_history=3)
+    now = datetime.now(timezone.utc)
+    for depth in (80, 65, 55):
+        md = MarketData(
+            symbol="EURUSD",
+            timestamp=now,
+            close=1.1005,
+            volume=150.0,
+            depth=depth,
+            spread=0.0002,
+            order_imbalance=-0.45,
+            data_quality=0.6,
+        )
+        prober.record_snapshot("EURUSD", md)
+        now += timedelta(seconds=1)
+
+    results = await prober.probe_liquidity("EURUSD", [1.1003, 1.1005], "SELL")
+    score = prober.calculate_liquidity_confidence_score(results, intended_volume=800)
+
+    assert score < 0.4
+
+    summary = prober.get_probe_summary(results)
+    assert summary["observations_used"] >= 1
+    assert summary["total_liquidity"] == pytest.approx(sum(results.values()))

--- a/tests/current/test_market_data_fabric.py
+++ b/tests/current/test_market_data_fabric.py
@@ -1,0 +1,147 @@
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+import pytest
+
+from src.data_foundation import CallableConnector, MarketDataFabric
+
+
+@pytest.mark.asyncio
+async def test_fabric_prefers_higher_priority_and_caches() -> None:
+    calls: list[str] = []
+
+    async def primary(symbol: str, _: datetime | None) -> dict[str, Any]:
+        calls.append("primary")
+        return {
+            "symbol": symbol,
+            "bid": 99.5,
+            "ask": 100.5,
+            "volume": 10_000,
+            "timestamp": datetime.now(timezone.utc),
+        }
+
+    async def secondary(symbol: str, _: datetime | None) -> dict[str, Any]:
+        calls.append("secondary")
+        return {
+            "symbol": symbol,
+            "bid": 10.0,
+            "ask": 11.0,
+            "timestamp": datetime.now(timezone.utc),
+        }
+
+    fabric = MarketDataFabric(
+        {
+            "primary": CallableConnector(name="primary", func=primary, priority=0),
+            "secondary": CallableConnector(name="secondary", func=secondary, priority=10),
+        },
+        cache_ttl=timedelta(seconds=60),
+    )
+
+    reading = await fabric.fetch_latest("AAPL")
+    assert reading.symbol == "AAPL"
+    assert calls == ["primary"]
+
+    # Cache hit should avoid additional connector calls
+    cached = await fabric.fetch_latest("AAPL")
+    assert cached is reading
+    assert calls == ["primary"]
+
+    diagnostics = fabric.get_diagnostics()
+    assert diagnostics["telemetry"]["total_requests"] == 2
+    assert diagnostics["telemetry"]["cache_hits"] == 1
+    assert diagnostics["telemetry"]["success"]["primary"] == 1
+
+
+@pytest.mark.asyncio
+async def test_fabric_falls_back_on_connector_failure() -> None:
+    async def failing(_: str, __: datetime | None) -> None:
+        raise RuntimeError("boom")
+
+    async def fallback(symbol: str, _: datetime | None) -> dict[str, Any]:
+        return {
+            "symbol": symbol,
+            "price": 123.0,
+            "timestamp": datetime.now(timezone.utc),
+        }
+
+    fabric = MarketDataFabric(
+        {
+            "failing": CallableConnector(name="failing", func=failing, priority=0),
+            "fallback": CallableConnector(name="fallback", func=fallback, priority=1),
+        },
+        cache_ttl=timedelta(seconds=1),
+    )
+
+    reading = await fabric.fetch_latest("MSFT")
+    assert reading.symbol == "MSFT"
+    diagnostics = fabric.get_diagnostics()
+    assert diagnostics["telemetry"]["success"]["fallback"] == 1
+    assert diagnostics["telemetry"]["failures"]["failing"] == 1
+
+
+@pytest.mark.asyncio
+async def test_fabric_can_return_stale_data_when_all_connectors_fail() -> None:
+    emitted = {
+        "symbol": "NVDA",
+        "price": 456.7,
+        "timestamp": datetime.now(timezone.utc),
+    }
+
+    async def good_once(symbol: str, _: datetime | None) -> dict[str, Any]:
+        if emitted.get("used"):
+            raise RuntimeError("exhausted")
+        emitted["used"] = True
+        return emitted
+
+    fabric = MarketDataFabric(
+        {"degenerate": CallableConnector(name="degenerate", func=good_once, priority=0)},
+        cache_ttl=timedelta(seconds=0),
+    )
+
+    first = await fabric.fetch_latest("NVDA")
+    assert first.symbol == "NVDA"
+
+    # Force cache expiry
+    await asyncio.sleep(0.01)
+
+    stale = await fabric.fetch_latest("NVDA")
+    assert stale.symbol == "NVDA"
+    assert stale is first
+    diagnostics = fabric.get_diagnostics()
+    assert diagnostics["telemetry"]["total_requests"] == 2
+    assert diagnostics["telemetry"]["failures"]["degenerate"] >= 1
+    assert diagnostics["cache"]["NVDA"]["source"] == "degenerate"
+
+
+@pytest.mark.asyncio
+async def test_fetch_latest_can_bypass_cache_and_invalidate() -> None:
+    call_count = 0
+
+    async def connector(symbol: str, _: datetime | None) -> dict[str, Any]:
+        nonlocal call_count
+        call_count += 1
+        return {
+            "symbol": symbol,
+            "price": 100.0 + call_count,
+            "timestamp": datetime.now(timezone.utc),
+        }
+
+    fabric = MarketDataFabric(
+        {"primary": CallableConnector(name="primary", func=connector, priority=0)},
+        cache_ttl=timedelta(seconds=60),
+    )
+
+    first = await fabric.fetch_latest("ETHUSD")
+    assert call_count == 1
+
+    second = await fabric.fetch_latest("ETHUSD", use_cache=False)
+    assert call_count == 2
+    assert second.close != first.close
+
+    fabric.invalidate_cache("ETHUSD")
+    third = await fabric.fetch_latest("ETHUSD")
+    assert call_count == 3
+    assert third.symbol == "ETHUSD"

--- a/tests/current/test_portfolio_monitor_runtime.py
+++ b/tests/current/test_portfolio_monitor_runtime.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from src.core.event_bus import EventBus
+from src.trading.monitoring.portfolio_monitor import InMemoryRedis, PortfolioMonitor
+
+
+def test_portfolio_monitor_in_memory_state_tracks_positions() -> None:
+    monitor = PortfolioMonitor(EventBus(), InMemoryRedis())
+
+    state = monitor.get_state()
+    assert state["open_positions_count"] == 0
+    assert state["equity"] == monitor.get_total_value()
+
+    monitor.reserve_position("EURUSD", 1.5, 1.1)
+    state = monitor.get_state()
+    assert state["open_positions_count"] == 1
+    assert "EURUSD" in state["open_positions"]
+
+    monitor.release_position("EURUSD", 1.5)
+    state = monitor.get_state()
+    assert state["open_positions_count"] == 0
+    assert "EURUSD" not in state["open_positions"]
+
+
+@pytest.mark.asyncio()
+async def test_portfolio_monitor_updates_pnl_and_drawdown() -> None:
+    monitor = PortfolioMonitor(EventBus(), InMemoryRedis())
+
+    initial_state = monitor.get_state()
+    assert initial_state["equity"] == pytest.approx(100000.0)
+    assert initial_state["peak_equity"] == pytest.approx(100000.0)
+
+    buy_report = SimpleNamespace(symbol="EURUSD", side="BUY", quantity=50, price=100.0)
+    await monitor.on_execution_report(buy_report)
+
+    monitor.portfolio["open_positions"]["EURUSD"]["last_price"] = 90.0
+    state = monitor.get_state()
+    assert state["unrealized_pnl"] == pytest.approx(-500.0)
+    assert state["daily_pnl"] == pytest.approx(-500.0)
+    assert state["current_daily_drawdown"] == pytest.approx(0.005, rel=1e-6)
+
+    sell_partial = SimpleNamespace(symbol="EURUSD", side="SELL", quantity=20, price=120.0)
+    await monitor.on_execution_report(sell_partial)
+    state = monitor.get_state()
+    assert state["realized_pnl"] == pytest.approx(400.0)
+    assert state["unrealized_pnl"] == pytest.approx(600.0)
+    assert state["total_pnl"] == pytest.approx(1000.0)
+    assert state["daily_pnl"] == pytest.approx(1000.0)
+    assert state["peak_equity"] == pytest.approx(101000.0)
+
+    monitor.portfolio["open_positions"]["EURUSD"]["last_price"] = 85.0
+    state = monitor.get_state()
+    assert state["unrealized_pnl"] == pytest.approx(-450.0)
+    assert state["total_pnl"] == pytest.approx(-50.0)
+    assert state["current_daily_drawdown"] == pytest.approx(0.0005, rel=1e-6)
+
+    sell_final = SimpleNamespace(symbol="EURUSD", side="SELL", quantity=30, price=80.0)
+    await monitor.on_execution_report(sell_final)
+    state = monitor.get_state()
+    assert state["realized_pnl"] == pytest.approx(-200.0)
+    assert state["unrealized_pnl"] == pytest.approx(0.0)
+    assert state["total_pnl"] == pytest.approx(-200.0)
+    assert state["equity"] == pytest.approx(99800.0)
+    assert state["daily_pnl"] == pytest.approx(-200.0)
+    assert state["current_daily_drawdown"] == pytest.approx(0.002, rel=1e-6)
+    assert state["peak_equity"] == pytest.approx(101000.0)

--- a/tests/current/test_system_config_enums.py
+++ b/tests/current/test_system_config_enums.py
@@ -16,7 +16,7 @@ def test_defaults_match_ci():
     assert cfg.run_mode is RunMode.paper
     assert cfg.environment is EmpEnvironment.demo
     assert cfg.tier is EmpTier.tier_0
-    assert cfg.connection_protocol is ConnectionProtocol.fix
+    assert cfg.connection_protocol is ConnectionProtocol.bootstrap
     assert cfg.confirm_live is False
 
 
@@ -26,14 +26,14 @@ def test_case_insensitive_and_aliases():
         "EMP_ENVIRONMENT": "DEMO",
         "EMP_TIER": "Tier-1",
         "CONFIRM_LIVE": "True",
-        "CONNECTION_PROTOCOL": "FIX",
+        "CONNECTION_PROTOCOL": "mock",
     }
     cfg = SystemConfig.from_env(env)
     assert cfg.run_mode is RunMode.paper
     assert cfg.environment is EmpEnvironment.demo
     assert cfg.tier is EmpTier.tier_1
     assert cfg.confirm_live is True
-    assert cfg.connection_protocol is ConnectionProtocol.fix
+    assert cfg.connection_protocol is ConnectionProtocol.bootstrap
 
 
 def test_bad_values_fallback():
@@ -69,7 +69,7 @@ def test_to_env_roundtrip():
         environment=EmpEnvironment.staging,
         tier=EmpTier.tier_2,
         confirm_live=True,
-        connection_protocol=ConnectionProtocol.fix,
+        connection_protocol=ConnectionProtocol.paper,
     )
     env = cfg.to_env()
     cfg2 = SystemConfig.from_env(env)
@@ -77,7 +77,7 @@ def test_to_env_roundtrip():
     assert cfg2.environment is EmpEnvironment.staging
     assert cfg2.tier is EmpTier.tier_2
     assert cfg2.confirm_live is True
-    assert cfg2.connection_protocol is ConnectionProtocol.fix
+    assert cfg2.connection_protocol is ConnectionProtocol.paper
 
 
 def test_string_views():

--- a/tests/current/test_vision_alignment_report.py
+++ b/tests/current/test_vision_alignment_report.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+import pytest
+
+from src.core.event_bus import EventBus
+from src.governance.vision_alignment import VisionAlignmentReport
+from src.runtime.bootstrap_runtime import BootstrapRuntime
+
+
+class _StubChampion:
+    def __init__(self) -> None:
+        self.genome_id = "bootstrap-champion"
+        self.fitness = 1.08
+
+    def as_payload(self) -> dict[str, object]:
+        return {"genome_id": self.genome_id, "fitness": self.fitness}
+
+
+class _StubOrchestrator:
+    def __init__(self) -> None:
+        self.telemetry = {"total_generations": 5, "champion": {"genome_id": "bootstrap-champion"}}
+        self.population_statistics = {"population_size": 12, "best_fitness": 1.08}
+        self.champion = _StubChampion()
+
+
+@pytest.mark.asyncio()
+async def test_vision_alignment_report_tracks_layer_progress() -> None:
+    orchestrator = _StubOrchestrator()
+    runtime = BootstrapRuntime(event_bus=EventBus(), evolution_orchestrator=orchestrator)
+
+    for _ in range(12):
+        await runtime.trading_stack.evaluate_tick(runtime.symbols[0])
+
+    reporter = VisionAlignmentReport(
+        fabric=runtime.fabric,
+        pipeline=runtime.pipeline,
+        trading_manager=runtime.trading_manager,
+        control_center=runtime.control_center,
+        evolution_orchestrator=orchestrator,
+    )
+
+    payload = reporter.build()
+
+    assert payload["summary"]["status"] in {"ready", "progressing", "gap"}
+    assert payload["summary"]["readiness"] >= 0.0
+    assert len(payload["layers"]) == 5
+    assert payload["layers"][0]["layer"].startswith("Layer 1")
+    assert any(layer["status"] == "ready" for layer in payload["layers"])
+    assert payload["strengths"]
+    assert payload["gaps"]


### PR DESCRIPTION
## Summary
- add a vision alignment reporter that scores each encyclopedia layer and surfaces consolidated strengths and gaps
- expose the alignment report via the bootstrap control centre overview and runtime status for live telemetry consumers
- extend regression coverage so the control centre, runtime, and dedicated reporter all validate the new vision telemetry

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cd11111384832c841a163bbc161aa6