### PR TITLE
Fix workflow checkout for local python setup action

### DIFF
--- a/.github/actions/python-setup/action.yml
+++ b/.github/actions/python-setup/action.yml
@@ -3,8 +3,6 @@ description: Setup Python 3.11 with pip cache and install dev dependencies.
 runs:
   using: composite
   steps:
-    - name: Checkout
-      uses: actions/checkout@v4
     - name: Setup Python
       id: setup-python
       uses: actions/setup-python@v5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [policy]
     steps:
+      - uses: actions/checkout@v4
       - uses: ./.github/actions/python-setup
       - name: Ruff (lint)
         run: ruff check .
@@ -33,6 +34,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [lint]
     steps:
+      - uses: actions/checkout@v4
       - uses: ./.github/actions/python-setup
       - name: Guard single mypy source
         run: |
@@ -55,6 +57,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [types]
     steps:
+      - uses: actions/checkout@v4
       - uses: ./.github/actions/python-setup
       - name: Pytest (coverage)
         env:
@@ -91,6 +94,7 @@ jobs:
     needs: [types]
     if: ${{ github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'ci:full-tests') }}
     steps:
+      - uses: actions/checkout@v4
       - uses: ./.github/actions/python-setup
       - name: Pytest (full suite)
         env:
@@ -122,6 +126,7 @@ jobs:
     if: github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'ci:backtest')
     needs: [tests]
     steps:
+      - uses: actions/checkout@v4
       - uses: ./.github/actions/python-setup
       - name: Prepare fixtures
         run: |

--- a/.github/workflows/dead-code-audit.yml
+++ b/.github/workflows/dead-code-audit.yml
@@ -21,6 +21,8 @@ jobs:
     name: Run vulture audit
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
       - name: Set up Python
         uses: ./.github/actions/python-setup
 

--- a/.github/workflows/typing-nightly.yml
+++ b/.github/workflows/typing-nightly.yml
@@ -15,6 +15,7 @@ jobs:
   mypy:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v4
       - uses: ./.github/actions/python-setup
 
       - name: Guard: disallow [tool.mypy] in pyproject.toml


### PR DESCRIPTION
## Summary
- ensure workflow jobs check out the repository before invoking the local python-setup composite action
- remove the redundant checkout step from the python-setup composite action now that jobs perform checkout explicitly

## Testing
- not run (workflow-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d50b34e430832c9fa5dcaa67d04e67