### PR TITLE
Harden workflows and fix type regressions

### DIFF
--- a/.github/actions/python-setup/action.yml
+++ b/.github/actions/python-setup/action.yml
@@ -5,6 +5,8 @@ runs:
   steps:
     - name: Checkout
       uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
     - name: Setup Python
       id: setup-python
       uses: actions/setup-python@v5
@@ -15,13 +17,13 @@ runs:
           requirements/base.txt
           requirements/dev.txt
     - name: Restore virtualenv
-      id: cache-venv
+      id: cache_venv
       uses: actions/cache@v4
       with:
         path: .venv
-        key: venv-${{ runner.os }}-py${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('requirements/dev.txt') }}
+        key: venv-${{ runner.os }}-py${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('requirements/base.txt', 'requirements/dev.txt') }}
     - name: Install dev dependencies
-      if: steps.cache-venv.outputs.cache-hit != 'true'
+      if: steps.cache_venv.outputs.cache-hit != 'true'
       shell: bash
       run: |
         set -euo pipefail

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,16 +17,12 @@ permissions:
 
 jobs:
   policy:
-    uses: ./.github/workflows/forbidden-integrations.yml
+    uses: ./.github/workflows/forbidden-integrations.yml@main
 
   lint:
     runs-on: ubuntu-latest
     needs: [policy]
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
       - uses: ./.github/actions/python-setup
       - name: Ruff (lint)
         run: ruff check .
@@ -37,10 +33,6 @@ jobs:
     runs-on: ubuntu-latest
     needs: [lint]
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
       - uses: ./.github/actions/python-setup
       - name: Guard single mypy source
         run: |
@@ -50,15 +42,17 @@ jobs:
           test -f mypy.ini || { echo "mypy.ini missing"; exit 1; }
       - name: Determine changed Python files
         id: changed-python
-        uses: tj-actions/changed-files@v41
+        uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36
         with:
-          files: |
-            src/**/*.py
+          list-files: shell
+          filters: |
+            python:
+              - 'src/**/*.py'
 
       - name: Strict mypy on changed Python files
-        if: steps.changed-python.outputs.any_changed == 'true'
+        if: steps.changed-python.outputs.python == 'true'
         env:
-          CHANGED_PYTHON_FILES: ${{ steps.changed-python.outputs.all_changed_files }}
+          CHANGED_PYTHON_FILES: ${{ steps.changed-python.outputs.python_files }}
         run: |
           set -euo pipefail
           python tools/run_mypy_strict_on_changed.py
@@ -86,8 +80,6 @@ jobs:
     runs-on: ubuntu-latest
     needs: [types]
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
       - uses: ./.github/actions/python-setup
       - name: Pytest (coverage)
         env:
@@ -122,10 +114,8 @@ jobs:
   tests-full:
     runs-on: ubuntu-latest
     needs: [types]
-    if: ${{ github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'ci:full-tests') }}
+    if: github.event_name != 'pull_request' || contains(join(github.event.pull_request.labels.*.name, ','), 'ci:full-tests')
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
       - uses: ./.github/actions/python-setup
       - name: Pytest (full suite)
         env:
@@ -154,11 +144,9 @@ jobs:
 
   backtest:
     runs-on: ubuntu-latest
-    if: github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'ci:backtest')
-    needs: [tests]
+    if: github.event_name != 'pull_request' || contains(join(github.event.pull_request.labels.*.name, ','), 'ci:backtest')
+    needs: [tests, tests-full]
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
       - uses: ./.github/actions/python-setup
       - name: Prepare fixtures
         run: |

--- a/.github/workflows/dead-code-audit.yml
+++ b/.github/workflows/dead-code-audit.yml
@@ -21,8 +21,6 @@ jobs:
     name: Run vulture audit
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
       - name: Set up Python
         uses: ./.github/actions/python-setup
 

--- a/.github/workflows/mypy-nightly.yml
+++ b/.github/workflows/mypy-nightly.yml
@@ -14,8 +14,6 @@ jobs:
     name: Nightly mypy enforcement
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
       - uses: ./.github/actions/python-setup
       - name: Verify mypy configuration
         run: |

--- a/.github/workflows/policy-openapi-block.yml
+++ b/.github/workflows/policy-openapi-block.yml
@@ -7,4 +7,4 @@ on:
 
 jobs:
   block-openapi:
-    uses: ./.github/workflows/forbidden-integrations.yml
+    uses: ./.github/workflows/forbidden-integrations.yml@main

--- a/.github/workflows/typing-nightly.yml
+++ b/.github/workflows/typing-nightly.yml
@@ -15,8 +15,6 @@ jobs:
   mypy:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
       - uses: ./.github/actions/python-setup
 
       - name: Guard: disallow [tool.mypy] in pyproject.toml


### PR DESCRIPTION
## Summary
- make the full test and backtest jobs resilient to missing PR labels and ensure the backtest only runs after both suites complete
- include base requirements in the composite cache key and rely on the shared setup action for repository checkout to keep virtualenv caches fresh
- replace the compromised changed-files action with a pinned paths-filter invocation and pin the policy workflow reference for reproducible CI

## Testing
- not run (workflow changes only)


------
https://chatgpt.com/codex/tasks/task_e_68d65f5616e0832c9d8c90c8a5e3dac7