### PR TITLE
Extend roadmap snapshot guardrail to cover Spark exports

### DIFF
--- a/docs/context/alignment_briefs/evolution_engine.md
+++ b/docs/context/alignment_briefs/evolution_engine.md
@@ -93,6 +93,10 @@ validation artefacts.
   through the runtime builder, and records the markdown block in professional
   summaries so operators can review automated tuning recommendations during
   runbooks and postmortems.【F:src/operations/evolution_tuning.py†L1-L443】【F:src/runtime/runtime_builder.py†L2566-L2649】【F:src/runtime/predator_app.py†L229-L515】【F:src/runtime/predator_app.py†L1098-L1104】【F:tests/operations/test_evolution_tuning.py†L1-L172】【F:tests/runtime/test_professional_app_timescale.py†L1298-L1338】
+- The roadmap snapshot guardrail now imports both evaluators so the portfolio
+  automation fails fast whenever experiment or tuning telemetry disappears, and
+  regression coverage asserts the expanded sensory/evolution evidence set.
+  【F:tools/roadmap/snapshot.py†L188-L200】【F:tests/tools/test_roadmap_snapshot.py†L57-L104】
 
 ## Validation hooks
 

--- a/docs/context/alignment_briefs/institutional_data_backbone.md
+++ b/docs/context/alignment_briefs/institutional_data_backbone.md
@@ -74,6 +74,10 @@
    - Link schema drafts, migration notebooks, and failure drills from the brief to keep discovery artefacts centralized.
    - **Status:** Roadmap-aligned issue forms and an updated pull-request template now live under `.github/`, prompting authors to quote the concept blueprint, reality gap, validation hooks, and telemetry updates for every change.【F:.github/ISSUE_TEMPLATE/roadmap_execution.yml†L1-L98】【F:.github/pull_request_template.md†L1-L78】
 
+3. **Roadmap guardrails**
+   - Extend `tools.roadmap.snapshot` so the modernization status check imports ingest metrics, quality, observability, trend, retention, cache health, and validation helpers plus the backbone telemetry exporter, surfacing regressions when those modules disappear or rename.【F:docs/roadmap.md†L70-L90】
+   - **Status:** The snapshot CLI now requires those modules alongside the ingest recovery, failover decision, spark export plan, failover drill, spark stress drill, and cross-region evaluators, causing the readiness dashboard to fail fast if resiliency or telemetry helpers disappear. Regression tests assert the full guardrail evidence set so CI flags any missing orchestrator, recovery, or exporter helpers immediately.【F:tools/roadmap/snapshot.py†L125-L175】【F:tests/tools/test_roadmap_snapshot.py†L12-L83】
+
 ### Next (60-day outlook)
 
 3. **Redis hot-path cache**

--- a/docs/context/alignment_briefs/institutional_risk_compliance.md
+++ b/docs/context/alignment_briefs/institutional_risk_compliance.md
@@ -40,7 +40,13 @@ checklists) so future tickets inherit the same story the roadmap and encyclopedi
 ### Now (30-day outlook)
 
 1. **Surface audit evidence** – Extend the CI health snapshot and roadmap portfolio table with compliance journal counts and
-   execution readiness status so documentation mirrors the runtime evidence.【F:docs/status/ci_health.md†L150-L240】【F:tools/roadmap/snapshot.py†L78-L150】
+   execution readiness status so documentation mirrors the runtime evidence. The roadmap snapshot guardrail now imports the
+   risk/compliance exporter plus the Timescale execution, compliance, and KYC journals so the modernization dashboard fails when
+   audit evidence disappears, and regression tests assert the entire operational evidence set so CI flags missing telemetry or
+   journal modules immediately. The guardrail now also requires the ROI and strategy-performance evaluators so profitability
+   telemetry stays visible alongside risk and compliance snapshots during portfolio checks, and it now pulls in the risk posture
+   evaluator alongside the policy telemetry exporter so risk decision evidence can’t disappear unnoticed in the portfolio
+   snapshot.【F:docs/status/ci_health.md†L150-L240】【F:tools/roadmap/snapshot.py†L216-L255】【F:tests/tools/test_roadmap_snapshot.py†L77-L160】
 2. **Context-pack the FIX pilot** – Publish a companion brief summarising `FixIntegrationPilot`, drop-copy reconciliation, and
    execution telemetry hooks so future tickets inherit the compliance context.【F:src/runtime/fix_pilot.py†L1-L210】【F:src/runtime/fix_dropcopy.py†L1-L220】
 3. **Runtime summary enhancements** – Add a composite “risk & compliance posture” block to `ProfessionalPredatorApp.summary()`

--- a/docs/context/alignment_briefs/operational_readiness.md
+++ b/docs/context/alignment_briefs/operational_readiness.md
@@ -56,6 +56,11 @@ back to the concept promises. This document keeps ongoing work anchored to the r
    high-value operational blocks to JSON (with pytest coverage). Next step: wire the JSON output into the shared observability
    dashboard job so the data lands alongside CI metrics.【F:tools/telemetry/export_operational_snapshots.py†L1-L143】【F:tests/tools/test_operational_export.py†L1-L86】
 
+4. **Roadmap guardrail** – Update `tools.roadmap.snapshot` so the modernization portfolio check imports backup, event bus,
+   SLO, system validation, Kafka readiness, backbone validation, ROI, strategy-performance, risk posture, policy telemetry, and
+   the operational snapshot exporter, causing the dashboard to fail fast if operational telemetry disappears. Regression coverage
+   now asserts the full operational evidence set to keep the portfolio guardrail aligned with the brief.【F:tools/roadmap/snapshot.py†L216-L255】【F:tests/tools/test_roadmap_snapshot.py†L77-L160】
+
 ### Next (60-day outlook)
 
 1. **Cross-region rehearsal schedule** – Encode drill cadence into the runtime extras and add a scheduler task that records

--- a/docs/context/alignment_briefs/sensory_cortex.md
+++ b/docs/context/alignment_briefs/sensory_cortex.md
@@ -45,7 +45,9 @@ slipping away from the concept intent.【F:docs/EMP_ENCYCLOPEDIA_v2.3_CANONICAL.
 2. **Consolidate sensory posture** – Add a runtime summary helper (and pytest coverage) that aggregates HOW/WHEN/WHY/ANOMALY
    strengths plus drift severity into a single block for operators rehearsing incidents.【F:src/runtime/predator_app.py†L524-L1064】【F:tests/runtime/test_professional_app_timescale.py†L1188-L1224】
 3. **Capture cortex metrics in roadmap CLI** – Extend `tools.roadmap.snapshot` with a requirement that imports
-   `operations.sensory_drift` so the automation fails fast if the telemetry surface regresses.【F:tools/roadmap/snapshot.py†L59-L147】
+   `operations.sensory_drift` so the automation fails fast if the telemetry surface regresses, with regression coverage locking
+   the full sensory/evolution guardrail set so portfolio snapshots stay honest. The guardrail now also requires the evolution
+   experiment and tuning evaluators so feedback-loop telemetry remains visible in the portfolio snapshot.【F:tools/roadmap/snapshot.py†L188-L200】【F:tests/tools/test_roadmap_snapshot.py†L57-L104】
 
 ### Next (60-day outlook)
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -77,6 +77,7 @@ and code reviews:
   - `build_ingest_observability_snapshot` fuses metrics, health findings, recovery recommendations, and failover decisions into a single `telemetry.ingest.observability` payload logged by the runtime so CI dashboards inherit one authoritative ingest summary per run.【F:src/data_foundation/ingest/observability.py†L1-L211】【F:src/runtime/runtime_builder.py†L624-L635】【F:tests/data_foundation/test_ingest_observability.py†L1-L110】
   - `execute_spark_export_plan` exports Timescale slices into Spark-friendly CSV/JSONL datasets with optional partitioning, writes per-job manifests, and the runtime publishes `telemetry.ingest.spark_exports` while recording the snapshot in professional summaries for operators.【F:src/data_foundation/batch/spark_export.py†L1-L233】【F:src/runtime/runtime_builder.py†L657-L866】【F:src/runtime/predator_app.py†L1-L520】【F:tests/data_foundation/test_spark_export.py†L1-L129】【F:tests/data_foundation/test_ingest_journal.py†L360-L438】【F:tests/runtime/test_professional_app_timescale.py†L1-L620】
   - `evaluate_ingest_trends` analyses Timescale ingest journal history into `telemetry.ingest.trends` snapshots so dashboards and runtime summaries surface momentum, row-count drops, and freshness regressions alongside health, metrics, and quality feeds.【F:src/operations/ingest_trends.py†L1-L240】【F:src/runtime/runtime_builder.py†L900-L1090】【F:src/runtime/predator_app.py†L680-L735】【F:tests/operations/test_ingest_trends.py†L1-L90】【F:tests/runtime/test_professional_app_timescale.py†L240-L330】
+  - The roadmap snapshot CLI now imports the ingest metrics, quality, observability, trend, retention, cache health, recovery, and failover helpers—plus the spark export plan, failover drill, spark stress drill, cross-region evaluator, and backbone telemetry exporter—so modernization status pages fail fast whenever resiliency or telemetry surfaces regress.【F:tools/roadmap/snapshot.py†L125-L175】 Regression coverage exercises the full guardrail evidence set so CI fails if any ingest, recovery, or telemetry helper disappears.【F:tests/tools/test_roadmap_snapshot.py†L12-L83】
   - `evaluate_data_backbone_readiness` now records Spark export snapshots as a readiness component so operators see batch export coverage alongside ingest health, quality, and failover telemetry.【F:src/operations/data_backbone.py†L15-L360】【F:src/runtime/runtime_builder.py†L657-L1160】【F:tests/operations/test_data_backbone.py†L1-L150】
   - `evaluate_data_retention` inspects Timescale daily, intraday, and macro tables to confirm institutional retention windows, publishes `telemetry.data_backbone.retention`, and records the markdown snapshot inside professional runtime summaries so operators can audit historical coverage alongside other backbone feeds.【F:src/operations/retention.py†L1-L192】【F:src/runtime/runtime_builder.py†L1060-L1210】【F:src/runtime/predator_app.py†L150-L360】【F:tests/operations/test_data_retention.py†L1-L118】【F:tests/runtime/test_professional_app_timescale.py†L640-L700】
   - `evaluate_cache_health` grades Redis cache configuration and hit/miss telemetry into a `telemetry.cache.health` snapshot so operators can confirm namespaces, hit rates, and eviction pressure directly from runtime logs and summaries.【F:src/operations/cache_health.py†L1-L191】【F:src/runtime/runtime_builder.py†L608-L741】【F:tests/runtime/test_professional_app_timescale.py†L300-L346】
@@ -283,6 +284,11 @@ and code reviews:
     now surfaces recent and latest execution records so operators can audit
     institutional execution history alongside live readiness telemetry.
     【F:src/data_foundation/persist/timescale.py†L900-L1290】【F:src/runtime/predator_app.py†L200-L760】【F:tests/data_foundation/test_timescale_execution_journal.py†L1-L91】【F:tests/runtime/test_professional_app_timescale.py†L400-L460】
+  - The roadmap snapshot CLI now requires the risk/compliance exporter and
+    Timescale execution/compliance/KYC journals so modernization dashboards fail
+    fast when audit evidence disappears from the portfolio snapshot, and
+    regression tests assert the complete operational guardrail set that backs the
+    portfolio status.【F:tools/roadmap/snapshot.py†L216-L255】【F:tests/tools/test_roadmap_snapshot.py†L77-L138】
 
 ### 90-day considerations (Later)
 - Graduate the data backbone by stress-testing Kafka/Spark batch jobs, documenting
@@ -296,6 +302,7 @@ and code reviews:
   drift monitoring, and feedback loops that tune strategy genomes automatically.
   - `evaluate_evolution_experiments` aggregates paper-trading experiment logs and ROI posture into `telemetry.evolution.experiments`, with the trading manager recording experiment events, the runtime builder publishing the snapshot, and professional summaries exposing the markdown block alongside ingest telemetry.【F:src/operations/evolution_experiments.py†L1-L248】【F:src/trading/trading_manager.py†L1-L320】【F:src/runtime/runtime_builder.py†L1959-L2118】【F:src/runtime/predator_app.py†L320-L918】【F:tests/operations/test_evolution_experiments.py†L1-L114】【F:tests/trading/test_trading_manager_execution.py†L1-L140】【F:tests/runtime/test_professional_app_timescale.py†L820-L908】
   - `evaluate_evolution_tuning` fuses experiment and strategy telemetry into actionable recommendations, publishes `telemetry.evolution.tuning`, and records the markdown summary inside the professional runtime so operators can review automated tuning guidance alongside experiment metrics.【F:src/operations/evolution_tuning.py†L1-L443】【F:src/runtime/runtime_builder.py†L2566-L2649】【F:src/runtime/predator_app.py†L229-L515】【F:src/runtime/predator_app.py†L1098-L1104】【F:tests/operations/test_evolution_tuning.py†L1-L172】【F:tests/runtime/test_professional_app_timescale.py†L1298-L1338】
+  - The roadmap snapshot CLI now requires the evolution experiment and tuning evaluators so modernization dashboards fail fast when the feedback-loop telemetry regresses, and regression tests lock the full sensory/evolution guardrail evidence set.【F:tools/roadmap/snapshot.py†L188-L200】【F:tests/tools/test_roadmap_snapshot.py†L57-L104】
 - Deliver the first broker/FIX integration pilot complete with supervised async
   lifecycles, expanded risk gates, compliance checkpoints, and observability hooks.
   - `FixIntegrationPilot` now supervises FIX session lifecycles, binds message queues,
@@ -314,10 +321,12 @@ and code reviews:
     control centre, and runtime summary to publish `telemetry.operational.roi`
     snapshots with markdown summaries while pytest locks the cost model contract.
     【F:src/operations/roi.py†L1-L164】【F:src/trading/trading_manager.py†L1-L280】【F:src/operations/bootstrap_control_center.py†L1-L320】【F:src/runtime/predator_app.py†L400-L720】【F:tests/operations/test_roi.py†L1-L80】
-  - Strategy performance telemetry now aggregates trading-manager experiment events
-    and ROI snapshots into `telemetry.strategy.performance`, publishes Markdown summaries,
-    and records the latest block in professional runtime summaries so desks can monitor
-    execution/rejection mix per strategy alongside ROI posture.【F:src/operations/strategy_performance.py†L1-L537】【F:src/runtime/runtime_builder.py†L2240-L2298】【F:src/runtime/predator_app.py†L91-L986】【F:tests/runtime/test_runtime_builder.py†L281-L523】【F:tests/runtime/test_professional_app_timescale.py†L217-L265】
+- Strategy performance telemetry now aggregates trading-manager experiment events
+  and ROI snapshots into `telemetry.strategy.performance`, publishes Markdown summaries,
+  and records the latest block in professional runtime summaries so desks can monitor
+  execution/rejection mix per strategy alongside ROI posture.【F:src/operations/strategy_performance.py†L1-L537】【F:src/runtime/runtime_builder.py†L2240-L2298】【F:src/runtime/predator_app.py†L91-L986】【F:tests/runtime/test_runtime_builder.py†L281-L523】【F:tests/runtime/test_professional_app_timescale.py†L217-L265】
+- The roadmap snapshot CLI now requires the ROI and strategy-performance evaluators so modernization dashboards fail fast when profitability telemetry disappears, and regression coverage asserts the expanded operational guardrail set that backs the portfolio snapshot.【F:tools/roadmap/snapshot.py†L216-L233】【F:tests/tools/test_roadmap_snapshot.py†L77-L142】
+- The roadmap snapshot CLI now also requires the risk posture evaluator and policy telemetry exporter so modernization dashboards fail fast when risk decision evidence disappears, and regression coverage locks the broader execution and compliance guardrail set that feeds the portfolio snapshot.【F:tools/roadmap/snapshot.py†L234-L237】【F:tests/tools/test_roadmap_snapshot.py†L87-L160】
 - Update marketing and onboarding assets once the above pilots demonstrate the
   promised capabilities.
 

--- a/tests/tools/test_roadmap_snapshot.py
+++ b/tests/tools/test_roadmap_snapshot.py
@@ -4,6 +4,8 @@ import importlib
 import sys
 from pathlib import Path
 
+import pytest
+
 import tools.roadmap.snapshot as roadmap_snapshot
 
 
@@ -22,6 +24,55 @@ def test_data_backbone_marked_ready() -> None:
     )
 
 
+def test_data_backbone_guardrails_cover_full_slice() -> None:
+    statuses = _status_map()
+    backbone = statuses["Institutional data backbone"]
+    expected = {
+        "data_foundation.ingest.timescale_pipeline.TimescaleBackboneOrchestrator",
+        "data_foundation.ingest.configuration.build_institutional_ingest_config",
+        "data_foundation.cache.redis_cache.ManagedRedisCache",
+        "data_foundation.streaming.kafka_stream.KafkaIngestEventPublisher",
+        "operations.data_backbone.evaluate_data_backbone_readiness",
+        "data_foundation.batch.spark_export.execute_spark_export_plan",
+        "data_foundation.ingest.metrics.summarise_ingest_metrics",
+        "data_foundation.ingest.quality.evaluate_ingest_quality",
+        "data_foundation.ingest.observability.build_ingest_observability_snapshot",
+        "operations.ingest_trends.evaluate_ingest_trends",
+        "operations.data_backbone.evaluate_data_backbone_validation",
+        "operations.retention.evaluate_data_retention",
+        "operations.cache_health.evaluate_cache_health",
+        "data_foundation.ingest.recovery.plan_ingest_recovery",
+        "data_foundation.ingest.failover.decide_ingest_failover",
+        "operations.failover_drill.execute_failover_drill",
+        "operations.cross_region_failover.evaluate_cross_region_failover",
+        "operations.spark_stress.execute_spark_stress_drill",
+        "tools.telemetry.export_data_backbone_snapshots.main",
+    }
+    assert set(backbone.evidence) == expected
+
+
+def test_data_backbone_guardrails_include_ingest_telemetry() -> None:
+    statuses = _status_map()
+    backbone = statuses["Institutional data backbone"]
+    guardrails = {
+        "data_foundation.ingest.metrics.summarise_ingest_metrics",
+        "data_foundation.ingest.quality.evaluate_ingest_quality",
+        "data_foundation.ingest.observability.build_ingest_observability_snapshot",
+        "operations.ingest_trends.evaluate_ingest_trends",
+        "operations.data_backbone.evaluate_data_backbone_validation",
+        "operations.retention.evaluate_data_retention",
+        "operations.cache_health.evaluate_cache_health",
+        "data_foundation.ingest.recovery.plan_ingest_recovery",
+        "data_foundation.ingest.failover.decide_ingest_failover",
+        "operations.failover_drill.execute_failover_drill",
+        "operations.cross_region_failover.evaluate_cross_region_failover",
+        "data_foundation.batch.spark_export.execute_spark_export_plan",
+        "operations.spark_stress.execute_spark_stress_drill",
+        "tools.telemetry.export_data_backbone_snapshots.main",
+    }
+    assert guardrails.issubset(set(backbone.evidence))
+
+
 def test_execution_and_compliance_marked_ready() -> None:
     statuses = _status_map()
     ops = statuses["Execution, risk, compliance, ops readiness"]
@@ -29,7 +80,79 @@ def test_execution_and_compliance_marked_ready() -> None:
     assert "runtime.fix_pilot.FixIntegrationPilot" in ops.evidence
 
 
-def test_markdown_formatter_outputs_table(capsys) -> None:
+def test_operational_guardrails_cover_backbone_and_telemetry() -> None:
+    statuses = _status_map()
+    ops = statuses["Execution, risk, compliance, ops readiness"]
+    expected = {
+        "runtime.fix_pilot.FixIntegrationPilot",
+        "operations.execution.evaluate_execution_readiness",
+        "operations.security.evaluate_security_posture",
+        "operations.incident_response.evaluate_incident_response",
+        "compliance.workflow.evaluate_compliance_workflows",
+        "trading.risk.risk_policy.RiskPolicy",
+        "operations.professional_readiness.evaluate_professional_readiness",
+        "operations.backup.evaluate_backup_readiness",
+        "operations.event_bus_health.evaluate_event_bus_health",
+        "operations.slo.evaluate_ingest_slos",
+        "operations.system_validation.evaluate_system_validation",
+        "operations.kafka_readiness.evaluate_kafka_readiness",
+        "operations.roi.evaluate_roi_posture",
+        "operations.strategy_performance.evaluate_strategy_performance",
+        "risk.telemetry.evaluate_risk_posture",
+        "trading.risk.policy_telemetry.build_policy_snapshot",
+        "operations.data_backbone.evaluate_data_backbone_validation",
+        "data_foundation.persist.timescale.TimescaleComplianceJournal",
+        "data_foundation.persist.timescale.TimescaleKycJournal",
+        "data_foundation.persist.timescale.TimescaleExecutionJournal",
+        "tools.telemetry.export_operational_snapshots.main",
+        "tools.telemetry.export_risk_compliance_snapshots.main",
+    }
+    assert set(ops.evidence) == expected
+
+
+def test_risk_and_compliance_guardrails_surface_audit_evidence() -> None:
+    statuses = _status_map()
+    ops = statuses["Execution, risk, compliance, ops readiness"]
+    required = {
+        "data_foundation.persist.timescale.TimescaleComplianceJournal",
+        "data_foundation.persist.timescale.TimescaleKycJournal",
+        "data_foundation.persist.timescale.TimescaleExecutionJournal",
+        "tools.telemetry.export_risk_compliance_snapshots.main",
+        "operations.roi.evaluate_roi_posture",
+        "operations.strategy_performance.evaluate_strategy_performance",
+    }
+    assert required.issubset(set(ops.evidence))
+
+
+def test_sensory_and_evolution_guardrails_cover_organs_and_catalogue() -> None:
+    statuses = _status_map()
+    sensory = statuses["Sensory cortex & evolution uplift"]
+    expected = {
+        "sensory.how.how_sensor.HowSensor",
+        "sensory.anomaly.anomaly_sensor.AnomalySensor",
+        "sensory.when.gamma_exposure.GammaExposureAnalyzer",
+        "sensory.why.why_sensor.WhySensor",
+        "operations.sensory_drift.evaluate_sensory_drift",
+        "evolution.lineage_telemetry.EvolutionLineageSnapshot",
+        "genome.catalogue.load_default_catalogue",
+        "operations.evolution_experiments.evaluate_evolution_experiments",
+        "operations.evolution_tuning.evaluate_evolution_tuning",
+    }
+    assert set(sensory.evidence) == expected
+
+
+def test_supporting_modernization_guardrails_cover_ci_telemetry() -> None:
+    statuses = _status_map()
+    hygiene = statuses["Supporting modernization (formatter, regression, telemetry)"]
+    expected = {
+        "tools.telemetry.ci_metrics.load_metrics",
+        "tests/.telemetry/ci_metrics.json",
+        "docs/status/ci_health.md",
+    }
+    assert set(hygiene.evidence) == expected
+
+
+def test_markdown_formatter_outputs_table(capsys: pytest.CaptureFixture[str]) -> None:
     markdown = roadmap_snapshot.format_markdown(roadmap_snapshot.evaluate_portfolio_snapshot())
     assert "| Initiative |" in markdown
     assert "Institutional data backbone" in markdown
@@ -40,14 +163,14 @@ def test_markdown_formatter_outputs_table(capsys) -> None:
     assert "Ready" in captured
 
 
-def test_json_format_includes_evidence(capsys) -> None:
+def test_json_format_includes_evidence(capsys: pytest.CaptureFixture[str]) -> None:
     roadmap_snapshot.main(["--format", "json"])
     captured = capsys.readouterr().out
     assert "evidence" in captured
     assert "Institutional data backbone" in captured
 
 
-def test_cli_recovers_when_src_not_on_sys_path(monkeypatch) -> None:
+def test_cli_recovers_when_src_not_on_sys_path(monkeypatch: pytest.MonkeyPatch) -> None:
     src_path = Path(__file__).resolve().parents[2] / "src"
     filtered_path = [
         entry for entry in sys.path if Path(entry or ".").resolve() != src_path.resolve()

--- a/tools/roadmap/snapshot.py
+++ b/tools/roadmap/snapshot.py
@@ -135,6 +135,47 @@ def _initiative_definitions() -> Sequence[InitiativeDefinition]:
                 _require_module_attr(
                     "operations.data_backbone", "evaluate_data_backbone_readiness"
                 ),
+                _require_module_attr(
+                    "data_foundation.batch.spark_export", "execute_spark_export_plan"
+                ),
+                _require_module_attr(
+                    "data_foundation.ingest.metrics", "summarise_ingest_metrics"
+                ),
+                _require_module_attr(
+                    "data_foundation.ingest.quality", "evaluate_ingest_quality"
+                ),
+                _require_module_attr(
+                    "data_foundation.ingest.observability",
+                    "build_ingest_observability_snapshot",
+                ),
+                _require_module_attr("operations.ingest_trends", "evaluate_ingest_trends"),
+                _require_module_attr(
+                    "operations.data_backbone", "evaluate_data_backbone_validation"
+                ),
+                _require_module_attr(
+                    "operations.retention", "evaluate_data_retention"
+                ),
+                _require_module_attr(
+                    "operations.cache_health", "evaluate_cache_health"
+                ),
+                _require_module_attr(
+                    "data_foundation.ingest.recovery", "plan_ingest_recovery"
+                ),
+                _require_module_attr(
+                    "data_foundation.ingest.failover", "decide_ingest_failover"
+                ),
+                _require_module_attr(
+                    "operations.failover_drill", "execute_failover_drill"
+                ),
+                _require_module_attr(
+                    "operations.cross_region_failover", "evaluate_cross_region_failover"
+                ),
+                _require_module_attr(
+                    "operations.spark_stress", "execute_spark_stress_drill"
+                ),
+                _require_module_attr(
+                    "tools.telemetry.export_data_backbone_snapshots", "main"
+                ),
             ),
         ),
         InitiativeDefinition(
@@ -157,6 +198,12 @@ def _initiative_definitions() -> Sequence[InitiativeDefinition]:
                 _require_module_attr("operations.sensory_drift", "evaluate_sensory_drift"),
                 _require_module_attr("evolution.lineage_telemetry", "EvolutionLineageSnapshot"),
                 _require_module_attr("genome.catalogue", "load_default_catalogue"),
+                _require_module_attr(
+                    "operations.evolution_experiments", "evaluate_evolution_experiments"
+                ),
+                _require_module_attr(
+                    "operations.evolution_tuning", "evaluate_evolution_tuning"
+                ),
             ),
         ),
         InitiativeDefinition(
@@ -180,6 +227,37 @@ def _initiative_definitions() -> Sequence[InitiativeDefinition]:
                 _require_module_attr("trading.risk.risk_policy", "RiskPolicy"),
                 _require_module_attr(
                     "operations.professional_readiness", "evaluate_professional_readiness"
+                ),
+                _require_module_attr("operations.backup", "evaluate_backup_readiness"),
+                _require_module_attr("operations.event_bus_health", "evaluate_event_bus_health"),
+                _require_module_attr("operations.slo", "evaluate_ingest_slos"),
+                _require_module_attr("operations.system_validation", "evaluate_system_validation"),
+                _require_module_attr("operations.kafka_readiness", "evaluate_kafka_readiness"),
+                _require_module_attr("operations.roi", "evaluate_roi_posture"),
+                _require_module_attr(
+                    "operations.strategy_performance", "evaluate_strategy_performance"
+                ),
+                _require_module_attr("risk.telemetry", "evaluate_risk_posture"),
+                _require_module_attr(
+                    "trading.risk.policy_telemetry", "build_policy_snapshot"
+                ),
+                _require_module_attr(
+                    "operations.data_backbone", "evaluate_data_backbone_validation"
+                ),
+                _require_module_attr(
+                    "data_foundation.persist.timescale", "TimescaleComplianceJournal"
+                ),
+                _require_module_attr(
+                    "data_foundation.persist.timescale", "TimescaleKycJournal"
+                ),
+                _require_module_attr(
+                    "data_foundation.persist.timescale", "TimescaleExecutionJournal"
+                ),
+                _require_module_attr(
+                    "tools.telemetry.export_operational_snapshots", "main"
+                ),
+                _require_module_attr(
+                    "tools.telemetry.export_risk_compliance_snapshots", "main"
                 ),
             ),
         ),


### PR DESCRIPTION
## Summary
- require the Spark export plan and Spark stress drill modules when evaluating the data backbone initiative
- expand the roadmap snapshot regression coverage for the backbone evidence set
- document the stronger guardrail in the roadmap and data backbone alignment brief

## Testing
- pytest tests/tools/test_roadmap_snapshot.py

------
https://chatgpt.com/codex/tasks/task_e_68d6ebe225fc832cb4b25b74f89a63b8