### PR TITLE
Integrate lifecycle tracker into FIX executor

### DIFF
--- a/src/trading/order_management/__init__.py
+++ b/src/trading/order_management/__init__.py
@@ -18,12 +18,14 @@ from .position_tracker import (
 )
 
 __all__ = [
+    # Order lifecycle exports
     "LifecycleStatus",
     "OrderEvent",
     "OrderEventType",
     "OrderLifecycle",
     "OrderLifecycleSnapshot",
     "OrderStateError",
+    # Position tracking exports
     "PnLMode",
     "PositionLot",
     "PositionSnapshot",

--- a/src/trading/order_management/__init__.py
+++ b/src/trading/order_management/__init__.py
@@ -9,12 +9,12 @@ from .position_tracker import (
     PositionTracker,
 )
 from .order_state_machine import (
+    LifecycleStatus,
     OrderEvent,
     OrderEventType,
     OrderLifecycle,
     OrderLifecycleSnapshot,
     OrderStateError,
-    OrderStatus,
 )
 
 __all__ = [
@@ -29,5 +29,5 @@ __all__ = [
     "OrderLifecycle",
     "OrderLifecycleSnapshot",
     "OrderStateError",
-    "OrderStatus",
+    "LifecycleStatus",
 ]

--- a/src/trading/order_management/__init__.py
+++ b/src/trading/order_management/__init__.py
@@ -17,16 +17,15 @@ from .position_tracker import (
     ReconciliationReport,
 )
 
-_LIFECYCLE_EXPORTS = [
+__all__ = [
+    # Order lifecycle exports
     "LifecycleStatus",
     "OrderEvent",
     "OrderEventType",
     "OrderLifecycle",
     "OrderLifecycleSnapshot",
     "OrderStateError",
-]
-
-_POSITION_EXPORTS = [
+    # Position tracking exports
     "PnLMode",
     "PositionLot",
     "PositionSnapshot",
@@ -34,5 +33,3 @@ _POSITION_EXPORTS = [
     "ReconciliationDifference",
     "ReconciliationReport",
 ]
-
-__all__ = [*_LIFECYCLE_EXPORTS, *_POSITION_EXPORTS]

--- a/src/trading/order_management/__init__.py
+++ b/src/trading/order_management/__init__.py
@@ -18,16 +18,18 @@ from .order_state_machine import (
 )
 
 __all__ = [
+    # Order lifecycle exports
+    "LifecycleStatus",
+    "OrderEvent",
+    "OrderEventType",
+    "OrderLifecycle",
+    "OrderLifecycleSnapshot",
+    "OrderStateError",
+    # Position tracking exports
     "PnLMode",
     "PositionLot",
     "PositionSnapshot",
     "ReconciliationDifference",
     "ReconciliationReport",
     "PositionTracker",
-    "OrderEvent",
-    "OrderEventType",
-    "OrderLifecycle",
-    "OrderLifecycleSnapshot",
-    "OrderStateError",
-    "LifecycleStatus",
 ]

--- a/src/trading/order_management/__init__.py
+++ b/src/trading/order_management/__init__.py
@@ -17,15 +17,16 @@ from .position_tracker import (
     ReconciliationReport,
 )
 
-__all__ = [
-    # Order lifecycle exports
+_LIFECYCLE_EXPORTS = [
     "LifecycleStatus",
     "OrderEvent",
     "OrderEventType",
     "OrderLifecycle",
     "OrderLifecycleSnapshot",
     "OrderStateError",
-    # Position tracking exports
+]
+
+_POSITION_EXPORTS = [
     "PnLMode",
     "PositionLot",
     "PositionSnapshot",
@@ -33,3 +34,5 @@ __all__ = [
     "ReconciliationDifference",
     "ReconciliationReport",
 ]
+
+__all__ = [*_LIFECYCLE_EXPORTS, *_POSITION_EXPORTS]

--- a/src/trading/order_management/__init__.py
+++ b/src/trading/order_management/__init__.py
@@ -1,3 +1,33 @@
 from __future__ import annotations
 
-__all__: list[str] = []
+from .position_tracker import (
+    PnLMode,
+    PositionLot,
+    PositionSnapshot,
+    ReconciliationDifference,
+    ReconciliationReport,
+    PositionTracker,
+)
+from .order_state_machine import (
+    OrderEvent,
+    OrderEventType,
+    OrderLifecycle,
+    OrderLifecycleSnapshot,
+    OrderStateError,
+    OrderStatus,
+)
+
+__all__ = [
+    "PnLMode",
+    "PositionLot",
+    "PositionSnapshot",
+    "ReconciliationDifference",
+    "ReconciliationReport",
+    "PositionTracker",
+    "OrderEvent",
+    "OrderEventType",
+    "OrderLifecycle",
+    "OrderLifecycleSnapshot",
+    "OrderStateError",
+    "OrderStatus",
+]

--- a/src/trading/order_management/__init__.py
+++ b/src/trading/order_management/__init__.py
@@ -1,13 +1,5 @@
 from __future__ import annotations
 
-from .position_tracker import (
-    PnLMode,
-    PositionLot,
-    PositionSnapshot,
-    ReconciliationDifference,
-    ReconciliationReport,
-    PositionTracker,
-)
 from .order_state_machine import (
     LifecycleStatus,
     OrderEvent,
@@ -16,20 +8,26 @@ from .order_state_machine import (
     OrderLifecycleSnapshot,
     OrderStateError,
 )
+from .position_tracker import (
+    PnLMode,
+    PositionLot,
+    PositionSnapshot,
+    PositionTracker,
+    ReconciliationDifference,
+    ReconciliationReport,
+)
 
 __all__ = [
-    # Order lifecycle exports
     "LifecycleStatus",
     "OrderEvent",
     "OrderEventType",
     "OrderLifecycle",
     "OrderLifecycleSnapshot",
     "OrderStateError",
-    # Position tracking exports
     "PnLMode",
     "PositionLot",
     "PositionSnapshot",
+    "PositionTracker",
     "ReconciliationDifference",
     "ReconciliationReport",
-    "PositionTracker",
 ]

--- a/src/trading/order_management/order_state_machine.py
+++ b/src/trading/order_management/order_state_machine.py
@@ -1,0 +1,414 @@
+"""State machine utilities for FIX order lifecycle management.
+
+This module provides a focused state machine that mirrors the roadmap
+expectation for institutional order handling.  It translates FIX execution
+events into deterministic order states, keeps a history of lifecycle events,
+and exposes immutable snapshots that downstream components can consume for
+monitoring, reconciliation, or telemetry exports.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from enum import Enum
+from typing import Any, Iterable, Mapping, Optional
+
+__all__ = [
+    "OrderStatus",
+    "OrderEventType",
+    "OrderEvent",
+    "OrderLifecycleSnapshot",
+    "OrderLifecycle",
+    "OrderStateError",
+]
+
+
+class OrderStateError(RuntimeError):
+    """Raised when an invalid state transition is attempted."""
+
+
+class OrderStatus(str, Enum):
+    """Enumerates the canonical states for an order lifecycle."""
+
+    NEW = "NEW"
+    ACKNOWLEDGED = "ACKNOWLEDGED"
+    PARTIALLY_FILLED = "PARTIALLY_FILLED"
+    FILLED = "FILLED"
+    CANCELLED = "CANCELLED"
+    REJECTED = "REJECTED"
+
+
+class OrderEventType(str, Enum):
+    """Lifecycle events that drive state transitions."""
+
+    NEW = "NEW"
+    ACKNOWLEDGED = "ACKNOWLEDGED"
+    PARTIAL_FILL = "PARTIAL_FILL"
+    FILL = "FILL"
+    CANCELLED = "CANCELLED"
+    REJECTED = "REJECTED"
+
+
+@dataclass(frozen=True)
+class OrderEvent:
+    """Represents a single lifecycle event."""
+
+    type: OrderEventType
+    timestamp: datetime
+    quantity: float = 0.0
+    price: Optional[float] = None
+    leaves_quantity: Optional[float] = None
+    reason: Optional[str] = None
+    raw_exec_type: Optional[str] = None
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "type": self.type.value,
+            "timestamp": self.timestamp.isoformat(),
+            "quantity": self.quantity,
+            "price": self.price,
+            "leaves_quantity": self.leaves_quantity,
+            "reason": self.reason,
+            "raw_exec_type": self.raw_exec_type,
+            "metadata": dict(self.metadata),
+        }
+
+
+@dataclass(frozen=True)
+class OrderLifecycleSnapshot:
+    """Immutable view of the current order lifecycle state."""
+
+    order_id: str
+    status: OrderStatus
+    filled_quantity: float
+    remaining_quantity: float
+    average_price: Optional[float]
+    created_at: datetime
+    updated_at: datetime
+    symbol: Optional[str]
+    side: Optional[str]
+    initial_quantity: Optional[float]
+    last_event: Optional[OrderEvent]
+    reason: Optional[str]
+
+    def to_dict(self) -> dict[str, Any]:
+        payload = {
+            "order_id": self.order_id,
+            "status": self.status.value,
+            "filled_quantity": self.filled_quantity,
+            "remaining_quantity": self.remaining_quantity,
+            "average_price": self.average_price,
+            "created_at": self.created_at.isoformat(),
+            "updated_at": self.updated_at.isoformat(),
+            "symbol": self.symbol,
+            "side": self.side,
+            "initial_quantity": self.initial_quantity,
+            "reason": self.reason,
+        }
+        if self.last_event is not None:
+            payload["last_event"] = self.last_event.to_dict()
+        return payload
+
+
+_FIX_EXEC_TYPE_TO_EVENT: dict[str, OrderEventType] = {
+    "0": OrderEventType.ACKNOWLEDGED,
+    "1": OrderEventType.PARTIAL_FILL,
+    "2": OrderEventType.FILL,
+    "4": OrderEventType.CANCELLED,
+    "8": OrderEventType.REJECTED,
+}
+
+_ALLOWED_TRANSITIONS: Mapping[OrderStatus, set[OrderStatus]] = {
+    OrderStatus.NEW: {
+        OrderStatus.ACKNOWLEDGED,
+        OrderStatus.PARTIALLY_FILLED,
+        OrderStatus.FILLED,
+        OrderStatus.CANCELLED,
+        OrderStatus.REJECTED,
+    },
+    OrderStatus.ACKNOWLEDGED: {
+        OrderStatus.ACKNOWLEDGED,
+        OrderStatus.PARTIALLY_FILLED,
+        OrderStatus.FILLED,
+        OrderStatus.CANCELLED,
+        OrderStatus.REJECTED,
+    },
+    OrderStatus.PARTIALLY_FILLED: {
+        OrderStatus.PARTIALLY_FILLED,
+        OrderStatus.FILLED,
+        OrderStatus.CANCELLED,
+    },
+    OrderStatus.FILLED: set(),
+    OrderStatus.CANCELLED: set(),
+    OrderStatus.REJECTED: set(),
+}
+
+_FILL_EPSILON = 1e-9
+
+
+def _ensure_utc(timestamp: Optional[datetime]) -> datetime:
+    if timestamp is None:
+        return datetime.now(timezone.utc)
+    if timestamp.tzinfo is None:
+        return timestamp.replace(tzinfo=timezone.utc)
+    return timestamp.astimezone(timezone.utc)
+
+
+def _coerce_float(value: Any) -> Optional[float]:
+    if value is None:
+        return None
+    if isinstance(value, (int, float)):
+        return float(value)
+    if isinstance(value, (bytes, bytearray)):
+        try:
+            return float(value.decode())
+        except Exception as exc:  # pragma: no cover - defensive
+            raise ValueError(f"Could not decode float value: {value!r}") from exc
+    try:
+        return float(value)
+    except Exception as exc:  # pragma: no cover - defensive
+        raise ValueError(f"Could not convert value to float: {value!r}") from exc
+
+
+class OrderLifecycle:
+    """Track a single order lifecycle and enforce roadmap transitions."""
+
+    def __init__(
+        self,
+        order_id: str,
+        *,
+        quantity: Optional[float] = None,
+        symbol: Optional[str] = None,
+        side: Optional[str] = None,
+        created_at: Optional[datetime] = None,
+    ) -> None:
+        self.order_id = order_id
+        self._initial_quantity: Optional[float] = float(quantity) if quantity is not None else None
+        self.symbol = symbol
+        self.side = side
+        self._created_at = _ensure_utc(created_at)
+        self._updated_at = self._created_at
+        self._status = OrderStatus.NEW
+        self._filled_quantity = 0.0
+        self._average_price: Optional[float] = None
+        self._last_leaves: Optional[float] = None
+        self._last_event: Optional[OrderEvent] = None
+        self._reason: Optional[str] = None
+        self._events: list[OrderEvent] = []
+        self._record_event(OrderEventType.NEW, timestamp=self._created_at)
+
+    @property
+    def status(self) -> OrderStatus:
+        return self._status
+
+    @property
+    def initial_quantity(self) -> Optional[float]:
+        return self._initial_quantity
+
+    @property
+    def filled_quantity(self) -> float:
+        return self._filled_quantity
+
+    @property
+    def average_price(self) -> Optional[float]:
+        return self._average_price
+
+    @property
+    def events(self) -> Iterable[OrderEvent]:
+        return tuple(self._events)
+
+    def set_initial_quantity(self, quantity: float) -> None:
+        if quantity <= 0:
+            return
+        if self._initial_quantity is None:
+            self._initial_quantity = float(quantity)
+
+    def _record_event(
+        self,
+        event_type: OrderEventType,
+        *,
+        timestamp: Optional[datetime] = None,
+        quantity: float = 0.0,
+        price: Optional[float] = None,
+        leaves_quantity: Optional[float] = None,
+        reason: Optional[str] = None,
+        raw_exec_type: Optional[str] = None,
+        metadata: Optional[Mapping[str, Any]] = None,
+    ) -> OrderEvent:
+        event = OrderEvent(
+            type=event_type,
+            timestamp=_ensure_utc(timestamp),
+            quantity=quantity,
+            price=price,
+            leaves_quantity=leaves_quantity,
+            reason=reason,
+            raw_exec_type=raw_exec_type,
+            metadata=dict(metadata or {}),
+        )
+        self._events.append(event)
+        self._last_event = event
+        self._updated_at = event.timestamp
+        self._reason = reason
+        if leaves_quantity is not None:
+            self._last_leaves = max(leaves_quantity, 0.0)
+        return event
+
+    def _validate_transition(self, target_status: OrderStatus) -> None:
+        if self._status == target_status:
+            return
+        allowed = _ALLOWED_TRANSITIONS[self._status]
+        if target_status not in allowed:
+            raise OrderStateError(
+                f"Invalid transition from {self._status.value} to {target_status.value}"
+            )
+
+    def _update_fill_metrics(
+        self,
+        quantity: float,
+        price: Optional[float],
+        leaves_quantity: Optional[float],
+    ) -> None:
+        if quantity < -_FILL_EPSILON:
+            raise OrderStateError("Fill quantity cannot be negative")
+
+        new_total = self._filled_quantity + quantity
+        if self._initial_quantity is not None and new_total > self._initial_quantity + _FILL_EPSILON:
+            raise OrderStateError(
+                "Filled quantity exceeds the initial order quantity"
+            )
+
+        if self._initial_quantity is None and leaves_quantity is not None:
+            inferred = new_total + max(leaves_quantity, 0.0)
+            if inferred > 0:
+                self._initial_quantity = inferred
+
+        self._filled_quantity = new_total
+
+        if quantity > _FILL_EPSILON and price is not None:
+            if self._average_price is None:
+                self._average_price = price
+            else:
+                total_notional = self._average_price * (new_total - quantity) + price * quantity
+                if new_total > _FILL_EPSILON:
+                    self._average_price = total_notional / new_total
+
+        if leaves_quantity is not None:
+            self._last_leaves = max(leaves_quantity, 0.0)
+        elif self._initial_quantity is not None:
+            self._last_leaves = max(self._initial_quantity - self._filled_quantity, 0.0)
+
+    def apply_event(
+        self,
+        event_type: OrderEventType,
+        *,
+        timestamp: Optional[datetime] = None,
+        quantity: Optional[float] = None,
+        price: Optional[float] = None,
+        leaves_quantity: Optional[float] = None,
+        reason: Optional[str] = None,
+        raw_exec_type: Optional[str] = None,
+        metadata: Optional[Mapping[str, Any]] = None,
+    ) -> OrderLifecycleSnapshot:
+        qty = float(quantity or 0.0)
+        px = price
+        leaves = leaves_quantity
+
+        target_status = {
+            OrderEventType.NEW: OrderStatus.NEW,
+            OrderEventType.ACKNOWLEDGED: OrderStatus.ACKNOWLEDGED,
+            OrderEventType.PARTIAL_FILL: OrderStatus.PARTIALLY_FILLED,
+            OrderEventType.FILL: OrderStatus.FILLED,
+            OrderEventType.CANCELLED: OrderStatus.CANCELLED,
+            OrderEventType.REJECTED: OrderStatus.REJECTED,
+        }[event_type]
+
+        if self._status in {OrderStatus.FILLED, OrderStatus.CANCELLED, OrderStatus.REJECTED}:
+            raise OrderStateError(f"Order lifecycle already terminal: {self._status.value}")
+
+        if event_type in {OrderEventType.CANCELLED, OrderEventType.REJECTED} and leaves is None:
+            leaves = 0.0
+
+        if event_type in {OrderEventType.PARTIAL_FILL, OrderEventType.FILL}:
+            self._update_fill_metrics(qty, px, leaves)
+            if (
+                event_type == OrderEventType.PARTIAL_FILL
+                and ((leaves is not None and leaves <= _FILL_EPSILON)
+                     or (
+                        self._initial_quantity is not None
+                        and self._initial_quantity - self._filled_quantity <= _FILL_EPSILON
+                    ))
+            ):
+                target_status = OrderStatus.FILLED
+
+        self._validate_transition(target_status)
+        self._status = target_status
+
+        event = self._record_event(
+            event_type,
+            timestamp=timestamp,
+            quantity=qty,
+            price=px,
+            leaves_quantity=leaves,
+            reason=reason,
+            raw_exec_type=raw_exec_type,
+            metadata=metadata,
+        )
+
+        return self.snapshot()
+
+    def apply_fix_execution(
+        self,
+        exec_type: Any,
+        *,
+        last_qty: Any = None,
+        last_px: Any = None,
+        leaves_qty: Any = None,
+        reason: Optional[str] = None,
+        timestamp: Optional[datetime] = None,
+        metadata: Optional[Mapping[str, Any]] = None,
+    ) -> OrderLifecycleSnapshot:
+        exec_value = exec_type.decode() if isinstance(exec_type, (bytes, bytearray)) else str(exec_type)
+        event_type = _FIX_EXEC_TYPE_TO_EVENT.get(exec_value)
+        if event_type is None:
+            raise OrderStateError(f"Unsupported FIX ExecType: {exec_type!r}")
+
+        qty = _coerce_float(last_qty) or 0.0
+        px = _coerce_float(last_px) if last_px is not None else None
+        leaves = _coerce_float(leaves_qty) if leaves_qty is not None else None
+
+        return self.apply_event(
+            event_type,
+            timestamp=timestamp,
+            quantity=qty,
+            price=px,
+            leaves_quantity=leaves,
+            reason=reason,
+            raw_exec_type=exec_value,
+            metadata=metadata,
+        )
+
+    def snapshot(self) -> OrderLifecycleSnapshot:
+        remaining = self._last_leaves
+        if remaining is None:
+            if self._initial_quantity is not None:
+                remaining = max(self._initial_quantity - self._filled_quantity, 0.0)
+            else:
+                remaining = 0.0
+
+        return OrderLifecycleSnapshot(
+            order_id=self.order_id,
+            status=self._status,
+            filled_quantity=self._filled_quantity,
+            remaining_quantity=remaining,
+            average_price=self._average_price,
+            created_at=self._created_at,
+            updated_at=self._updated_at,
+            symbol=self.symbol,
+            side=self.side,
+            initial_quantity=self._initial_quantity,
+            last_event=self._last_event,
+            reason=self._reason,
+        )
+

--- a/src/trading/order_management/position_tracker.py
+++ b/src/trading/order_management/position_tracker.py
@@ -1,0 +1,434 @@
+"""Position tracking utilities for EMP order management.
+
+This module provides a stateful :class:`PositionTracker` capable of ingesting
+fills, computing realised/unrealised PnL under FIFO or LIFO accounting, and
+reporting account level exposures.  The implementation is intentionally
+side-effect free (apart from internal state mutation) so it can be embedded in
+services or exercised during dry runs.
+"""
+
+from __future__ import annotations
+
+from collections import deque
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Deque, Dict, Iterable, Literal, Mapping, MutableMapping, Optional, Tuple
+
+PnLMode = Literal["fifo", "lifo"]
+
+__all__ = [
+    "PnLMode",
+    "PositionLot",
+    "PositionSnapshot",
+    "ReconciliationDifference",
+    "ReconciliationReport",
+    "PositionTracker",
+]
+
+
+_EPSILON = 1e-12
+
+
+def _utc_now() -> datetime:
+    """Return a timezone-aware UTC timestamp."""
+
+    return datetime.now(timezone.utc)
+
+
+@dataclass(slots=True)
+class PositionLot:
+    """A single open lot in the inventory."""
+
+    quantity: float
+    price: float
+    timestamp: datetime
+
+
+@dataclass(slots=True)
+class PositionSnapshot:
+    """Summary of the tracked state for a symbol and account."""
+
+    symbol: str
+    account: str
+    net_quantity: float
+    long_quantity: float
+    short_quantity: float
+    market_price: Optional[float]
+    average_long_price: Optional[float]
+    average_short_price: Optional[float]
+    realized_pnl: float
+    unrealized_pnl: Optional[float]
+    exposure: Optional[float]
+
+    @property
+    def market_value(self) -> Optional[float]:
+        """Return the market value of the net position if a price is known."""
+
+        if self.market_price is None:
+            return None
+        return self.net_quantity * self.market_price
+
+
+@dataclass(slots=True)
+class ReconciliationDifference:
+    """Represents a delta between tracked and broker reported quantity."""
+
+    symbol: str
+    tracker_quantity: float
+    broker_quantity: float
+    difference: float
+
+
+@dataclass(slots=True)
+class ReconciliationReport:
+    """Container describing the outcome of a reconciliation pass."""
+
+    timestamp: datetime
+    account: str
+    differences: Tuple[ReconciliationDifference, ...]
+
+    def has_discrepancies(self) -> bool:
+        return bool(self.differences)
+
+
+class _TrackedPosition:
+    """Internal structure keeping lots and realised PnL for a symbol."""
+
+    __slots__ = (
+        "long_lots",
+        "short_lots",
+        "realized_pnl",
+        "fees",
+        "last_price",
+        "last_timestamp",
+    )
+
+    def __init__(self) -> None:
+        self.long_lots: Deque[PositionLot] = deque()
+        self.short_lots: Deque[PositionLot] = deque()
+        self.realized_pnl: float = 0.0
+        self.fees: float = 0.0
+        self.last_price: Optional[float] = None
+        self.last_timestamp: Optional[datetime] = None
+
+    # --- mutation helpers -------------------------------------------------
+    def add_long(self, quantity: float, price: float, timestamp: datetime) -> None:
+        if quantity <= _EPSILON:
+            return
+        self.long_lots.append(PositionLot(quantity=quantity, price=price, timestamp=timestamp))
+
+    def add_short(self, quantity: float, price: float, timestamp: datetime) -> None:
+        if quantity <= _EPSILON:
+            return
+        self.short_lots.append(PositionLot(quantity=quantity, price=price, timestamp=timestamp))
+
+    def close_longs(self, quantity: float, price: float, mode: PnLMode) -> Tuple[float, float]:
+        realized = 0.0
+        remaining = quantity
+        while remaining > _EPSILON and self.long_lots:
+            lot = self.long_lots[0] if mode == "fifo" else self.long_lots[-1]
+            matched = min(remaining, lot.quantity)
+            realized += (price - lot.price) * matched
+            lot.quantity -= matched
+            remaining -= matched
+            if lot.quantity <= _EPSILON:
+                if mode == "fifo":
+                    self.long_lots.popleft()
+                else:
+                    self.long_lots.pop()
+        return realized, remaining
+
+    def close_shorts(self, quantity: float, price: float, mode: PnLMode) -> Tuple[float, float]:
+        realized = 0.0
+        remaining = quantity
+        while remaining > _EPSILON and self.short_lots:
+            lot = self.short_lots[0] if mode == "fifo" else self.short_lots[-1]
+            matched = min(remaining, lot.quantity)
+            realized += (lot.price - price) * matched
+            lot.quantity -= matched
+            remaining -= matched
+            if lot.quantity <= _EPSILON:
+                if mode == "fifo":
+                    self.short_lots.popleft()
+                else:
+                    self.short_lots.pop()
+        return realized, remaining
+
+    # --- measurement helpers ---------------------------------------------
+    def total_long_quantity(self) -> float:
+        return sum(lot.quantity for lot in self.long_lots)
+
+    def total_short_quantity(self) -> float:
+        return sum(lot.quantity for lot in self.short_lots)
+
+    def net_quantity(self) -> float:
+        return self.total_long_quantity() - self.total_short_quantity()
+
+    def average_long_price(self) -> Optional[float]:
+        total_qty = self.total_long_quantity()
+        if total_qty <= _EPSILON:
+            return None
+        total_cost = sum(lot.price * lot.quantity for lot in self.long_lots)
+        return total_cost / total_qty
+
+    def average_short_price(self) -> Optional[float]:
+        total_qty = self.total_short_quantity()
+        if total_qty <= _EPSILON:
+            return None
+        total_cost = sum(lot.price * lot.quantity for lot in self.short_lots)
+        return total_cost / total_qty
+
+    def unrealized_pnl(self, market_price: Optional[float]) -> Optional[float]:
+        if market_price is None:
+            return None
+        long_component = sum((market_price - lot.price) * lot.quantity for lot in self.long_lots)
+        short_component = sum((lot.price - market_price) * lot.quantity for lot in self.short_lots)
+        return long_component + short_component
+
+    def notional_exposure(self, market_price: Optional[float]) -> Optional[float]:
+        if market_price is None:
+            return None
+        return abs(self.net_quantity()) * market_price
+
+
+class PositionTracker:
+    """Track positions, PnL, and exposures at the account level."""
+
+    def __init__(
+        self,
+        *,
+        pnl_mode: PnLMode = "fifo",
+        default_account: str = "PRIMARY",
+    ) -> None:
+        if pnl_mode not in ("fifo", "lifo"):
+            raise ValueError("pnl_mode must be either 'fifo' or 'lifo'")
+        self._mode = pnl_mode
+        self._default_account = default_account
+        self._positions: Dict[Tuple[str, str], _TrackedPosition] = {}
+        self._marks: MutableMapping[str, tuple[float, datetime]] = {}
+
+    # --- internal utilities ----------------------------------------------
+    def _resolve_account(self, account: Optional[str]) -> str:
+        return account or self._default_account
+
+    def _get_position(self, account: str, symbol: str) -> _TrackedPosition:
+        key = (account, symbol)
+        position = self._positions.get(key)
+        if position is None:
+            position = _TrackedPosition()
+            self._positions[key] = position
+        return position
+
+    def _peek_position(self, account: str, symbol: str) -> Optional[_TrackedPosition]:
+        return self._positions.get((account, symbol))
+
+    def _resolve_mark_price(self, symbol: str, position: Optional[_TrackedPosition]) -> Optional[float]:
+        if symbol in self._marks:
+            return self._marks[symbol][0]
+        if position is not None:
+            return position.last_price
+        return None
+
+    # --- public API -------------------------------------------------------
+    def record_fill(
+        self,
+        symbol: str,
+        quantity: float,
+        price: float,
+        *,
+        account: Optional[str] = None,
+        timestamp: Optional[datetime] = None,
+        fees: float = 0.0,
+    ) -> PositionSnapshot:
+        """Register an executed fill and update tracked state.
+
+        Args:
+            symbol: Instrument identifier.
+            quantity: Signed quantity (positive for buy, negative for sell).
+            price: Execution price.
+            account: Optional account identifier (defaults to tracker default).
+            timestamp: Timestamp of the fill (UTC assumed if naive).
+            fees: Optional transaction fees applied to the fill.
+        """
+
+        if abs(quantity) <= _EPSILON:
+            raise ValueError("Fill quantity must be non-zero")
+
+        account_id = self._resolve_account(account)
+        fill_time = timestamp or _utc_now()
+        if fill_time.tzinfo is None:
+            fill_time = fill_time.replace(tzinfo=timezone.utc)
+
+        position = self._get_position(account_id, symbol)
+        position.last_price = price
+        position.last_timestamp = fill_time
+
+        abs_quantity = abs(quantity)
+        realized_pnl = 0.0
+        if quantity > 0:
+            realized_delta, remaining = position.close_shorts(abs_quantity, price, self._mode)
+            realized_pnl += realized_delta
+            if remaining > _EPSILON:
+                position.add_long(remaining, price, fill_time)
+        else:
+            realized_delta, remaining = position.close_longs(abs_quantity, price, self._mode)
+            realized_pnl += realized_delta
+            if remaining > _EPSILON:
+                position.add_short(remaining, price, fill_time)
+
+        position.realized_pnl += realized_pnl - fees
+        if fees:
+            position.fees += fees
+
+        return self.get_position_snapshot(symbol, account=account_id)
+
+    def update_mark_price(
+        self,
+        symbol: str,
+        price: float,
+        *,
+        timestamp: Optional[datetime] = None,
+    ) -> None:
+        """Update the latest observed market price for a symbol."""
+
+        mark_time = timestamp or _utc_now()
+        if mark_time.tzinfo is None:
+            mark_time = mark_time.replace(tzinfo=timezone.utc)
+        self._marks[symbol] = (price, mark_time)
+
+    def get_position_snapshot(
+        self,
+        symbol: str,
+        *,
+        account: Optional[str] = None,
+    ) -> PositionSnapshot:
+        account_id = self._resolve_account(account)
+        position = self._peek_position(account_id, symbol)
+        mark_price = self._resolve_mark_price(symbol, position)
+
+        if position is None:
+            return PositionSnapshot(
+                symbol=symbol,
+                account=account_id,
+                net_quantity=0.0,
+                long_quantity=0.0,
+                short_quantity=0.0,
+                market_price=mark_price,
+                average_long_price=None,
+                average_short_price=None,
+                realized_pnl=0.0,
+                unrealized_pnl=None if mark_price is None else 0.0,
+                exposure=None if mark_price is None else 0.0,
+            )
+
+        long_qty = position.total_long_quantity()
+        short_qty = position.total_short_quantity()
+        net_qty = long_qty - short_qty
+        unrealized = position.unrealized_pnl(mark_price)
+        exposure = position.notional_exposure(mark_price)
+
+        return PositionSnapshot(
+            symbol=symbol,
+            account=account_id,
+            net_quantity=net_qty,
+            long_quantity=long_qty,
+            short_quantity=short_qty,
+            market_price=mark_price,
+            average_long_price=position.average_long_price(),
+            average_short_price=position.average_short_price(),
+            realized_pnl=position.realized_pnl,
+            unrealized_pnl=unrealized,
+            exposure=exposure,
+        )
+
+    def iter_positions(
+        self,
+        *,
+        account: Optional[str] = None,
+    ) -> Iterable[PositionSnapshot]:
+        """Yield snapshots for all tracked symbols, optionally for one account."""
+
+        if account is None:
+            items = self._positions.items()
+        else:
+            account_id = self._resolve_account(account)
+            items = ((key, value) for key, value in self._positions.items() if key[0] == account_id)
+
+        for (account_id, symbol), position in items:
+            mark_price = self._resolve_mark_price(symbol, position)
+            long_qty = position.total_long_quantity()
+            short_qty = position.total_short_quantity()
+            net_qty = long_qty - short_qty
+            yield PositionSnapshot(
+                symbol=symbol,
+                account=account_id,
+                net_quantity=net_qty,
+                long_quantity=long_qty,
+                short_quantity=short_qty,
+                market_price=mark_price,
+                average_long_price=position.average_long_price(),
+                average_short_price=position.average_short_price(),
+                realized_pnl=position.realized_pnl,
+                unrealized_pnl=position.unrealized_pnl(mark_price),
+                exposure=position.notional_exposure(mark_price),
+            )
+
+    def total_exposure(self, *, account: Optional[str] = None) -> float:
+        """Aggregate notional exposure across all tracked positions."""
+
+        total = 0.0
+        for snapshot in self.iter_positions(account=account):
+            if snapshot.exposure is not None:
+                total += snapshot.exposure
+        return total
+
+    def generate_reconciliation_report(
+        self,
+        broker_positions: Mapping[str, float],
+        *,
+        account: Optional[str] = None,
+        tolerance: float = 1e-6,
+    ) -> ReconciliationReport:
+        """Compare tracked quantities against broker provided balances."""
+
+        account_id = self._resolve_account(account)
+        timestamp = _utc_now()
+        tracked_symbols = {
+            symbol
+            for (acct, symbol) in self._positions
+            if acct == account_id
+        }
+        symbols = tracked_symbols.union(broker_positions.keys())
+        differences: list[ReconciliationDifference] = []
+
+        for symbol in sorted(symbols):
+            snapshot = self.get_position_snapshot(symbol, account=account_id)
+            tracker_qty = snapshot.net_quantity
+            broker_qty = float(broker_positions.get(symbol, 0.0))
+            diff = tracker_qty - broker_qty
+            if abs(diff) > tolerance:
+                differences.append(
+                    ReconciliationDifference(
+                        symbol=symbol,
+                        tracker_quantity=tracker_qty,
+                        broker_quantity=broker_qty,
+                        difference=diff,
+                    )
+                )
+
+        return ReconciliationReport(
+            timestamp=timestamp,
+            account=account_id,
+            differences=tuple(differences),
+        )
+
+    def accounts(self) -> Tuple[str, ...]:
+        """Return a tuple of accounts with tracked activity."""
+
+        return tuple(sorted({account for account, _ in self._positions}))
+
+    def reset(self) -> None:
+        """Clear all tracked state."""
+
+        self._positions.clear()
+        self._marks.clear()

--- a/tests/current/test_fix_executor.py
+++ b/tests/current/test_fix_executor.py
@@ -39,6 +39,12 @@ async def test_execute_order_updates_position_and_history() -> None:
     history_entry = executor.execution_history[-1]
     assert history_entry["order_id"] == "ABC123"
     assert history_entry["status"] == OrderStatus.FILLED.value
+    assert history_entry["lifecycle_status"] == OrderStatus.FILLED.value
+    assert history_entry["position_net_quantity"] == pytest.approx(order.quantity)
+
+    snapshot = executor.get_order_snapshot(order.order_id)
+    assert snapshot is not None
+    assert getattr(snapshot.status, "value", snapshot.status) == OrderStatus.FILLED.value
 
 
 @pytest.mark.asyncio

--- a/tests/current/test_trading_fix_broker_interface.py
+++ b/tests/current/test_trading_fix_broker_interface.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from src.trading.integration.fix_broker_interface import FIXBrokerInterface
+
+
+class _StubMessage:
+    def __init__(self, data: dict[int, object]) -> None:
+        self._data = data
+
+    def get(self, tag: int) -> object | None:
+        return self._data.get(tag)
+
+
+class _StubBus:
+    def __init__(self) -> None:
+        self.events: list[tuple[str, dict[str, object]]] = []
+
+    async def emit(self, name: str, payload: dict[str, object]) -> None:
+        self.events.append((name, payload))
+
+
+@pytest.mark.asyncio
+async def test_execution_report_updates_state_machine() -> None:
+    interface = FIXBrokerInterface(_StubBus(), asyncio.Queue(), fix_initiator=None)
+
+    message = _StubMessage(
+        {
+            11: b"ORDER1",
+            150: b"1",
+            32: b"4",
+            31: b"1.25",
+            55: b"EURUSD",
+            54: b"1",
+            38: b"10",
+            151: b"6",
+        }
+    )
+
+    await interface._handle_execution_report(message)
+
+    status = interface.get_order_status("ORDER1")
+    assert status is not None
+    assert status["status"] == "PARTIALLY_FILLED"
+    assert status["filled_quantity"] == pytest.approx(4.0)
+    assert status["remaining_quantity"] == pytest.approx(6.0)
+    assert status["symbol"] == "EURUSD"
+    assert status["side"] == "BUY"
+
+
+@pytest.mark.asyncio
+async def test_execution_report_final_fill_and_event_bus() -> None:
+    bus = _StubBus()
+    interface = FIXBrokerInterface(bus, asyncio.Queue(), fix_initiator=None)
+
+    partial = _StubMessage(
+        {
+            11: b"ORDER2",
+            150: b"1",
+            32: b"5",
+            31: b"1.10",
+            55: b"AAPL",
+            54: b"2",
+            38: b"10",
+            151: b"5",
+        }
+    )
+    await interface._handle_execution_report(partial)
+
+    fill = _StubMessage(
+        {
+            11: b"ORDER2",
+            150: b"2",
+            32: b"5",
+            31: b"1.12",
+            55: b"AAPL",
+            54: b"2",
+            151: b"0",
+        }
+    )
+    await interface._handle_execution_report(fill)
+
+    status = interface.get_order_status("ORDER2")
+    assert status is not None
+    assert status["status"] == "FILLED"
+    assert status["filled_quantity"] == pytest.approx(10.0)
+    assert status["remaining_quantity"] == pytest.approx(0.0)
+    assert bus.events, "Expected order_update events to be emitted"
+    assert all(name == "order_update" for name, _ in bus.events)

--- a/tests/current/test_trading_lifecycle.py
+++ b/tests/current/test_trading_lifecycle.py
@@ -1,0 +1,181 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+
+from src.trading.order_management import (
+    OrderEventType,
+    OrderLifecycle,
+    OrderStateError,
+    OrderStatus,
+    PositionTracker,
+)
+
+
+def _ts(hour: int) -> datetime:
+    return datetime(2025, 1, 1, hour, tzinfo=timezone.utc)
+
+
+# --- Order lifecycle ---------------------------------------------------------
+
+def test_order_lifecycle_partial_fill_flow() -> None:
+    lifecycle = OrderLifecycle("ORD-1", quantity=10, symbol="EURUSD", side="BUY", created_at=_ts(9))
+
+    snapshot = lifecycle.apply_event(OrderEventType.ACKNOWLEDGED, timestamp=_ts(9))
+    assert snapshot.status is OrderStatus.ACKNOWLEDGED
+
+    snapshot = lifecycle.apply_event(
+        OrderEventType.PARTIAL_FILL,
+        timestamp=_ts(10),
+        quantity=4,
+        price=1.1,
+        leaves_quantity=6,
+    )
+    assert snapshot.status is OrderStatus.PARTIALLY_FILLED
+    assert snapshot.filled_quantity == pytest.approx(4.0)
+    assert snapshot.remaining_quantity == pytest.approx(6.0)
+    assert snapshot.average_price == pytest.approx(1.1)
+
+    snapshot = lifecycle.apply_event(
+        OrderEventType.PARTIAL_FILL,
+        timestamp=_ts(11),
+        quantity=3,
+        price=1.2,
+        leaves_quantity=3,
+    )
+    assert snapshot.status is OrderStatus.PARTIALLY_FILLED
+    assert snapshot.filled_quantity == pytest.approx(7.0)
+    assert snapshot.remaining_quantity == pytest.approx(3.0)
+    assert snapshot.average_price == pytest.approx((4 * 1.1 + 3 * 1.2) / 7)
+
+    snapshot = lifecycle.apply_event(
+        OrderEventType.FILL,
+        timestamp=_ts(12),
+        quantity=3,
+        price=1.15,
+        leaves_quantity=0,
+    )
+    assert snapshot.status is OrderStatus.FILLED
+    assert snapshot.remaining_quantity == pytest.approx(0.0)
+    assert snapshot.filled_quantity == pytest.approx(10.0)
+
+
+def test_order_lifecycle_cancel_and_reject() -> None:
+    lifecycle = OrderLifecycle("ORD-2", quantity=5, symbol="AAPL", side="SELL", created_at=_ts(9))
+    lifecycle.apply_event(OrderEventType.ACKNOWLEDGED, timestamp=_ts(9))
+    snapshot = lifecycle.apply_event(OrderEventType.CANCELLED, timestamp=_ts(10), leaves_quantity=5)
+
+    assert snapshot.status is OrderStatus.CANCELLED
+    assert snapshot.remaining_quantity == pytest.approx(5.0)
+
+    rejected = OrderLifecycle("ORD-3", quantity=2, symbol="MSFT", side="BUY", created_at=_ts(9))
+    snapshot = rejected.apply_event(OrderEventType.REJECTED, timestamp=_ts(9), reason="NoLiquidity")
+    assert snapshot.status is OrderStatus.REJECTED
+    assert snapshot.remaining_quantity == pytest.approx(0.0)
+
+
+def test_order_lifecycle_invalid_transition() -> None:
+    lifecycle = OrderLifecycle("ORD-4", quantity=1, symbol="BTCUSD", side="BUY", created_at=_ts(9))
+
+    lifecycle.apply_event(OrderEventType.ACKNOWLEDGED, timestamp=_ts(9))
+
+    with pytest.raises(OrderStateError):
+        lifecycle.apply_event(OrderEventType.PARTIAL_FILL, quantity=2, timestamp=_ts(10), price=100.0)
+
+
+@pytest.mark.parametrize(
+    "exec_type,expected_status",
+    [
+        ("0", OrderStatus.ACKNOWLEDGED),
+        ("1", OrderStatus.PARTIALLY_FILLED),
+        ("2", OrderStatus.FILLED),
+        ("4", OrderStatus.CANCELLED),
+        ("8", OrderStatus.REJECTED),
+    ],
+)
+def test_order_lifecycle_apply_fix_execution(exec_type: str, expected_status: OrderStatus) -> None:
+    lifecycle = OrderLifecycle("ORD-5", quantity=10, symbol="EURUSD", side="BUY", created_at=_ts(9))
+
+    snapshot = lifecycle.apply_fix_execution(
+        exec_type,
+        last_qty=5 if exec_type in {"1", "2"} else 0,
+        last_px=1.11,
+        leaves_qty=5 if exec_type == "1" else 0,
+        timestamp=_ts(10),
+    )
+
+    assert snapshot.status is expected_status
+
+
+# --- Position tracker --------------------------------------------------------
+
+def test_position_tracker_fifo_accounting() -> None:
+    tracker = PositionTracker(pnl_mode="fifo")
+
+    tracker.record_fill("AAPL", 10, 100.0, timestamp=_ts(9))
+    tracker.record_fill("AAPL", 5, 110.0, timestamp=_ts(10))
+    tracker.update_mark_price("AAPL", 115.0, timestamp=_ts(11))
+    tracker.record_fill("AAPL", -8, 120.0, timestamp=_ts(12))
+
+    snapshot = tracker.get_position_snapshot("AAPL")
+
+    assert snapshot.net_quantity == pytest.approx(7.0)
+    assert snapshot.realized_pnl == pytest.approx(160.0)
+    assert snapshot.unrealized_pnl == pytest.approx(55.0)
+    assert snapshot.exposure == pytest.approx(805.0)
+    assert snapshot.market_value == pytest.approx(805.0)
+
+
+def test_position_tracker_lifo_changes_realized_pnl() -> None:
+    tracker = PositionTracker(pnl_mode="lifo")
+
+    tracker.record_fill("AAPL", 10, 100.0, timestamp=_ts(9))
+    tracker.record_fill("AAPL", 5, 110.0, timestamp=_ts(10))
+    tracker.record_fill("AAPL", -8, 120.0, timestamp=_ts(11))
+
+    snapshot = tracker.get_position_snapshot("AAPL")
+
+    assert snapshot.net_quantity == pytest.approx(7.0)
+    assert snapshot.realized_pnl == pytest.approx(110.0)
+    assert snapshot.market_price == pytest.approx(120.0)
+    assert snapshot.unrealized_pnl == pytest.approx(140.0)
+
+
+def test_position_tracker_short_covering_flow() -> None:
+    tracker = PositionTracker()
+
+    tracker.record_fill("MSFT", -5, 50.0, timestamp=_ts(9))
+    tracker.update_mark_price("MSFT", 45.0, timestamp=_ts(10))
+    tracker.record_fill("MSFT", 3, 40.0, timestamp=_ts(11))
+
+    snapshot = tracker.get_position_snapshot("MSFT")
+
+    assert snapshot.net_quantity == pytest.approx(-2.0)
+    assert snapshot.realized_pnl == pytest.approx(30.0)
+    assert snapshot.unrealized_pnl == pytest.approx(10.0)
+    assert snapshot.exposure == pytest.approx(90.0)
+
+
+def test_position_tracker_reconciliation_and_reset() -> None:
+    tracker = PositionTracker()
+    tracker.record_fill("AAPL", 10, 100.0, timestamp=_ts(9))
+
+    report = tracker.generate_reconciliation_report({"AAPL": 8.0, "MSFT": 1.0})
+
+    assert report.has_discrepancies() is True
+    assert {(diff.symbol, round(diff.difference, 6)) for diff in report.differences} == {
+        ("AAPL", 2.0),
+        ("MSFT", -1.0),
+    }
+
+    tracker.record_fill("AAPL", 1, 100.0, account="alpha", timestamp=_ts(9))
+    tracker.record_fill("MSFT", 1, 50.0, account="beta", timestamp=_ts(10))
+
+    assert tracker.accounts() == ("PRIMARY", "alpha", "beta")
+    assert tracker.total_exposure() > 0
+
+    tracker.reset()
+
+    assert tracker.accounts() == ()
+    assert tracker.total_exposure() == 0.0


### PR DESCRIPTION
## Summary
- refactor the legacy FIXExecutor to drive order lifecycles and inventory via the roadmap state machine and position tracker
- promote the lifecycle, position tracker, and FIX broker integration tests into the main suite under tests/current

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d78839963c832c9992f4f4bfc7a585