### PR TITLE
Implement order lifecycle state machine and structured FIX callbacks

### DIFF
--- a/src/trading/order_management/__init__.py
+++ b/src/trading/order_management/__init__.py
@@ -8,6 +8,15 @@ from .position_tracker import (
     ReconciliationReport,
     PositionTracker,
 )
+from .order_state_machine import (
+    OrderStatus,
+    OrderStateError,
+    OrderMetadata,
+    OrderExecutionEvent,
+    OrderState,
+    OrderLifecycleSnapshot,
+    OrderStateMachine,
+)
 
 __all__ = [
     "PnLMode",
@@ -16,4 +25,11 @@ __all__ = [
     "ReconciliationDifference",
     "ReconciliationReport",
     "PositionTracker",
+    "OrderStatus",
+    "OrderStateError",
+    "OrderMetadata",
+    "OrderExecutionEvent",
+    "OrderState",
+    "OrderLifecycleSnapshot",
+    "OrderStateMachine",
 ]

--- a/src/trading/order_management/order_state_machine.py
+++ b/src/trading/order_management/order_state_machine.py
@@ -1,0 +1,335 @@
+"""State machine for managing FIX order lifecycles.
+
+This module provides a light-weight but strictly validated representation of an
+order lifecycle so downstream components (risk, telemetry, reconciliation)
+receive consistent state transitions.  The implementation intentionally mirrors
+the roadmap requirement for deterministic New → Acknowledged →
+Partially Filled → (Filled|Cancelled|Rejected) flows with quantity and price
+parity across events.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from enum import Enum
+from typing import Dict, Iterable, Literal, Optional
+
+__all__ = [
+    "OrderStatus",
+    "OrderStateError",
+    "OrderMetadata",
+    "OrderExecutionEvent",
+    "OrderState",
+    "OrderLifecycleSnapshot",
+    "OrderStateMachine",
+]
+
+
+def _utc_now() -> datetime:
+    now = datetime.utcnow().replace(tzinfo=timezone.utc)
+    return now
+
+
+class OrderStatus(str, Enum):
+    """Enumerates the supported lifecycle states for an order."""
+
+    PENDING_NEW = "PENDING_NEW"
+    ACKNOWLEDGED = "ACKNOWLEDGED"
+    PARTIALLY_FILLED = "PARTIALLY_FILLED"
+    FILLED = "FILLED"
+    CANCELLED = "CANCELLED"
+    REJECTED = "REJECTED"
+
+
+TERMINAL_STATES = {
+    OrderStatus.FILLED,
+    OrderStatus.CANCELLED,
+    OrderStatus.REJECTED,
+}
+
+
+ExecutionEventType = Literal[
+    "acknowledged",
+    "partial_fill",
+    "filled",
+    "cancelled",
+    "rejected",
+]
+
+
+class OrderStateError(RuntimeError):
+    """Raised when an invalid transition or payload is applied."""
+
+
+@dataclass(slots=True, frozen=True)
+class OrderMetadata:
+    """Static order attributes supplied at creation time."""
+
+    order_id: str
+    symbol: str
+    side: Literal["BUY", "SELL"]
+    quantity: float
+
+    def __post_init__(self) -> None:  # pragma: no cover - dataclass guard
+        if self.quantity <= 0:
+            raise ValueError("quantity must be positive")
+
+
+@dataclass(slots=True, frozen=True)
+class OrderExecutionEvent:
+    """Execution report normalised into typed attributes."""
+
+    order_id: str
+    event_type: ExecutionEventType
+    exec_type: str
+    last_quantity: Optional[float] = None
+    last_price: Optional[float] = None
+    cumulative_quantity: Optional[float] = None
+    leaves_quantity: Optional[float] = None
+    timestamp: datetime = field(default_factory=_utc_now)
+
+    def __post_init__(self) -> None:  # pragma: no cover - dataclass guard
+        if self.last_quantity is not None and self.last_quantity < 0:
+            raise ValueError("last_quantity cannot be negative")
+        if self.cumulative_quantity is not None and self.cumulative_quantity < 0:
+            raise ValueError("cumulative_quantity cannot be negative")
+        if self.leaves_quantity is not None and self.leaves_quantity < 0:
+            raise ValueError("leaves_quantity cannot be negative")
+        if self.event_type in {"partial_fill", "filled"}:
+            if self.last_quantity is None and self.cumulative_quantity is None:
+                raise ValueError(
+                    "fill events require last_quantity or cumulative_quantity"
+                )
+
+    @classmethod
+    def from_broker_payload(cls, order_id: str, payload: Dict[str, object]) -> "OrderExecutionEvent":
+        """Create an event from a broker update payload."""
+
+        exec_type = str(payload.get("exec_type", ""))
+        event_map: Dict[str, ExecutionEventType] = {
+            "0": "acknowledged",
+            "1": "partial_fill",
+            "2": "filled",
+            "4": "cancelled",
+            "8": "rejected",
+        }
+        try:
+            event_type = event_map[exec_type]
+        except KeyError as exc:  # pragma: no cover - defensive
+            raise OrderStateError(f"Unsupported exec_type: {exec_type!r}") from exc
+
+        timestamp = payload.get("timestamp")
+        if isinstance(timestamp, datetime):
+            ts = timestamp
+        else:
+            ts = _utc_now()
+
+        def _coerce_float(value: object | None) -> Optional[float]:
+            if value is None:
+                return None
+            try:
+                return float(value)
+            except (TypeError, ValueError):  # pragma: no cover - defensive
+                return None
+
+        return cls(
+            order_id=order_id,
+            event_type=event_type,
+            exec_type=exec_type,
+            last_quantity=_coerce_float(payload.get("last_qty"))
+            or _coerce_float(payload.get("last_quantity")),
+            last_price=_coerce_float(payload.get("last_px"))
+            or _coerce_float(payload.get("last_price")),
+            cumulative_quantity=_coerce_float(payload.get("cum_qty"))
+            or _coerce_float(payload.get("cumulative_qty")),
+            leaves_quantity=_coerce_float(payload.get("leaves_qty")),
+            timestamp=ts,
+        )
+
+
+@dataclass(slots=True)
+class OrderState:
+    """Mutable state tracked for an order."""
+
+    metadata: OrderMetadata
+    status: OrderStatus = OrderStatus.PENDING_NEW
+    filled_quantity: float = 0.0
+    average_fill_price: Optional[float] = None
+    last_event: Optional[ExecutionEventType] = None
+    last_update: datetime = field(default_factory=_utc_now)
+    events: list[OrderExecutionEvent] = field(default_factory=list)
+
+    @property
+    def remaining_quantity(self) -> float:
+        return max(self.metadata.quantity - self.filled_quantity, 0.0)
+
+    @property
+    def is_terminal(self) -> bool:
+        return self.status in TERMINAL_STATES
+
+
+@dataclass(slots=True, frozen=True)
+class OrderLifecycleSnapshot:
+    """Read-only representation of an order state."""
+
+    order_id: str
+    status: OrderStatus
+    filled_quantity: float
+    remaining_quantity: float
+    average_fill_price: Optional[float]
+    last_event: Optional[ExecutionEventType]
+    last_update: datetime
+
+
+class OrderStateMachine:
+    """Manage order states and validate lifecycle transitions."""
+
+    _quantity_epsilon = 1e-9
+
+    def __init__(self) -> None:
+        self._orders: Dict[str, OrderState] = {}
+
+    # -- registration -----------------------------------------------------
+    def register_order(self, metadata: OrderMetadata) -> OrderState:
+        if metadata.order_id in self._orders:
+            raise OrderStateError(f"Order {metadata.order_id} already registered")
+        state = OrderState(metadata=metadata)
+        self._orders[metadata.order_id] = state
+        return state
+
+    def has_order(self, order_id: str) -> bool:
+        return order_id in self._orders
+
+    # -- event ingestion --------------------------------------------------
+    def apply_event(self, event: OrderExecutionEvent) -> OrderState:
+        if event.order_id not in self._orders:
+            raise OrderStateError(f"Unknown order {event.order_id}")
+
+        state = self._orders[event.order_id]
+        if state.is_terminal and event.event_type != state.last_event:
+            raise OrderStateError(
+                f"Order {event.order_id} is terminal ({state.status}); event {event.event_type} not allowed"
+            )
+
+        if event.event_type == "acknowledged":
+            self._apply_ack(state, event)
+        elif event.event_type in {"partial_fill", "filled"}:
+            self._apply_fill(state, event)
+        elif event.event_type == "cancelled":
+            self._apply_cancel(state, event)
+        elif event.event_type == "rejected":
+            self._apply_reject(state, event)
+        else:  # pragma: no cover - should be unreachable
+            raise OrderStateError(f"Unsupported event type: {event.event_type}")
+
+        state.events.append(event)
+        state.last_event = event.event_type
+        state.last_update = event.timestamp
+        return state
+
+    # -- event handlers ---------------------------------------------------
+    def _apply_ack(self, state: OrderState, event: OrderExecutionEvent) -> None:
+        if state.status not in {OrderStatus.PENDING_NEW, OrderStatus.ACKNOWLEDGED}:
+            raise OrderStateError(
+                f"Cannot acknowledge order in state {state.status}"
+            )
+        state.status = OrderStatus.ACKNOWLEDGED
+
+    def _apply_fill(self, state: OrderState, event: OrderExecutionEvent) -> None:
+        if state.status not in {
+            OrderStatus.PENDING_NEW,
+            OrderStatus.ACKNOWLEDGED,
+            OrderStatus.PARTIALLY_FILLED,
+        }:
+            raise OrderStateError(
+                f"Cannot apply fill to order in state {state.status}"
+            )
+
+        increment = 0.0
+        previous_filled = state.filled_quantity
+
+        if event.cumulative_quantity is not None:
+            if event.cumulative_quantity + self._quantity_epsilon < previous_filled:
+                raise OrderStateError(
+                    "Cumulative quantity moved backwards for order " f"{state.metadata.order_id}"
+                )
+            increment = max(event.cumulative_quantity - previous_filled, 0.0)
+            state.filled_quantity = event.cumulative_quantity
+        else:
+            increment = float(event.last_quantity or 0.0)
+            if increment < 0:
+                raise OrderStateError("Fill increment cannot be negative")
+            state.filled_quantity = previous_filled + increment
+
+        if state.filled_quantity - state.metadata.quantity > self._quantity_epsilon:
+            raise OrderStateError(
+                f"Order {state.metadata.order_id} overfilled: {state.filled_quantity} > {state.metadata.quantity}"
+            )
+
+        if increment > 0 and event.last_price is not None:
+            notional_before = previous_filled * (state.average_fill_price or 0.0)
+            notional_delta = increment * event.last_price
+            new_total = previous_filled + increment
+            if new_total <= self._quantity_epsilon:
+                state.average_fill_price = event.last_price
+            else:
+                state.average_fill_price = (notional_before + notional_delta) / new_total
+
+        remaining = state.remaining_quantity
+        if remaining <= self._quantity_epsilon:
+            state.status = OrderStatus.FILLED
+            state.filled_quantity = min(state.metadata.quantity, state.filled_quantity)
+        else:
+            state.status = OrderStatus.PARTIALLY_FILLED
+
+    def _apply_cancel(self, state: OrderState, event: OrderExecutionEvent) -> None:
+        if state.status in TERMINAL_STATES:
+            if state.status != OrderStatus.CANCELLED:
+                raise OrderStateError(
+                    f"Order already terminal as {state.status}, cannot cancel"
+                )
+            return
+        if state.status not in {
+            OrderStatus.PENDING_NEW,
+            OrderStatus.ACKNOWLEDGED,
+            OrderStatus.PARTIALLY_FILLED,
+        }:
+            raise OrderStateError(
+                f"Cannot cancel order in state {state.status}"
+            )
+        state.status = OrderStatus.CANCELLED
+
+    def _apply_reject(self, state: OrderState, event: OrderExecutionEvent) -> None:
+        if state.status in TERMINAL_STATES and state.status != OrderStatus.REJECTED:
+            raise OrderStateError(
+                f"Order already terminal as {state.status}, cannot reject"
+            )
+        if state.status not in {OrderStatus.PENDING_NEW, OrderStatus.ACKNOWLEDGED}:
+            raise OrderStateError(
+                f"Cannot reject order in state {state.status}"
+            )
+        state.status = OrderStatus.REJECTED
+
+    # -- inspection -------------------------------------------------------
+    def snapshot(self, order_id: str) -> OrderLifecycleSnapshot:
+        state = self._orders.get(order_id)
+        if state is None:
+            raise OrderStateError(f"Unknown order {order_id}")
+        return OrderLifecycleSnapshot(
+            order_id=order_id,
+            status=state.status,
+            filled_quantity=state.filled_quantity,
+            remaining_quantity=state.remaining_quantity,
+            average_fill_price=state.average_fill_price,
+            last_event=state.last_event,
+            last_update=state.last_update,
+        )
+
+    def iter_open_orders(self) -> Iterable[OrderLifecycleSnapshot]:
+        for order_id, state in self._orders.items():
+            if not state.is_terminal:
+                yield self.snapshot(order_id)
+
+    def reset(self) -> None:
+        self._orders.clear()

--- a/tests/trading/test_fix_broker_interface_events.py
+++ b/tests/trading/test_fix_broker_interface_events.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime
+from typing import Any
+
+import pytest
+import simplefix
+
+from src.trading.integration.fix_broker_interface import FIXBrokerInterface
+
+
+class DummyEventBus:
+    def __init__(self) -> None:
+        self.emitted: list[tuple[str, dict[str, Any]]] = []
+
+    async def emit(self, topic: str, payload: dict[str, Any]) -> None:
+        self.emitted.append((topic, payload))
+
+
+@pytest.mark.asyncio
+async def test_fix_interface_emits_structured_order_events() -> None:
+    trade_queue: asyncio.Queue[Any] = asyncio.Queue()
+    interface = FIXBrokerInterface(DummyEventBus(), trade_queue, fix_initiator=None)
+
+    # Pre-populate with order metadata to mirror placement stage
+    interface.orders["ORD-1"] = {
+        "symbol": "EURUSD",
+        "side": "BUY",
+        "quantity": 10,
+        "status": "PENDING",
+        "timestamp": datetime.utcnow(),
+    }
+
+    observed: list[tuple[str, dict[str, Any]]] = []
+
+    interface.add_event_listener(
+        "acknowledged", lambda order_id, payload: observed.append((order_id, payload))
+    )
+    interface.add_event_listener(
+        "partial_fill", lambda order_id, payload: observed.append((order_id, payload))
+    )
+    interface.add_event_listener(
+        "filled", lambda order_id, payload: observed.append((order_id, payload))
+    )
+
+    # Ack message
+    ack_msg = simplefix.FixMessage()
+    ack_msg.append_pair(11, "ORD-1")
+    ack_msg.append_pair(150, "0")
+    await interface._handle_execution_report(ack_msg)  # type: ignore[attr-defined]
+
+    # Partial fill
+    partial_msg = simplefix.FixMessage()
+    partial_msg.append_pair(11, "ORD-1")
+    partial_msg.append_pair(150, "1")
+    partial_msg.append_pair(32, "4")
+    partial_msg.append_pair(31, "101.0")
+    partial_msg.append_pair(14, "4")
+    await interface._handle_execution_report(partial_msg)  # type: ignore[attr-defined]
+
+    # Final fill
+    fill_msg = simplefix.FixMessage()
+    fill_msg.append_pair(11, "ORD-1")
+    fill_msg.append_pair(150, "2")
+    fill_msg.append_pair(32, "6")
+    fill_msg.append_pair(31, "102.0")
+    fill_msg.append_pair(14, "10")
+    await interface._handle_execution_report(fill_msg)  # type: ignore[attr-defined]
+
+    assert [event for event, _ in observed] == ["ORD-1", "ORD-1", "ORD-1"]
+    statuses = [payload["status"] for _, payload in observed]
+    assert statuses == ["ACKNOWLEDGED", "PARTIALLY_FILLED", "FILLED"]
+    filled_qty = [payload.get("filled_qty") for _, payload in observed]
+    assert filled_qty[-1] == pytest.approx(10)
+

--- a/tests/trading/test_order_state_machine.py
+++ b/tests/trading/test_order_state_machine.py
@@ -1,0 +1,130 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+
+from src.trading.order_management import (
+    OrderExecutionEvent,
+    OrderMetadata,
+    OrderStateError,
+    OrderStateMachine,
+    OrderStatus,
+)
+
+
+def _ts() -> datetime:
+    return datetime(2025, 1, 1, tzinfo=timezone.utc)
+
+
+def test_order_state_machine_full_fill_flow() -> None:
+    machine = OrderStateMachine()
+    machine.register_order(OrderMetadata("ORD1", "EURUSD", "BUY", 10))
+
+    state = machine.apply_event(
+        OrderExecutionEvent(
+            order_id="ORD1",
+            event_type="acknowledged",
+            exec_type="0",
+            timestamp=_ts(),
+        )
+    )
+    assert state.status is OrderStatus.ACKNOWLEDGED
+
+    state = machine.apply_event(
+        OrderExecutionEvent(
+            order_id="ORD1",
+            event_type="partial_fill",
+            exec_type="1",
+            last_quantity=4,
+            last_price=101.0,
+            cumulative_quantity=4,
+            timestamp=_ts(),
+        )
+    )
+    assert state.status is OrderStatus.PARTIALLY_FILLED
+    assert pytest.approx(state.filled_quantity) == 4
+    assert pytest.approx(state.average_fill_price or 0.0) == 101.0
+
+    state = machine.apply_event(
+        OrderExecutionEvent(
+            order_id="ORD1",
+            event_type="filled",
+            exec_type="2",
+            last_quantity=6,
+            last_price=102.0,
+            cumulative_quantity=10,
+            timestamp=_ts(),
+        )
+    )
+    assert state.status is OrderStatus.FILLED
+    assert pytest.approx(state.filled_quantity) == 10
+    assert pytest.approx(state.remaining_quantity, abs=1e-9) == 0
+    # Weighted average of the two fills
+    assert pytest.approx(state.average_fill_price or 0.0, rel=1e-9) == pytest.approx(
+        (4 * 101 + 6 * 102) / 10
+    )
+
+
+def test_order_state_machine_rejects_invalid_progression() -> None:
+    machine = OrderStateMachine()
+    machine.register_order(OrderMetadata("ORD2", "GBPUSD", "SELL", 5))
+
+    # Cannot overfill an order
+    machine.apply_event(
+        OrderExecutionEvent(
+            order_id="ORD2",
+            event_type="partial_fill",
+            exec_type="1",
+            last_quantity=2,
+            last_price=1.2,
+            timestamp=_ts(),
+        )
+    )
+
+    with pytest.raises(OrderStateError):
+        machine.apply_event(
+            OrderExecutionEvent(
+                order_id="ORD2",
+                event_type="filled",
+                exec_type="2",
+                last_quantity=4,
+                cumulative_quantity=6,
+                last_price=1.2,
+                timestamp=_ts(),
+            )
+        )
+
+
+def test_order_state_machine_reject_transition_requires_pre_terminal_state() -> None:
+    machine = OrderStateMachine()
+    machine.register_order(OrderMetadata("ORD3", "AAPL", "BUY", 1))
+
+    machine.apply_event(
+        OrderExecutionEvent(
+            order_id="ORD3",
+            event_type="acknowledged",
+            exec_type="0",
+            timestamp=_ts(),
+        )
+    )
+
+    machine.apply_event(
+        OrderExecutionEvent(
+            order_id="ORD3",
+            event_type="cancelled",
+            exec_type="4",
+            timestamp=_ts(),
+        )
+    )
+
+    with pytest.raises(OrderStateError):
+        machine.apply_event(
+            OrderExecutionEvent(
+                order_id="ORD3",
+                event_type="rejected",
+                exec_type="8",
+                timestamp=_ts(),
+            )
+        )
+


### PR DESCRIPTION
## Summary
- add an institutional-grade order state machine with explicit lifecycle validation and broker payload helpers
- extend the FIX broker interface with structured event listeners for acknowledgements, fills, cancellations, and cancel rejects
- cover the new flows with unit tests for the state machine and FIX callback fan-out

## Testing
- pytest tests/trading -q

------
https://chatgpt.com/codex/tasks/task_e_68d7b0be64c0832c85bad5757af0cd29