### PR TITLE
Add roadmap-aligned risk analytics and telemetry integration

### DIFF
--- a/src/risk/analytics/__init__.py
+++ b/src/risk/analytics/__init__.py
@@ -1,0 +1,19 @@
+"""Risk analytics helpers aligned with the high-impact roadmap."""
+
+from .var import (
+    compute_historical_var,
+    compute_parametric_var,
+    compute_monte_carlo_var,
+)
+from .expected_shortfall import (
+    compute_historical_expected_shortfall,
+    compute_parametric_expected_shortfall,
+)
+
+__all__ = [
+    "compute_historical_var",
+    "compute_parametric_var",
+    "compute_monte_carlo_var",
+    "compute_historical_expected_shortfall",
+    "compute_parametric_expected_shortfall",
+]

--- a/src/risk/analytics/expected_shortfall.py
+++ b/src/risk/analytics/expected_shortfall.py
@@ -1,0 +1,99 @@
+"""Expected Shortfall estimators supporting the high-impact roadmap."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, Sequence
+
+import numpy as np
+
+__all__ = [
+    "ExpectedShortfallResult",
+    "compute_historical_expected_shortfall",
+    "compute_parametric_expected_shortfall",
+]
+
+
+@dataclass(slots=True)
+class ExpectedShortfallResult:
+    """Container summarising an Expected Shortfall calculation."""
+
+    value: float
+    confidence: float
+    sample_size: int
+
+    def as_dict(self) -> dict[str, float]:
+        return {
+            "value": self.value,
+            "confidence": self.confidence,
+            "sample_size": float(self.sample_size),
+        }
+
+
+def _normalise_confidence(confidence: float) -> float:
+    if not 0.0 < confidence < 1.0:
+        raise ValueError("confidence must be between 0 and 1")
+    return confidence
+
+
+def _prepare_returns(returns: Sequence[float] | Iterable[float]) -> np.ndarray:
+    array = np.asarray(list(returns), dtype=float)
+    if array.size == 0:
+        raise ValueError("returns must contain at least one element")
+    array = array[np.isfinite(array)]
+    if array.size == 0:
+        raise ValueError("returns must contain at least one finite element")
+    return array
+
+
+def compute_historical_expected_shortfall(
+    returns: Sequence[float] | Iterable[float],
+    *,
+    confidence: float = 0.99,
+) -> ExpectedShortfallResult:
+    """Compute Expected Shortfall using the empirical loss tail."""
+
+    confidence = _normalise_confidence(confidence)
+    sample = _prepare_returns(returns)
+    percentile = (1.0 - confidence) * 100.0
+    var_threshold = np.percentile(sample, percentile)
+    tail = sample[sample <= var_threshold]
+    if tail.size == 0:
+        es_value = float(max(-var_threshold, 0.0))
+    else:
+        es_value = float(max(-float(np.mean(tail)), 0.0))
+    return ExpectedShortfallResult(
+        value=es_value,
+        confidence=confidence,
+        sample_size=int(sample.size),
+    )
+
+
+def compute_parametric_expected_shortfall(
+    returns: Sequence[float] | Iterable[float],
+    *,
+    confidence: float = 0.99,
+    ddof: int = 1,
+) -> ExpectedShortfallResult:
+    """Compute Expected Shortfall assuming a normal distribution."""
+
+    confidence = _normalise_confidence(confidence)
+    sample = _prepare_returns(returns)
+    mean = float(np.mean(sample))
+    std = float(np.std(sample, ddof=ddof if sample.size > ddof else 0))
+    if std <= 0.0:
+        es_value = float(max(-mean, 0.0))
+    else:
+        # Closed-form ES for normal distribution
+        from statistics import NormalDist
+
+        dist = NormalDist(mu=mean, sigma=std)
+        var_threshold = dist.inv_cdf(1.0 - confidence)
+        pdf = dist.pdf(var_threshold)
+        es = mean - std * pdf / (1.0 - confidence)
+        es_value = float(max(-es, 0.0))
+    return ExpectedShortfallResult(
+        value=es_value,
+        confidence=confidence,
+        sample_size=int(sample.size),
+    )

--- a/src/risk/analytics/var.py
+++ b/src/risk/analytics/var.py
@@ -1,0 +1,121 @@
+"""Value-at-Risk estimators aligned with the high-impact roadmap.
+
+The roadmap calls for historical, parametric, and Monte Carlo VaR calculations
+that can be plugged into pre-trade risk checks.  These helpers keep the
+implementation small and dependency-light while ensuring consistent sanitisation
+and statistical assumptions.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from statistics import NormalDist
+from typing import Iterable, Sequence
+
+import numpy as np
+
+__all__ = [
+    "VarResult",
+    "compute_historical_var",
+    "compute_parametric_var",
+    "compute_monte_carlo_var",
+]
+
+
+@dataclass(slots=True)
+class VarResult:
+    """Container summarising a VaR calculation."""
+
+    value: float
+    confidence: float
+    sample_size: int
+
+    def as_dict(self) -> dict[str, float]:
+        """Return a JSON-serialisable representation."""
+
+        return {
+            "value": self.value,
+            "confidence": self.confidence,
+            "sample_size": float(self.sample_size),
+        }
+
+
+def _normalise_confidence(confidence: float) -> float:
+    if not 0.0 < confidence < 1.0:
+        raise ValueError("confidence must be between 0 and 1")
+    return confidence
+
+
+def _prepare_returns(returns: Sequence[float] | Iterable[float]) -> np.ndarray:
+    array = np.asarray(list(returns), dtype=float)
+    if array.size == 0:
+        raise ValueError("returns must contain at least one element")
+    # Drop NaNs/Infs defensively
+    array = array[np.isfinite(array)]
+    if array.size == 0:
+        raise ValueError("returns must contain at least one finite element")
+    return array
+
+
+def compute_historical_var(
+    returns: Sequence[float] | Iterable[float],
+    *,
+    confidence: float = 0.99,
+) -> VarResult:
+    """Compute historical Value-at-Risk via empirical quantiles."""
+
+    confidence = _normalise_confidence(confidence)
+    sample = _prepare_returns(returns)
+    percentile = (1.0 - confidence) * 100.0
+    threshold = np.percentile(sample, percentile)
+    value = float(max(-threshold, 0.0))
+    return VarResult(value=value, confidence=confidence, sample_size=int(sample.size))
+
+
+def compute_parametric_var(
+    returns: Sequence[float] | Iterable[float],
+    *,
+    confidence: float = 0.99,
+    ddof: int = 1,
+) -> VarResult:
+    """Compute parametric VaR assuming normally distributed returns."""
+
+    confidence = _normalise_confidence(confidence)
+    sample = _prepare_returns(returns)
+    mean = float(np.mean(sample))
+    std = float(np.std(sample, ddof=ddof if sample.size > ddof else 0))
+    if std <= 0.0:
+        threshold = mean
+    else:
+        z_score = NormalDist().inv_cdf(1.0 - confidence)
+        threshold = mean + std * z_score
+    value = float(max(-threshold, 0.0))
+    return VarResult(value=value, confidence=confidence, sample_size=int(sample.size))
+
+
+def compute_monte_carlo_var(
+    returns: Sequence[float] | Iterable[float],
+    *,
+    confidence: float = 0.99,
+    simulations: int = 10000,
+    seed: int | None = None,
+) -> VarResult:
+    """Estimate VaR using Monte Carlo sampling from a normal approximation."""
+
+    if simulations <= 0:
+        raise ValueError("simulations must be positive")
+    confidence = _normalise_confidence(confidence)
+    sample = _prepare_returns(returns)
+    mean = float(np.mean(sample))
+    std = float(np.std(sample, ddof=1 if sample.size > 1 else 0))
+
+    if std <= 0.0:
+        simulated = np.repeat(mean, simulations)
+    else:
+        rng = np.random.default_rng(seed)
+        simulated = rng.normal(mean, std, size=simulations)
+
+    percentile = (1.0 - confidence) * 100.0
+    threshold = float(np.percentile(simulated, percentile))
+    value = float(max(-threshold, 0.0))
+    return VarResult(value=value, confidence=confidence, sample_size=int(sample.size))

--- a/tests/risk/test_risk_analytics.py
+++ b/tests/risk/test_risk_analytics.py
@@ -1,0 +1,65 @@
+"""Unit tests for the high-impact risk analytics helpers."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from src.risk.analytics import (
+    compute_historical_expected_shortfall,
+    compute_historical_var,
+    compute_monte_carlo_var,
+    compute_parametric_expected_shortfall,
+    compute_parametric_var,
+)
+
+
+def test_historical_var_matches_percentile() -> None:
+    returns = np.array([-0.04, -0.02, -0.01, 0.0, 0.01, 0.02])
+    expected_threshold = float(np.percentile(returns, 5.0))
+
+    result = compute_historical_var(returns, confidence=0.95)
+
+    assert result.confidence == pytest.approx(0.95)
+    assert result.value == pytest.approx(max(-expected_threshold, 0.0))
+    assert result.sample_size == len(returns)
+
+
+def test_parametric_var_uses_normal_approximation() -> None:
+    returns = np.array([-0.03, -0.015, 0.005, 0.012, -0.02, 0.01])
+    result = compute_parametric_var(returns, confidence=0.975)
+
+    assert result.confidence == pytest.approx(0.975)
+    assert result.value >= 0
+
+
+def test_monte_carlo_var_is_reproducible_with_seed() -> None:
+    returns = np.array([-0.015, 0.003, -0.02, 0.007, -0.005, 0.002])
+
+    first = compute_monte_carlo_var(
+        returns, confidence=0.99, simulations=1_000, seed=42
+    )
+    second = compute_monte_carlo_var(
+        returns, confidence=0.99, simulations=1_000, seed=42
+    )
+
+    assert first.value == pytest.approx(second.value)
+    assert first.sample_size == len(returns)
+    assert second.sample_size == len(returns)
+
+
+def test_expected_shortfall_not_less_than_var() -> None:
+    returns = np.array([-0.025, -0.018, 0.004, -0.01, 0.006, -0.022])
+    var_result = compute_historical_var(returns, confidence=0.95)
+    es_result = compute_historical_expected_shortfall(returns, confidence=0.95)
+
+    assert es_result.value >= var_result.value
+    assert es_result.sample_size == len(returns)
+
+
+def test_parametric_expected_shortfall_handles_zero_volatility() -> None:
+    returns = np.array([-0.01, -0.01, -0.01, -0.01])
+    result = compute_parametric_expected_shortfall(returns, confidence=0.99)
+
+    assert result.value == pytest.approx(0.01)
+    assert result.sample_size == len(returns)


### PR DESCRIPTION
## Summary
- add a risk analytics helper package that provides historical, parametric, and Monte Carlo VaR plus expected shortfall calculators required by the high-impact roadmap
- integrate the new analytics into `RiskManagerImpl` summaries and portfolio snapshots, including configurable VaR controls
- extend the regression suite with dedicated analytics tests and market-risk coverage for the risk manager

## Testing
- pytest tests/risk/test_risk_analytics.py tests/current/test_risk_manager_impl.py


------
https://chatgpt.com/codex/tasks/task_e_68d7c388fc5c832c9f792663f8015b60