### PR TITLE
Add risk reporting toolkit and CLI for roadmap coverage

### DIFF
--- a/scripts/generate_risk_report.py
+++ b/scripts/generate_risk_report.py
@@ -1,0 +1,109 @@
+"""CLI for generating high-impact risk reports."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+from typing import Dict
+
+from src.risk import (
+    PortfolioRiskLimits,
+    generate_risk_report,
+    load_portfolio_limits,
+    render_risk_report_json,
+    render_risk_report_markdown,
+)
+from src.risk.reporting.report_generator import parse_returns_file
+
+
+def _parse_exposure(value: str) -> tuple[str, float]:
+    if "=" not in value:
+        raise argparse.ArgumentTypeError("exposures must be provided as SYMBOL=value")
+    symbol, raw = value.split("=", 1)
+    try:
+        return symbol.strip(), float(raw)
+    except ValueError as exc:  # pragma: no cover - defensive guard
+        raise argparse.ArgumentTypeError(str(exc)) from exc
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "returns_file",
+        type=Path,
+        help="Path to a text file containing delimited return series",
+    )
+    parser.add_argument(
+        "--confidence",
+        type=float,
+        default=0.99,
+        help="Confidence level for VaR/ES calculations (default: 0.99)",
+    )
+    parser.add_argument(
+        "--simulations",
+        type=int,
+        default=10_000,
+        help="Number of Monte Carlo simulations (default: 10000)",
+    )
+    parser.add_argument(
+        "--output-markdown",
+        type=Path,
+        help="Optional path to write the Markdown report",
+    )
+    parser.add_argument(
+        "--output-json",
+        type=Path,
+        help="Optional path to write the JSON report",
+    )
+    parser.add_argument(
+        "--limits-file",
+        type=Path,
+        help="Optional path to an alternative portfolio risk limits YAML file",
+    )
+    parser.add_argument(
+        "--exposure",
+        action="append",
+        type=_parse_exposure,
+        help="Repeatable SYMBOL=value exposure inputs",
+    )
+    return parser
+
+
+def main() -> None:
+    parser = build_parser()
+    args = parser.parse_args()
+
+    returns = parse_returns_file(args.returns_file)
+    exposures: Dict[str, float] | None = None
+    if args.exposure:
+        exposures = {symbol: value for symbol, value in args.exposure}
+
+    limits: PortfolioRiskLimits | None = None
+    try:
+        limits = load_portfolio_limits(args.limits_file) if args.limits_file else load_portfolio_limits()
+    except FileNotFoundError:
+        parser.error("Unable to locate portfolio limits file")
+    except ValueError as exc:
+        parser.error(str(exc))
+
+    report = generate_risk_report(
+        returns,
+        confidence=args.confidence,
+        simulations=args.simulations,
+        exposures=exposures,
+        limits=limits,
+    )
+
+    markdown = render_risk_report_markdown(report)
+    json_payload = render_risk_report_json(report)
+
+    if args.output_markdown:
+        args.output_markdown.write_text(markdown, encoding="utf-8")
+    if args.output_json:
+        args.output_json.write_text(json_payload, encoding="utf-8")
+
+    print(markdown)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/risk/__init__.py
+++ b/src/risk/__init__.py
@@ -3,6 +3,15 @@
 from __future__ import annotations
 
 from .real_risk_manager import RealRiskConfig, RealRiskManager
+from .reporting import (
+    ExposureBreakdown,
+    PortfolioRiskLimits,
+    RiskReport,
+    generate_risk_report,
+    load_portfolio_limits,
+    render_risk_report_json,
+    render_risk_report_markdown,
+)
 from .telemetry import (
     RiskLimitCheck,
     RiskLimitStatus,
@@ -16,6 +25,13 @@ from .telemetry import (
 __all__ = [
     "RealRiskManager",
     "RealRiskConfig",
+    "ExposureBreakdown",
+    "PortfolioRiskLimits",
+    "RiskReport",
+    "generate_risk_report",
+    "load_portfolio_limits",
+    "render_risk_report_json",
+    "render_risk_report_markdown",
     "RiskLimitCheck",
     "RiskLimitStatus",
     "RiskTelemetrySnapshot",

--- a/src/risk/reporting/__init__.py
+++ b/src/risk/reporting/__init__.py
@@ -1,0 +1,23 @@
+"""Risk reporting helpers supporting the high-impact roadmap."""
+
+from __future__ import annotations
+
+from .report_generator import (
+    ExposureBreakdown,
+    PortfolioRiskLimits,
+    RiskReport,
+    generate_risk_report,
+    load_portfolio_limits,
+    render_risk_report_json,
+    render_risk_report_markdown,
+)
+
+__all__ = [
+    "ExposureBreakdown",
+    "PortfolioRiskLimits",
+    "RiskReport",
+    "generate_risk_report",
+    "load_portfolio_limits",
+    "render_risk_report_json",
+    "render_risk_report_markdown",
+]

--- a/src/risk/reporting/report_generator.py
+++ b/src/risk/reporting/report_generator.py
@@ -1,0 +1,320 @@
+"""Generate portfolio risk reports aligned with the high-impact roadmap."""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+import json
+from pathlib import Path
+import re
+from typing import Iterable, Mapping, Sequence
+
+import numpy as np
+import yaml
+
+from ..analytics import (
+    compute_historical_expected_shortfall,
+    compute_historical_var,
+    compute_monte_carlo_var,
+    compute_parametric_expected_shortfall,
+    compute_parametric_var,
+)
+
+__all__ = [
+    "ExposureBreakdown",
+    "PortfolioRiskLimits",
+    "RiskReport",
+    "generate_risk_report",
+    "load_portfolio_limits",
+    "render_risk_report_json",
+    "render_risk_report_markdown",
+]
+
+
+@dataclass(slots=True)
+class ExposureBreakdown:
+    """Summary of exposure for a single instrument."""
+
+    symbol: str
+    notional: float
+    percentage: float
+
+    def to_dict(self) -> dict[str, float | str]:
+        return {
+            "symbol": self.symbol,
+            "notional": self.notional,
+            "percentage": self.percentage,
+        }
+
+
+@dataclass(slots=True)
+class PortfolioRiskLimits:
+    """Structured representation of portfolio risk limits."""
+
+    per_asset_cap: float | None = None
+    aggregate_cap: float | None = None
+    usd_beta_cap: float | None = None
+    var95_cap: float | None = None
+
+    def to_dict(self) -> dict[str, float | None]:
+        return asdict(self)
+
+    @classmethod
+    def from_mapping(cls, mapping: Mapping[str, object]) -> "PortfolioRiskLimits":
+        def _maybe_float(value: object | None) -> float | None:
+            if value is None:
+                return None
+            try:
+                return float(value)  # type: ignore[return-value]
+            except (TypeError, ValueError):
+                return None
+
+        return cls(
+            per_asset_cap=_maybe_float(mapping.get("per_asset_cap")),
+            aggregate_cap=_maybe_float(mapping.get("aggregate_cap")),
+            usd_beta_cap=_maybe_float(mapping.get("usd_beta_cap")),
+            var95_cap=_maybe_float(mapping.get("var95_cap")),
+        )
+
+
+@dataclass(slots=True)
+class RiskReport:
+    """Computed risk report for a portfolio snapshot."""
+
+    generated_at: datetime
+    confidence: float
+    sample_size: int
+    historical_var: float
+    parametric_var: float
+    monte_carlo_var: float
+    monte_carlo_simulations: int
+    historical_expected_shortfall: float
+    parametric_expected_shortfall: float
+    total_exposure: float
+    exposures: tuple[ExposureBreakdown, ...]
+    breaches: dict[str, object]
+    limits: PortfolioRiskLimits | None
+
+    def to_dict(self) -> dict[str, object]:
+        data = {
+            "generated_at": self.generated_at.isoformat(),
+            "confidence": self.confidence,
+            "sample_size": self.sample_size,
+            "historical_var": self.historical_var,
+            "parametric_var": self.parametric_var,
+            "monte_carlo_var": self.monte_carlo_var,
+            "monte_carlo_simulations": self.monte_carlo_simulations,
+            "historical_expected_shortfall": self.historical_expected_shortfall,
+            "parametric_expected_shortfall": self.parametric_expected_shortfall,
+            "total_exposure": self.total_exposure,
+            "exposures": [exposure.to_dict() for exposure in self.exposures],
+            "breaches": self.breaches,
+        }
+        if self.limits is not None:
+            data["limits"] = self.limits.to_dict()
+        return data
+
+
+def _normalise_returns(returns: Sequence[float] | Iterable[float]) -> np.ndarray:
+    array = np.asarray(list(returns), dtype=float)
+    if array.size == 0:
+        raise ValueError("returns must contain at least one observation")
+    array = array[np.isfinite(array)]
+    if array.size == 0:
+        raise ValueError("returns must contain at least one finite observation")
+    return array
+
+
+def _prepare_exposures(
+    exposures: Mapping[str, float] | None,
+) -> tuple[tuple[ExposureBreakdown, ...], float]:
+    if not exposures:
+        return tuple(), 0.0
+
+    resolved: list[ExposureBreakdown] = []
+    total_abs = sum(abs(float(value)) for value in exposures.values())
+    total_abs = float(total_abs)
+
+    for symbol, value in sorted(
+        exposures.items(), key=lambda item: abs(float(item[1])), reverse=True
+    ):
+        notional = float(value)
+        if total_abs == 0.0:
+            pct = 0.0
+        else:
+            pct = abs(notional) / total_abs * 100.0
+        resolved.append(
+            ExposureBreakdown(symbol=symbol, notional=notional, percentage=pct)
+        )
+
+    return tuple(resolved), total_abs
+
+
+def _evaluate_breaches(
+    *,
+    exposures: tuple[ExposureBreakdown, ...],
+    total_exposure: float,
+    historical_var: float,
+    limits: PortfolioRiskLimits | None,
+) -> dict[str, object]:
+    if limits is None:
+        return {}
+
+    breaches: dict[str, object] = {}
+
+    if limits.aggregate_cap is not None and total_exposure > limits.aggregate_cap:
+        breaches["aggregate_exposure"] = {
+            "current": total_exposure,
+            "limit": limits.aggregate_cap,
+        }
+
+    if limits.per_asset_cap is not None:
+        violators = [
+            exposure.symbol
+            for exposure in exposures
+            if abs(exposure.notional) > limits.per_asset_cap
+        ]
+        if violators:
+            breaches["per_asset"] = {
+                "symbols": violators,
+                "limit": limits.per_asset_cap,
+            }
+
+    if limits.var95_cap is not None and historical_var > limits.var95_cap:
+        breaches["var_limit"] = {
+            "historical_var": historical_var,
+            "limit": limits.var95_cap,
+        }
+
+    return breaches
+
+
+def generate_risk_report(
+    returns: Sequence[float] | Iterable[float],
+    *,
+    confidence: float = 0.99,
+    simulations: int = 10_000,
+    exposures: Mapping[str, float] | None = None,
+    limits: PortfolioRiskLimits | None = None,
+) -> RiskReport:
+    """Compute a risk report from historical returns and exposures."""
+
+    sample = _normalise_returns(returns)
+
+    historical_var = compute_historical_var(sample, confidence=confidence)
+    parametric_var = compute_parametric_var(sample, confidence=confidence)
+    monte_carlo_var = compute_monte_carlo_var(
+        sample, confidence=confidence, simulations=simulations
+    )
+    historical_es = compute_historical_expected_shortfall(sample, confidence=confidence)
+    parametric_es = compute_parametric_expected_shortfall(sample, confidence=confidence)
+
+    exposures_breakdown, total_exposure = _prepare_exposures(exposures)
+    breaches = _evaluate_breaches(
+        exposures=exposures_breakdown,
+        total_exposure=total_exposure,
+        historical_var=historical_var.value,
+        limits=limits,
+    )
+
+    return RiskReport(
+        generated_at=datetime.now(timezone.utc),
+        confidence=confidence,
+        sample_size=historical_var.sample_size,
+        historical_var=historical_var.value,
+        parametric_var=parametric_var.value,
+        monte_carlo_var=monte_carlo_var.value,
+        monte_carlo_simulations=simulations,
+        historical_expected_shortfall=historical_es.value,
+        parametric_expected_shortfall=parametric_es.value,
+        total_exposure=total_exposure,
+        exposures=exposures_breakdown,
+        breaches=breaches,
+        limits=limits,
+    )
+
+
+def render_risk_report_markdown(report: RiskReport) -> str:
+    """Render a risk report to Markdown."""
+
+    def _format_pct(value: float) -> str:
+        return f"{value * 100:.2f}%"
+
+    lines = [
+        "# Portfolio Risk Report",
+        "",
+        f"Generated: {report.generated_at.isoformat()}",
+        "",
+        "## Risk Metrics",
+        "",
+        "| Metric | Value |",
+        "| --- | ---: |",
+        f"| Historical VaR ({report.confidence:.0%}) | {_format_pct(report.historical_var)} |",
+        f"| Parametric VaR ({report.confidence:.0%}) | {_format_pct(report.parametric_var)} |",
+        f"| Monte Carlo VaR ({report.confidence:.0%}) | {_format_pct(report.monte_carlo_var)} |",
+        f"| Historical Expected Shortfall | {_format_pct(report.historical_expected_shortfall)} |",
+        f"| Parametric Expected Shortfall | {_format_pct(report.parametric_expected_shortfall)} |",
+        "",
+        "## Exposure Breakdown",
+        "",
+        f"Total absolute exposure: {report.total_exposure:.4f}",
+    ]
+
+    if report.exposures:
+        lines.extend(
+            [
+                "",
+                "| Symbol | Notional | Share |",
+                "| --- | ---: | ---: |",
+            ]
+        )
+        for exposure in report.exposures:
+            lines.append(
+                f"| {exposure.symbol} | {exposure.notional:.4f} | {exposure.percentage:.2f}% |"
+            )
+    else:
+        lines.append("\n_No exposures supplied._")
+
+    if report.breaches:
+        lines.extend(["", "## Breach Summary", ""])
+        for name, payload in report.breaches.items():
+            lines.append(f"- **{name.replace('_', ' ').title()}**: {json.dumps(payload)}")
+
+    return "\n".join(lines).strip() + "\n"
+
+
+def render_risk_report_json(report: RiskReport) -> str:
+    """Render a risk report to JSON."""
+
+    return json.dumps(report.to_dict(), indent=2, sort_keys=True)
+
+
+def load_portfolio_limits(path: str | Path | None = None) -> PortfolioRiskLimits:
+    """Load portfolio risk limits from a YAML document."""
+
+    candidate = Path(path) if path is not None else _default_limits_path()
+    if not candidate.exists():
+        raise FileNotFoundError(f"risk limits file not found: {candidate}")
+
+    with candidate.open("r", encoding="utf-8") as handle:
+        data = yaml.safe_load(handle) or {}
+
+    section = data.get("portfolio_risk", data)
+    if not isinstance(section, Mapping):
+        raise ValueError("portfolio risk configuration must be a mapping")
+    return PortfolioRiskLimits.from_mapping(section)
+
+
+def _default_limits_path() -> Path:
+    return Path(__file__).resolve().parents[3] / "config" / "risk" / "portfolio.yaml"
+
+
+def parse_returns_file(path: Path) -> list[float]:
+    """Parse a text file containing delimited return series."""
+
+    raw = path.read_text(encoding="utf-8")
+    tokens = re.split(r"[\s,]+", raw.strip())
+    returns = [float(token) for token in tokens if token]
+    if not returns:
+        raise ValueError("returns file did not contain any numeric values")
+    return returns

--- a/tests/risk/test_risk_report_generator.py
+++ b/tests/risk/test_risk_report_generator.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from src.risk import (
+    generate_risk_report,
+    load_portfolio_limits,
+    render_risk_report_json,
+    render_risk_report_markdown,
+)
+from src.risk.reporting.report_generator import parse_returns_file
+
+
+@pytest.fixture()
+def sample_returns() -> list[float]:
+    return [-0.045, -0.02, -0.015, 0.005, 0.012, 0.02, -0.03, 0.018]
+
+
+def test_generate_risk_report_includes_expected_metrics(sample_returns: list[float]) -> None:
+    limits = load_portfolio_limits()
+    exposures = {"EURUSD": 2.5, "GBPUSD": 1.2}
+
+    report = generate_risk_report(
+        sample_returns,
+        confidence=0.95,
+        simulations=5000,
+        exposures=exposures,
+        limits=limits,
+    )
+
+    assert report.sample_size == len(sample_returns)
+    assert report.monte_carlo_simulations == 5000
+    # VaR/ES values should align with direct calculations
+    assert report.historical_var > 0
+    assert report.parametric_expected_shortfall >= report.historical_expected_shortfall
+    # Exposure totals
+    assert pytest.approx(report.total_exposure, rel=1e-12) == sum(abs(v) for v in exposures.values())
+    # Breach detection (aggregate + per asset + VaR)
+    assert "aggregate_exposure" in report.breaches
+    assert "per_asset" in report.breaches
+    assert "var_limit" in report.breaches
+
+
+def test_render_risk_report_markdown_contains_tables(sample_returns: list[float]) -> None:
+    report = generate_risk_report(sample_returns, exposures=None, limits=None)
+    markdown = render_risk_report_markdown(report)
+
+    assert "# Portfolio Risk Report" in markdown
+    assert "| Metric | Value |" in markdown
+    assert "_No exposures supplied._" in markdown
+    assert markdown.endswith("\n")
+
+
+def test_render_risk_report_json_round_trip(sample_returns: list[float]) -> None:
+    report = generate_risk_report(sample_returns, exposures=None, limits=None)
+    payload = render_risk_report_json(report)
+    decoded = json.loads(payload)
+
+    assert decoded["sample_size"] == len(sample_returns)
+    assert decoded["historical_var"] == report.historical_var
+
+
+def test_parse_returns_file(tmp_path: Path) -> None:
+    data = "-0.01, 0.02\n-0.03 0.04"
+    returns_file = tmp_path / "returns.txt"
+    returns_file.write_text(data, encoding="utf-8")
+
+    parsed = parse_returns_file(returns_file)
+
+    assert parsed == [-0.01, 0.02, -0.03, 0.04]
+
+
+def test_load_portfolio_limits_allows_override(tmp_path: Path) -> None:
+    custom_yaml = tmp_path / "limits.yaml"
+    custom_yaml.write_text(
+        """
+portfolio_risk:
+  per_asset_cap: 0.5
+  aggregate_cap: 1.0
+  var95_cap: 0.01
+        """.strip(),
+        encoding="utf-8",
+    )
+
+    limits = load_portfolio_limits(custom_yaml)
+
+    assert limits.per_asset_cap == 0.5
+    assert limits.aggregate_cap == 1.0
+    assert limits.var95_cap == 0.01


### PR DESCRIPTION
## Summary
- add a risk reporting package that computes VaR/ES, aggregates exposures, and flags limit breaches
- expose the reporting helpers through src.risk and add a CLI to emit Markdown/JSON artifacts for CI use
- cover the reporting workflow with unit tests and fixtures for parsing return series and limits files

## Testing
- pytest tests/risk/test_risk_report_generator.py

------
https://chatgpt.com/codex/tasks/task_e_68d7c519d854832c9b85f211864a4077