### PR TITLE
Implement order lifecycle processor and journaling

### DIFF
--- a/scripts/order_lifecycle_dry_run.py
+++ b/scripts/order_lifecycle_dry_run.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+"""Replay FIX execution events against the order lifecycle processor."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Iterable
+
+from src.trading.order_management import (
+    OrderEventJournal,
+    OrderLifecycleProcessor,
+    OrderMetadata,
+)
+
+
+def _load_orders(path: Path) -> Iterable[OrderMetadata]:
+    data = json.loads(path.read_text())
+    for entry in data:
+        yield OrderMetadata(
+            order_id=str(entry["order_id"]),
+            symbol=str(entry["symbol"]),
+            side=str(entry["side"]).upper(),
+            quantity=float(entry["quantity"]),
+        )
+
+
+def _load_events(path: Path) -> Iterable[tuple[str, dict]]:
+    for line in path.read_text().splitlines():
+        if not line.strip():
+            continue
+        payload = json.loads(line)
+        order_id = str(payload.get("order_id"))
+        if not order_id:
+            raise ValueError("Event missing order_id")
+        yield order_id, payload
+
+
+def run_dry_run(order_file: Path, events_file: Path, journal_path: Path) -> int:
+    processor = OrderLifecycleProcessor(journal=OrderEventJournal(journal_path))
+
+    for metadata in _load_orders(order_file):
+        processor.register_order(metadata)
+
+    failures = 0
+    for order_id, payload in _load_events(events_file):
+        try:
+            snapshot = processor.handle_broker_payload(order_id, payload)
+        except Exception as exc:  # pragma: no cover - script level logging
+            failures += 1
+            print(f"[ERROR] {order_id}: {exc}", file=sys.stderr)
+            continue
+
+        print(
+            f"{order_id}: {snapshot.status.value} "
+            f"filled={snapshot.filled_quantity} remaining={snapshot.remaining_quantity}"
+        )
+
+    if failures:
+        print(f"Encountered {failures} failures", file=sys.stderr)
+        return 1
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("orders", type=Path, help="JSON list of order definitions")
+    parser.add_argument(
+        "events", type=Path, help="Newline-delimited JSON events from FIX execution logs"
+    )
+    parser.add_argument(
+        "--journal",
+        type=Path,
+        default=Path("data_foundation/events/order_events.parquet"),
+        help="Target Parquet path for the append-only journal",
+    )
+    args = parser.parse_args(argv)
+
+    return run_dry_run(args.orders, args.events, args.journal)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/trading/order_management/__init__.py
+++ b/src/trading/order_management/__init__.py
@@ -17,6 +17,8 @@ from .order_state_machine import (
     OrderLifecycleSnapshot,
     OrderStateMachine,
 )
+from .event_journal import OrderEventJournal, InMemoryOrderEventJournal
+from .lifecycle_processor import OrderLifecycleProcessor
 
 __all__ = [
     "PnLMode",
@@ -32,4 +34,7 @@ __all__ = [
     "OrderState",
     "OrderLifecycleSnapshot",
     "OrderStateMachine",
+    "OrderEventJournal",
+    "InMemoryOrderEventJournal",
+    "OrderLifecycleProcessor",
 ]

--- a/src/trading/order_management/event_journal.py
+++ b/src/trading/order_management/event_journal.py
@@ -1,0 +1,146 @@
+"""Utilities for persisting order lifecycle events for replay/audit."""
+
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import asdict
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+from .order_state_machine import OrderExecutionEvent, OrderLifecycleSnapshot
+
+__all__ = ["OrderEventJournal", "InMemoryOrderEventJournal"]
+
+logger = logging.getLogger(__name__)
+
+
+class OrderEventJournal:
+    """Append-only event journal backed by Parquet with JSON fallback."""
+
+    def __init__(self, path: str | Path) -> None:
+        self._path = Path(path)
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+        self._json_fallback_path = self._path.with_suffix(self._path.suffix + ".jsonl")
+
+        self._pd = None
+        self._parquet_available = False
+        try:  # pragma: no cover - optional dependency discovery
+            import pandas as pd  # type: ignore
+
+            self._pd = pd
+            # pandas requires a parquet engine; pyarrow is the default recommendation
+            try:
+                import pyarrow  # noqa: F401  # type: ignore
+
+                self._parquet_available = True
+            except Exception:  # pragma: no cover - best effort detection
+                self._parquet_available = False
+        except Exception:  # pragma: no cover - optional dependency discovery
+            self._pd = None
+            self._parquet_available = False
+
+    # ------------------------------------------------------------------
+    def append(
+        self,
+        event: OrderExecutionEvent,
+        snapshot: OrderLifecycleSnapshot,
+        *,
+        extra: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        """Persist an execution event and the resulting snapshot."""
+
+        record = {
+            "order_id": event.order_id,
+            "event_type": event.event_type,
+            "exec_type": event.exec_type,
+            "last_quantity": event.last_quantity,
+            "last_price": event.last_price,
+            "cumulative_quantity": event.cumulative_quantity,
+            "leaves_quantity": event.leaves_quantity,
+            "event_timestamp": event.timestamp.isoformat(),
+            "status": snapshot.status.value,
+            "filled_quantity": snapshot.filled_quantity,
+            "remaining_quantity": snapshot.remaining_quantity,
+            "average_fill_price": snapshot.average_fill_price,
+            "last_event": snapshot.last_event,
+            "last_update": snapshot.last_update.isoformat(),
+        }
+        if extra:
+            record.update(extra)
+
+        if self._parquet_available and self._pd is not None:
+            self._append_parquet(record)
+        else:
+            self._append_json(record)
+
+    # ------------------------------------------------------------------
+    def append_error(self, payload: Dict[str, Any], *, reason: str) -> None:
+        """Persist malformed events into a dead-letter log for later inspection."""
+
+        record = {
+            "reason": reason,
+            "payload": payload,
+        }
+        with self._dead_letter_path.open("a", encoding="utf-8") as fh:
+            fh.write(json.dumps(record, default=str) + "\n")
+
+    # ------------------------------------------------------------------
+    def _append_parquet(self, record: Dict[str, Any]) -> None:
+        assert self._pd is not None
+        try:
+            df = self._pd.DataFrame([record])
+            if self._path.exists():
+                existing = self._pd.read_parquet(self._path)
+                df = self._pd.concat([existing, df], ignore_index=True)
+            df.to_parquet(self._path, index=False)
+        except Exception as exc:  # pragma: no cover - fallback path
+            logger.warning(
+                "Falling back to JSON journaling due to parquet error: %s", exc
+            )
+            self._append_json(record)
+
+    def _append_json(self, record: Dict[str, Any]) -> None:
+        with self._json_fallback_path.open("a", encoding="utf-8") as fh:
+            fh.write(json.dumps(record, default=str) + "\n")
+
+    @property
+    def _dead_letter_path(self) -> Path:
+        return self._path.with_suffix(self._path.suffix + ".deadletter.jsonl")
+
+
+class InMemoryOrderEventJournal(OrderEventJournal):
+    """Testing helper that stores events in memory instead of disk."""
+
+    def __init__(self) -> None:
+        self.records: list[Dict[str, Any]] = []
+        self.errors: list[Dict[str, Any]] = []
+        self._path = Path("/dev/null")
+        self._json_fallback_path = Path("/dev/null")
+        self._pd = None
+        self._parquet_available = False
+
+    def append(
+        self,
+        event: OrderExecutionEvent,
+        snapshot: OrderLifecycleSnapshot,
+        *,
+        extra: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        record = {
+            "event": asdict(event),
+            "snapshot": {
+                "order_id": snapshot.order_id,
+                "status": snapshot.status.value,
+                "filled_quantity": snapshot.filled_quantity,
+                "remaining_quantity": snapshot.remaining_quantity,
+                "average_fill_price": snapshot.average_fill_price,
+                "last_event": snapshot.last_event,
+            },
+        }
+        if extra:
+            record["extra"] = extra
+        self.records.append(record)
+
+    def append_error(self, payload: Dict[str, Any], *, reason: str) -> None:
+        self.errors.append({"payload": payload, "reason": reason})

--- a/src/trading/order_management/lifecycle_processor.py
+++ b/src/trading/order_management/lifecycle_processor.py
@@ -1,0 +1,122 @@
+"""Co-ordinates FIX broker callbacks with the order state machine."""
+
+from __future__ import annotations
+
+import logging
+from typing import Iterable, Optional
+
+from .event_journal import OrderEventJournal
+from .order_state_machine import (
+    OrderExecutionEvent,
+    OrderLifecycleSnapshot,
+    OrderMetadata,
+    OrderState,
+    OrderStateError,
+    OrderStateMachine,
+)
+
+try:  # pragma: no cover - optional import for type checking only
+    from ..integration.fix_broker_interface import FIXBrokerInterface
+except Exception:  # pragma: no cover - avoid import errors at runtime
+    FIXBrokerInterface = object  # type: ignore
+
+__all__ = ["OrderLifecycleProcessor"]
+
+logger = logging.getLogger(__name__)
+
+
+class OrderLifecycleProcessor:
+    """Glue code between the FIX broker interface and the state machine."""
+
+    _EVENT_TYPES = ("acknowledged", "partial_fill", "filled", "cancelled", "rejected")
+
+    def __init__(
+        self,
+        *,
+        journal: Optional[OrderEventJournal] = None,
+        state_machine: Optional[OrderStateMachine] = None,
+    ) -> None:
+        self._journal = journal
+        self._state_machine = state_machine or OrderStateMachine()
+        self._attached_broker: Optional[FIXBrokerInterface] = None
+
+    # ------------------------------------------------------------------
+    @property
+    def state_machine(self) -> OrderStateMachine:
+        return self._state_machine
+
+    def register_order(self, metadata: OrderMetadata) -> OrderState:
+        """Register a new order with the underlying state machine."""
+
+        return self._state_machine.register_order(metadata)
+
+    # ------------------------------------------------------------------
+    def attach_broker(self, broker: FIXBrokerInterface) -> None:
+        """Register callbacks on the broker for lifecycle events."""
+
+        for event_type in self._EVENT_TYPES:
+            broker.add_event_listener(event_type, self._handle_broker_event)
+        self._attached_broker = broker
+
+    def detach_broker(self) -> None:
+        broker = self._attached_broker
+        if broker is None:
+            return
+        for event_type in self._EVENT_TYPES:
+            try:
+                broker.remove_event_listener(event_type, self._handle_broker_event)
+            except Exception:  # pragma: no cover - defensive
+                logger.debug("Failed to remove %s listener", event_type)
+        self._attached_broker = None
+
+    # ------------------------------------------------------------------
+    def _handle_broker_event(self, order_id: str, payload: dict) -> None:
+        try:
+            self.handle_broker_payload(order_id, payload)
+        except OrderStateError as exc:
+            if self._journal is not None:
+                self._journal.append_error(payload, reason=str(exc))
+            logger.warning("Rejected order event for %s: %s", order_id, exc)
+
+    def handle_broker_payload(
+        self, order_id: str, payload: dict
+    ) -> OrderLifecycleSnapshot:
+        """Convert a broker payload into an execution event and apply it."""
+
+        event = OrderExecutionEvent.from_broker_payload(order_id, payload)
+        self._state_machine.apply_event(event)
+        snapshot = self._state_machine.snapshot(event.order_id)
+        if self._journal is not None:
+            self._journal.append(event, snapshot)
+        return snapshot
+
+    # ------------------------------------------------------------------
+    def get_snapshot(self, order_id: str) -> OrderLifecycleSnapshot:
+        return self._state_machine.snapshot(order_id)
+
+    def iter_open_orders(self) -> Iterable[OrderLifecycleSnapshot]:
+        return self._state_machine.iter_open_orders()
+
+    def reset(self) -> None:
+        self._state_machine.reset()
+
+    # Convenience wrappers for integration tests --------------------------------
+    def apply_acknowledgement(self, order_id: str, payload: dict[str, object] | None = None) -> OrderLifecycleSnapshot:
+        payload = {"exec_type": "0", **(payload or {})}
+        return self.handle_broker_payload(order_id, payload)
+
+    def apply_partial_fill(self, order_id: str, payload: dict[str, object] | None = None) -> OrderLifecycleSnapshot:
+        payload = {"exec_type": "1", **(payload or {})}
+        return self.handle_broker_payload(order_id, payload)
+
+    def apply_fill(self, order_id: str, payload: dict[str, object] | None = None) -> OrderLifecycleSnapshot:
+        payload = {"exec_type": "2", **(payload or {})}
+        return self.handle_broker_payload(order_id, payload)
+
+    def apply_cancel(self, order_id: str, payload: dict[str, object] | None = None) -> OrderLifecycleSnapshot:
+        payload = {"exec_type": "4", **(payload or {})}
+        return self.handle_broker_payload(order_id, payload)
+
+    def apply_reject(self, order_id: str, payload: dict[str, object] | None = None) -> OrderLifecycleSnapshot:
+        payload = {"exec_type": "8", **(payload or {})}
+        return self.handle_broker_payload(order_id, payload)

--- a/tests/current/test_order_lifecycle_processor.py
+++ b/tests/current/test_order_lifecycle_processor.py
@@ -1,0 +1,114 @@
+from __future__ import annotations
+
+import pytest
+
+from src.trading.order_management import (
+    InMemoryOrderEventJournal,
+    OrderLifecycleProcessor,
+    OrderMetadata,
+    OrderStateError,
+    OrderStatus,
+)
+
+
+class DummyBroker:
+    def __init__(self) -> None:
+        self.callbacks: dict[str, list] = {}
+
+    def add_event_listener(self, event_type: str, callback) -> bool:
+        self.callbacks.setdefault(event_type, []).append(callback)
+        return True
+
+    def remove_event_listener(self, event_type: str, callback) -> bool:
+        callbacks = self.callbacks.get(event_type, [])
+        if callback in callbacks:
+            callbacks.remove(callback)
+            return True
+        return False
+
+    def emit(self, event_type: str, order_id: str, payload: dict) -> None:
+        for callback in list(self.callbacks.get(event_type, [])):
+            callback(order_id, payload)
+
+
+@pytest.fixture
+def lifecycle_processor() -> tuple[OrderLifecycleProcessor, InMemoryOrderEventJournal]:
+    journal = InMemoryOrderEventJournal()
+    processor = OrderLifecycleProcessor(journal=journal)
+    return processor, journal
+
+
+def _register(processor: OrderLifecycleProcessor) -> str:
+    metadata = OrderMetadata(
+        order_id="ABC-123",
+        symbol="EUR/USD",
+        side="BUY",
+        quantity=100,
+    )
+    processor.register_order(metadata)
+    return metadata.order_id
+
+
+def test_ack_and_fill_flow(lifecycle_processor: tuple[OrderLifecycleProcessor, InMemoryOrderEventJournal]) -> None:
+    processor, journal = lifecycle_processor
+    order_id = _register(processor)
+
+    snap = processor.apply_acknowledgement(order_id)
+    assert snap.status is OrderStatus.ACKNOWLEDGED
+
+    snap = processor.apply_partial_fill(
+        order_id,
+        {"last_qty": "25", "last_px": "1.001"},
+    )
+    assert snap.status is OrderStatus.PARTIALLY_FILLED
+    assert snap.filled_quantity == pytest.approx(25)
+
+    snap = processor.apply_fill(order_id, {"cum_qty": "100", "last_px": "1.002"})
+    assert snap.status is OrderStatus.FILLED
+    assert snap.filled_quantity == pytest.approx(100)
+
+    assert [record["event"]["event_type"] for record in journal.records] == [
+        "acknowledged",
+        "partial_fill",
+        "filled",
+    ]
+
+
+def test_cancel_flow(lifecycle_processor: tuple[OrderLifecycleProcessor, InMemoryOrderEventJournal]) -> None:
+    processor, journal = lifecycle_processor
+    order_id = _register(processor)
+
+    processor.apply_acknowledgement(order_id)
+    snap = processor.apply_cancel(order_id)
+    assert snap.status is OrderStatus.CANCELLED
+    assert [record["event"]["event_type"] for record in journal.records][-1] == "cancelled"
+
+
+def test_reject_from_pending(lifecycle_processor: tuple[OrderLifecycleProcessor, InMemoryOrderEventJournal]) -> None:
+    processor, journal = lifecycle_processor
+    order_id = _register(processor)
+
+    snap = processor.apply_reject(order_id, {"text": "Invalid price"})
+    assert snap.status is OrderStatus.REJECTED
+    assert journal.records[-1]["event"]["event_type"] == "rejected"
+
+
+def test_unknown_order_raises_error(lifecycle_processor: tuple[OrderLifecycleProcessor, InMemoryOrderEventJournal]) -> None:
+    processor, _ = lifecycle_processor
+    with pytest.raises(OrderStateError):
+        processor.apply_acknowledgement("does-not-exist")
+
+
+def test_broker_attachment_dispatches_events(lifecycle_processor: tuple[OrderLifecycleProcessor, InMemoryOrderEventJournal]) -> None:
+    processor, journal = lifecycle_processor
+    order_id = _register(processor)
+    broker = DummyBroker()
+
+    processor.attach_broker(broker)
+    broker.emit("acknowledged", order_id, {"exec_type": "0"})
+    broker.emit("partial_fill", order_id, {"exec_type": "1", "last_qty": "10", "last_px": "1.0"})
+    broker.emit("filled", order_id, {"exec_type": "2", "cum_qty": "100", "last_px": "1.01"})
+
+    assert len(journal.records) == 3
+    processor.detach_broker()
+    assert all(not callbacks for callbacks in broker.callbacks.values())


### PR DESCRIPTION
## Summary
- add a lifecycle processor that connects FIX broker callbacks to the deterministic order state machine and optional journaling
- introduce an append-only order event journal with parquet/JSON persistence and a CLI dry-run tool for replaying execution logs
- cover the lifecycle processor with targeted pytest coverage for ack/fill/cancel/reject flows and broker integration

## Testing
- pytest tests/current/test_order_lifecycle_processor.py

------
https://chatgpt.com/codex/tasks/task_e_68d7da71a750832cba0de2685082c8e5