### PR TITLE
Add sector risk limits and FIX fill telemetry

### DIFF
--- a/docs/High-Impact Development Roadmap.md
+++ b/docs/High-Impact Development Roadmap.md
@@ -109,7 +109,7 @@ To reflect the true scope of institutional-grade trading components, the roadmap
 - [ ] Add position sizing adapters:
   - [x] Kelly fraction module with drawdown caps (`src/core/risk/position_sizing.py`, `RiskManagerImpl._recompute_drawdown_multiplier`)
   - [x] Volatility-target sizing fed by realized/GARCH volatility inputs (`src/risk/analytics/volatility_target.py`, `RiskManagerImpl.target_allocation_from_volatility`)
-  - [ ] Portfolio exposure limits by sector/asset class (config-driven)
+- [x] Portfolio exposure limits by sector/asset class (config-driven)
 - [x] Embed drawdown circuit breakers into `src/risk/manager.py` with unit tests simulating equity curve shocks.
 - [x] Produce automated risk report artifact (Markdown/JSON) for CI artifacts (`scripts/generate_risk_report.py`).
 - [ ] Backfill encyclopedia Tier-0/Tier-1 risk scenarios as pytest parametrized cases to validate guardrail behavior.

--- a/src/config/risk/risk_config.py
+++ b/src/config/risk/risk_config.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from decimal import Decimal
+from typing import Dict
 
 from pydantic import BaseModel, Field, validator
 
@@ -57,6 +58,14 @@ class RiskConfig(BaseModel):
         default=Decimal("1.0"),
         description="Annualisation factor applied to realised volatility",
     )
+    instrument_sector_map: Dict[str, str] = Field(
+        default_factory=dict,
+        description="Mapping of instrument symbol to sector or asset class identifier",
+    )
+    sector_exposure_limits: Dict[str, Decimal] = Field(
+        default_factory=dict,
+        description="Maximum fraction of equity allocatable to each sector or asset class",
+    )
 
     @validator(
         "max_risk_per_trade_pct",
@@ -79,6 +88,12 @@ class RiskConfig(BaseModel):
     def validate_annualisation(cls, v: Decimal) -> Decimal:
         if v <= 0:
             raise ValueError("Annualisation factor must be positive")
+        return v
+
+    @validator("sector_exposure_limits", each_item=True)
+    def validate_sector_limits(cls, v: Decimal) -> Decimal:
+        if v <= 0 or v > 1:
+            raise ValueError("Sector exposure limits must be between 0 and 1")
         return v
 
 

--- a/tests/current/test_fix_broker_interface.py
+++ b/tests/current/test_fix_broker_interface.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+import pytest
+import simplefix
+
+from src.trading.integration.fix_broker_interface import FIXBrokerInterface
+
+
+class _StubEventBus:
+    def __init__(self) -> None:
+        self.events: list[tuple[str, dict[str, Any]]] = []
+
+    async def emit(self, event_type: str, payload: dict[str, Any]) -> None:
+        self.events.append((event_type, payload))
+
+
+@pytest.mark.asyncio
+async def test_execution_report_emits_fill_details() -> None:
+    bus = _StubEventBus()
+    queue: asyncio.Queue[Any] = asyncio.Queue()
+    broker = FIXBrokerInterface(bus, queue, fix_initiator=None)
+
+    captured: dict[str, Any] = {}
+
+    def _on_fill(order_id: str, payload: dict[str, Any]) -> None:
+        captured["order_id"] = order_id
+        captured["payload"] = payload.copy()
+
+    broker.add_event_listener("filled", _on_fill)
+
+    msg = simplefix.FixMessage()
+    msg.append_pair(11, "ORD-123")
+    msg.append_pair(150, "2")
+    msg.append_pair(32, "2")
+    msg.append_pair(31, "1.25")
+    msg.append_pair(14, "5")
+    msg.append_pair(151, "3")
+
+    await broker._handle_execution_report(msg)
+
+    assert captured["order_id"] == "ORD-123"
+    payload = captured["payload"]
+    assert payload["last_qty"] == pytest.approx(2.0)
+    assert payload["last_px"] == pytest.approx(1.25)
+    assert payload["cum_qty"] == pytest.approx(5.0)
+    assert payload["leaves_qty"] == pytest.approx(3.0)
+    assert payload["filled_qty"] == pytest.approx(5.0)
+
+    assert bus.events
+    event_type, event_payload = bus.events[-1]
+    assert event_type == "order_update"
+    assert event_payload["last_qty"] == pytest.approx(2.0)
+    assert event_payload["cum_qty"] == pytest.approx(5.0)


### PR DESCRIPTION
## Summary
- add sector exposure configuration to the risk model and enforce it in validation and runtime checks
- surface sector utilisation in risk summaries and allow dynamic updates through the limits API
- enrich FIX execution report handling with detailed fill metrics and cover it with dedicated tests

## Testing
- pytest tests/current/test_risk_manager_impl.py tests/current/test_fix_broker_interface.py

------
https://chatgpt.com/codex/tasks/task_e_68d802192390832ca466865165f033ed