### PR TITLE
Add reconciliation CLI for order lifecycle journal playback

### DIFF
--- a/docs/High-Impact Development Roadmap.md
+++ b/docs/High-Impact Development Roadmap.md
@@ -94,6 +94,7 @@ To reflect the true scope of institutional-grade trading components, the roadmap
   - [ ] Daily reconciliation script against broker state (reuse dummy initiator for paper sim)
 - [ ] Wire the execution estimator in `src/trading/execution/execution_model.py` into pre-trade checks (slippage, market impact, notional caps).
 - [ ] Add CLI workflow (`scripts/order_lifecycle_dry_run.py`) that replays FIX logs and asserts state transitions.
+- [x] Provide nightly reconciliation CLI (`scripts/reconcile_positions.py`) that replays the journal and compares broker balances.
 - [ ] Persist FIX events into an append-only event journal (`data_foundation/events/order_events.parquet`) for replay and audit parity.
 - [ ] Implement dead-letter handling that quarantines malformed FIX messages and surfaces alerts to the ops dashboard.
 - [ ] Capture latency metrics (acknowledgement, fill, cancel) and publish per-venue benchmarks for encyclopedia alignment.

--- a/docs/runbooks/execution_lifecycle.md
+++ b/docs/runbooks/execution_lifecycle.md
@@ -80,6 +80,8 @@ FIXBrokerInterface --(2)--> FIX Venue
 3. **Reconciliation**
    - Invoke `PositionTracker.generate_reconciliation_report` nightly using
      broker-provided balances.
+   - Run `scripts/reconcile_positions.py --broker nightly_broker.json` to
+     replay the journal and emit discrepancies for operator review.
    - Investigate discrepancies surfaced in the dashboard totals and journal
      events.
 4. **Incident Response**

--- a/scripts/reconcile_positions.py
+++ b/scripts/reconcile_positions.py
@@ -1,0 +1,125 @@
+"""Replay the order event journal and compare against broker positions."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Optional
+
+from src.trading.order_management import (
+    PositionTracker,
+    load_broker_positions,
+    load_order_journal_records,
+    replay_order_events,
+    report_to_dict,
+)
+
+
+def run_reconciliation(
+    *,
+    journal_path: Path,
+    broker_path: Path | None,
+    account: str,
+    pnl_mode: str,
+    tolerance: float,
+    output_path: Path | None,
+    fail_on_discrepancy: bool,
+) -> int:
+    tracker = PositionTracker(pnl_mode=pnl_mode, default_account=account)
+    records = load_order_journal_records(journal_path)
+    if not records:
+        print(f"No order events found in {journal_path}")
+    else:
+        replay_order_events(records, tracker)
+
+    broker_positions = {}
+    if broker_path is not None:
+        broker_positions = load_broker_positions(broker_path)
+
+    report = tracker.generate_reconciliation_report(
+        broker_positions,
+        account=account,
+        tolerance=tolerance,
+    )
+
+    if report.differences:
+        print("Discrepancies detected:")
+        for diff in report.differences:
+            print(
+                f"  {diff.symbol}: tracker={diff.tracker_quantity:.6f} "
+                f"broker={diff.broker_quantity:.6f} Δ={diff.difference:.6f}"
+            )
+    else:
+        print("Tracker positions match broker balances within tolerance.")
+
+    if output_path is not None:
+        payload = report_to_dict(report)
+        output_path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+        print(f"Wrote reconciliation report to {output_path}")
+
+    if report.differences and fail_on_discrepancy:
+        return 1
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--journal",
+        type=Path,
+        default=Path("data_foundation/events/order_events.parquet"),
+        help="Path to the order event journal (Parquet or JSONL)",
+    )
+    parser.add_argument(
+        "--broker",
+        type=Path,
+        help="Path to broker statement (JSON/CSV) for nightly reconciliation",
+    )
+    parser.add_argument(
+        "--account",
+        default="PRIMARY",
+        help="Account identifier to reconcile (defaults to tracker default)",
+    )
+    parser.add_argument(
+        "--pnl-mode",
+        choices=("fifo", "lifo"),
+        default="fifo",
+        help="Inventory accounting mode for the position tracker",
+    )
+    parser.add_argument(
+        "--tolerance",
+        type=float,
+        default=1e-6,
+        help="Tolerance for quantity differences before flagging discrepancies",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        help="Optional path to write the reconciliation report as JSON",
+    )
+    parser.add_argument(
+        "--fail-on-discrepancy",
+        action="store_true",
+        help="Exit with status 1 if discrepancies are detected",
+    )
+    return parser
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    return run_reconciliation(
+        journal_path=args.journal,
+        broker_path=args.broker,
+        account=args.account,
+        pnl_mode=args.pnl_mode,
+        tolerance=args.tolerance,
+        output_path=args.output,
+        fail_on_discrepancy=args.fail_on_discrepancy,
+    )
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/trading/order_management/__init__.py
+++ b/src/trading/order_management/__init__.py
@@ -19,6 +19,12 @@ from .order_state_machine import (
 )
 from .event_journal import OrderEventJournal, InMemoryOrderEventJournal
 from .lifecycle_processor import OrderLifecycleProcessor
+from .reconciliation import (
+    load_order_journal_records,
+    load_broker_positions,
+    replay_order_events,
+    report_to_dict,
+)
 
 __all__ = [
     "PnLMode",
@@ -37,4 +43,8 @@ __all__ = [
     "OrderEventJournal",
     "InMemoryOrderEventJournal",
     "OrderLifecycleProcessor",
+    "load_order_journal_records",
+    "load_broker_positions",
+    "replay_order_events",
+    "report_to_dict",
 ]

--- a/src/trading/order_management/reconciliation.py
+++ b/src/trading/order_management/reconciliation.py
@@ -1,0 +1,198 @@
+"""Utilities for replaying order journals and generating reconciliation reports."""
+
+from __future__ import annotations
+
+import csv
+import json
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Mapping, MutableMapping
+
+from .position_tracker import PositionTracker, ReconciliationReport
+
+__all__ = [
+    "load_order_journal_records",
+    "replay_order_events",
+    "load_broker_positions",
+    "report_to_dict",
+]
+
+
+JournalRecord = Mapping[str, Any]
+
+
+def load_order_journal_records(path: Path) -> List[Dict[str, Any]]:
+    """Load order lifecycle records from the append-only journal.
+
+    The journal primarily writes to Parquet but falls back to ``.jsonl`` when
+    the optional dependencies are unavailable.  This helper mirrors that
+    behaviour, preferring the Parquet payload when dependencies are present and
+    otherwise reading the JSONL companion file.  Results are ordered by the
+    event timestamp to guarantee deterministic playback.
+    """
+
+    path = Path(path)
+    records: List[Dict[str, Any]] = []
+
+    if path.exists() and path.suffix == ".parquet":
+        try:
+            import pandas as pd  # type: ignore
+
+            df = pd.read_parquet(path)
+            records.extend(df.to_dict(orient="records"))
+        except Exception:  # pragma: no cover - optional dependency
+            records.clear()
+
+    if not records:
+        json_path = path if path.suffix.endswith(".jsonl") else path.with_suffix(path.suffix + ".jsonl")
+        if json_path.exists():
+            with json_path.open("r", encoding="utf-8") as fh:
+                for line in fh:
+                    line = line.strip()
+                    if not line:
+                        continue
+                    try:
+                        records.append(json.loads(line))
+                    except json.JSONDecodeError:  # pragma: no cover - log files can be messy
+                        continue
+
+    records.sort(key=_record_sort_key)
+    return records
+
+
+def replay_order_events(records: Iterable[JournalRecord], tracker: PositionTracker) -> None:
+    """Replay journal records into a :class:`PositionTracker` instance."""
+
+    cumulative_by_order: MutableMapping[str, float] = {}
+
+    for record in records:
+        event_type = str(record.get("event_type", "")).lower()
+        symbol = str(record.get("symbol") or "").strip()
+        if not symbol:
+            continue
+
+        side = str(record.get("side", "")).upper()
+        account = record.get("account")
+        price = _coerce_float(record.get("last_price"))
+        if price is None:
+            price = _coerce_float(record.get("average_fill_price"))
+
+        if event_type in {"partial_fill", "filled"}:
+            quantity = _coerce_float(record.get("last_quantity"))
+            cumulative = _coerce_float(record.get("cumulative_quantity"))
+            order_id = str(record.get("order_id") or symbol)
+            if cumulative is not None:
+                previous = cumulative_by_order.get(order_id, 0.0)
+                quantity = max(cumulative - previous, quantity or 0.0)
+                cumulative_by_order[order_id] = cumulative
+
+            if quantity is None or quantity <= 0.0:
+                continue
+            if price is None:
+                continue
+
+            signed_quantity = quantity if side == "BUY" else -quantity
+            tracker.record_fill(symbol, signed_quantity, price, account=account)
+            tracker.update_mark_price(symbol, price)
+        else:
+            if price is not None:
+                tracker.update_mark_price(symbol, price)
+
+
+def load_broker_positions(path: Path) -> Dict[str, float]:
+    """Load broker reported positions from JSON or CSV."""
+
+    path = Path(path)
+    suffix = path.suffix.lower()
+    if suffix in {".json", ".jsonl"}:
+        data = json.loads(path.read_text(encoding="utf-8"))
+        return _positions_from_json(data)
+
+    if suffix == ".csv":
+        return _positions_from_csv(path)
+
+    raise ValueError(f"Unsupported broker statement format: {path.suffix}")
+
+
+def report_to_dict(report: ReconciliationReport) -> Dict[str, Any]:
+    """Serialise a :class:`ReconciliationReport` to primitive types."""
+
+    return {
+        "timestamp": report.timestamp.isoformat(),
+        "account": report.account,
+        "differences": [
+            {
+                "symbol": diff.symbol,
+                "tracker_quantity": diff.tracker_quantity,
+                "broker_quantity": diff.broker_quantity,
+                "difference": diff.difference,
+            }
+            for diff in report.differences
+        ],
+    }
+
+
+def _positions_from_json(data: Any) -> Dict[str, float]:
+    positions: Dict[str, float] = {}
+    if isinstance(data, dict):
+        for symbol, quantity in data.items():
+            positions[str(symbol)] = _coerce_float(quantity, default=0.0)
+        return positions
+
+    if isinstance(data, list):
+        for entry in data:
+            if not isinstance(entry, Mapping):
+                continue
+            symbol = entry.get("symbol")
+            if symbol is None:
+                continue
+            quantity = _coerce_float(entry.get("quantity") or entry.get("qty"), default=0.0)
+            positions[str(symbol)] = quantity
+        return positions
+
+    raise ValueError("JSON broker statement must be an object or list of mappings")
+
+
+def _positions_from_csv(path: Path) -> Dict[str, float]:
+    positions: Dict[str, float] = {}
+    with path.open("r", encoding="utf-8", newline="") as fh:
+        reader = csv.DictReader(fh)
+        for row in reader:
+            symbol = row.get("symbol") or row.get("Symbol")
+            if not symbol:
+                continue
+            quantity = row.get("quantity") or row.get("qty") or row.get("Quantity")
+            positions[str(symbol)] = _coerce_float(quantity, default=0.0)
+    return positions
+
+
+def _record_sort_key(record: Mapping[str, Any]) -> tuple[datetime, str]:
+    timestamp = _parse_timestamp(record.get("event_timestamp") or record.get("last_update"))
+    order_id = str(record.get("order_id") or record.get("symbol") or "")
+    return (timestamp, order_id)
+
+
+def _parse_timestamp(value: Any) -> datetime:
+    if isinstance(value, datetime):
+        return value
+    if isinstance(value, str):
+        candidate = value.replace("Z", "+00:00")
+        try:
+            return datetime.fromisoformat(candidate)
+        except ValueError:
+            return datetime.min
+    return datetime.min
+
+
+def _coerce_float(value: Any, *, default: float | None = None) -> float | None:
+    if value is None:
+        return default
+    if isinstance(value, (int, float)):
+        return float(value)
+    if isinstance(value, str):
+        try:
+            return float(value)
+        except ValueError:
+            return default
+    return default
+

--- a/tests/trading/test_reconciliation.py
+++ b/tests/trading/test_reconciliation.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from src.trading.order_management import PositionTracker
+from src.trading.order_management.reconciliation import (
+    load_broker_positions,
+    load_order_journal_records,
+    replay_order_events,
+    report_to_dict,
+)
+
+def test_replay_order_events_updates_tracker() -> None:
+    tracker = PositionTracker()
+    records = [
+        {
+            "order_id": "ORD-1",
+            "symbol": "EURUSD",
+            "side": "BUY",
+            "event_type": "acknowledged",
+            "event_timestamp": "2025-01-01T00:00:00+00:00",
+        },
+        {
+            "order_id": "ORD-1",
+            "symbol": "EURUSD",
+            "side": "BUY",
+            "event_type": "partial_fill",
+            "last_quantity": 50000,
+            "last_price": 1.1,
+            "event_timestamp": "2025-01-01T00:00:01+00:00",
+        },
+        {
+            "order_id": "ORD-1",
+            "symbol": "EURUSD",
+            "side": "BUY",
+            "event_type": "filled",
+            "last_quantity": 50000,
+            "last_price": 1.2,
+            "event_timestamp": "2025-01-01T00:00:02+00:00",
+        },
+    ]
+
+    replay_order_events(records, tracker)
+
+    snapshot = tracker.get_position_snapshot("EURUSD")
+    assert snapshot.net_quantity == pytest.approx(100000)
+    assert snapshot.average_long_price == pytest.approx(1.15, abs=1e-9)
+
+
+def test_report_to_dict_round_trips(tmp_path: Path) -> None:
+    tracker = PositionTracker()
+    tracker.record_fill("AAPL", 10, 100.0)
+    broker = {"AAPL": 12}
+    report = tracker.generate_reconciliation_report(broker)
+    payload = report_to_dict(report)
+    assert payload["account"] == "PRIMARY"
+    assert payload["differences"][0]["symbol"] == "AAPL"
+    path = tmp_path / "report.json"
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    loaded = json.loads(path.read_text(encoding="utf-8"))
+    assert loaded["differences"][0]["symbol"] == "AAPL"
+
+
+def test_load_broker_positions_json(tmp_path: Path) -> None:
+    path = tmp_path / "broker.json"
+    path.write_text(json.dumps({"AAPL": 5, "TSLA": "-3"}), encoding="utf-8")
+    positions = load_broker_positions(path)
+    assert positions == {"AAPL": 5.0, "TSLA": -3.0}
+
+
+def test_load_broker_positions_csv(tmp_path: Path) -> None:
+    path = tmp_path / "broker.csv"
+    path.write_text("symbol,quantity\nAAPL,10\nTSLA,-2\n", encoding="utf-8")
+    positions = load_broker_positions(path)
+    assert positions == {"AAPL": 10.0, "TSLA": -2.0}
+
+
+def test_load_order_journal_records_json(tmp_path: Path) -> None:
+    path = tmp_path / "order_events.parquet.jsonl"
+    records = [
+        {
+            "order_id": "1",
+            "symbol": "EURUSD",
+            "side": "BUY",
+            "event_type": "filled",
+            "last_quantity": 1000,
+            "last_price": 1.1,
+            "event_timestamp": "2025-01-01T00:00:00+00:00",
+        },
+        {
+            "order_id": "1",
+            "symbol": "EURUSD",
+            "side": "BUY",
+            "event_type": "acknowledged",
+            "event_timestamp": "2024-12-31T23:59:59+00:00",
+        },
+    ]
+    with path.open("w", encoding="utf-8") as fh:
+        for record in records:
+            fh.write(json.dumps(record) + "\n")
+
+    loaded = load_order_journal_records(path)
+    assert loaded[0]["event_type"] == "acknowledged"
+    assert loaded[1]["event_type"] == "filled"


### PR DESCRIPTION
## Summary
- add order management reconciliation utilities to replay journal events and parse broker statements
- provide a reconcile_positions CLI to compare tracked state against broker balances and emit JSON reports
- extend runbook and roadmap documentation to capture the new nightly reconciliation workflow and mark its delivery
- add unit tests covering journal loading, replay, broker parsing, and report serialization helpers

## Testing
- pytest tests/trading/test_reconciliation.py

------
https://chatgpt.com/codex/tasks/task_e_68d83ec20944832cb01a87d9ea75c364