### PR TITLE
Add execution risk checks to risk gateway

### DIFF
--- a/config/execution/execution.yaml
+++ b/config/execution/execution.yaml
@@ -7,4 +7,8 @@ execution:
     size_coef: 5.0
   fees:
     commission_bps: 0.1
+  limits:
+    max_slippage_bps: 25.0
+    max_total_cost_bps: 35.0
+    max_notional_pct_of_equity: 0.25
 


### PR DESCRIPTION
## Summary
- add configurable execution risk limits and default thresholds to the execution configuration
- extend the risk gateway to evaluate execution cost, reject risky intents, and emit pre-trade denial metrics
- cover the execution rejection path with a dedicated risk gateway test

## Testing
- pytest tests/current/test_risk_gateway_validation.py

------
https://chatgpt.com/codex/tasks/task_e_68d8e9e8e364832c8c37dff4ac33f61a