### PR TITLE
Add lightweight structlog shim for roadmap readiness

### DIFF
--- a/src/structlog/__init__.py
+++ b/src/structlog/__init__.py
@@ -1,0 +1,131 @@
+"""Minimal ``structlog`` compatibility layer used in tests.
+
+This repository depends on :mod:`structlog` for structured logging helpers, but
+the real dependency is not available inside the execution environment that runs
+the kata.  To keep the public API stable—and avoid rewriting the higher level
+logging helpers—we provide a tiny, well-documented shim that mimics the handful
+of behaviours relied upon by the test-suite:
+
+* ``structlog.configure`` wires a processor chain and logger factory.
+* ``structlog.get_logger`` returns a bound logger instance.
+* ``structlog.contextvars`` exposes helpers to bind contextual metadata.
+* ``structlog.processors`` provides timestamp and JSON rendering processors.
+* ``structlog.stdlib`` supplies a ``BoundLogger`` implementation alongside the
+  ``ProcessorFormatter`` bridge used by :mod:`logging`.
+
+The goal is not to be feature complete—only to support the narrow surface used
+by :mod:`src.operational.structured_logging`.  The implementation intentionally
+mirrors the structure of the upstream library so future contributors can swap in
+the real dependency without touching call sites.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import logging
+from typing import Callable, Iterable, MutableMapping
+
+from . import contextvars, processors, stdlib
+
+__all__ = [
+    "configure",
+    "get_logger",
+    "make_filtering_bound_logger",
+    "contextvars",
+    "processors",
+    "stdlib",
+]
+
+
+@dataclass
+class _Configuration:
+    processors: list[Callable[[logging.Logger | None, str, MutableMapping[str, object]], MutableMapping[str, object] | str]]
+    logger_factory: Callable[[str | None], logging.Logger]
+    wrapper_class: type
+    cache_logger: bool
+
+
+_config = _Configuration(
+    processors=[],
+    logger_factory=lambda name: logging.getLogger(name),
+    wrapper_class=stdlib.BoundLogger,
+    cache_logger=False,
+)
+_logger_cache: dict[str | None, stdlib.BoundLogger] = {}
+
+
+def configure(
+    *,
+    processors: Iterable[Callable[[logging.Logger | None, str, MutableMapping[str, object]], MutableMapping[str, object] | str]] = (),
+    context_class: type[MutableMapping[str, object]] | None = None,
+    logger_factory: Callable[[str | None], logging.Logger] | None = None,
+    wrapper_class: type | None = None,
+    cache_logger_on_first_use: bool = False,
+) -> None:
+    """Configure the shim to mirror :func:`structlog.configure`.
+
+    Only the arguments exercised by the repository are supported.  ``context_class``
+    is accepted for signature compatibility but otherwise ignored because Python's
+    built-in ``dict`` already satisfies our needs.
+    """
+
+    global _config, _logger_cache
+
+    processor_chain = list(processors)
+    factory = logger_factory or (lambda name: logging.getLogger(name))
+    wrapper = wrapper_class or stdlib.BoundLogger
+
+    _config = _Configuration(
+        processors=processor_chain,
+        logger_factory=factory,
+        wrapper_class=wrapper,
+        cache_logger=cache_logger_on_first_use,
+    )
+    _logger_cache = {}
+
+
+def _run_processors(
+    logger: logging.Logger | None,
+    method_name: str,
+    event_dict: MutableMapping[str, object],
+) -> MutableMapping[str, object] | str:
+    """Execute the configured processor chain for a log event."""
+
+    processed: MutableMapping[str, object] | str = event_dict
+    for processor in _config.processors:
+        processed = processor(logger, method_name, processed)  # type: ignore[arg-type]
+    return processed
+
+
+def get_logger(name: str | None = None) -> stdlib.BoundLogger:
+    """Return a bound logger using the configured factory and wrapper."""
+
+    if _config.cache_logger and name in _logger_cache:
+        return _logger_cache[name]
+
+    logger = _config.logger_factory(name)
+    bound_logger = _config.wrapper_class(
+        logger=logger,
+        processor=_run_processors,
+    )
+    if _config.cache_logger:
+        _logger_cache[name] = bound_logger
+    return bound_logger
+
+
+def make_filtering_bound_logger(level: int) -> type:
+    """Return a ``BoundLogger`` variant that honours a minimum level."""
+
+    class FilteringBoundLogger(stdlib.BoundLogger):
+        _minimum_level = level
+
+        def _should_log(self, levelno: int) -> bool:  # pragma: no cover - simple guard
+            return levelno >= self._minimum_level
+
+    return FilteringBoundLogger
+
+
+def _reset_for_tests() -> None:
+    """Internal helper used by tests to isolate global state."""
+
+    configure()

--- a/src/structlog/contextvars.py
+++ b/src/structlog/contextvars.py
@@ -1,0 +1,54 @@
+"""Context management helpers mirroring ``structlog.contextvars``."""
+
+from __future__ import annotations
+
+from contextvars import ContextVar
+from typing import MutableMapping
+
+
+_CONTEXT: ContextVar[MutableMapping[str, object]] = ContextVar("structlog_context", default={})
+
+
+def bind_contextvars(**values: object) -> None:
+    """Bind key/value pairs into the current logging context."""
+
+    if not values:
+        return
+
+    current = dict(_CONTEXT.get())
+    current.update(values)
+    _CONTEXT.set(current)
+
+
+def unbind_contextvars(*keys: str) -> None:
+    """Remove keys from the current logging context."""
+
+    if not keys:
+        return
+
+    current = dict(_CONTEXT.get())
+    for key in keys:
+        current.pop(key, None)
+    _CONTEXT.set(current)
+
+
+def merge_contextvars(
+    _logger: object,
+    _method_name: str,
+    event_dict: MutableMapping[str, object],
+) -> MutableMapping[str, object]:
+    """Processor that merges bound context into the event dictionary."""
+
+    context = _CONTEXT.get()
+    if not context:
+        return event_dict
+    merged = dict(context)
+    merged.update(event_dict)
+    return merged
+
+
+__all__ = [
+    "bind_contextvars",
+    "unbind_contextvars",
+    "merge_contextvars",
+]

--- a/src/structlog/processors.py
+++ b/src/structlog/processors.py
@@ -1,0 +1,46 @@
+"""Simplified processors mirroring the :mod:`structlog.processors` API."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+import json
+from typing import MutableMapping
+
+
+class TimeStamper:
+    """Add an ISO8601 timestamp to the event dictionary."""
+
+    def __init__(self, *, fmt: str = "iso", utc: bool = False) -> None:
+        self._fmt = fmt
+        self._utc = utc
+
+    def __call__(
+        self,
+        _logger: object,
+        _method_name: str,
+        event_dict: MutableMapping[str, object],
+    ) -> MutableMapping[str, object]:
+        timestamp = datetime.now(tz=UTC if self._utc else None)
+        if self._fmt == "iso":
+            event_dict.setdefault("timestamp", timestamp.isoformat())
+        else:  # pragma: no cover - alternative formats are out of scope
+            event_dict.setdefault("timestamp", timestamp.strftime(self._fmt))
+        return event_dict
+
+
+class JSONRenderer:
+    """Render the event dictionary as a JSON encoded string."""
+
+    def __call__(
+        self,
+        _logger: object,
+        _method_name: str,
+        event_dict: MutableMapping[str, object],
+    ) -> str:
+        return json.dumps(event_dict, default=str, sort_keys=True)
+
+
+__all__ = [
+    "TimeStamper",
+    "JSONRenderer",
+]

--- a/src/structlog/stdlib.py
+++ b/src/structlog/stdlib.py
@@ -1,0 +1,134 @@
+"""Minimal compatibility shims mirroring :mod:`structlog.stdlib`."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+import logging
+from typing import Callable, MutableMapping
+
+
+class LoggerFactory:
+    """Factory returning :class:`logging.Logger` instances."""
+
+    def __call__(self, name: str | None = None) -> logging.Logger:
+        return logging.getLogger(name)
+
+
+def add_logger_name(
+    logger: logging.Logger | None,
+    _method_name: str,
+    event_dict: MutableMapping[str, object],
+) -> MutableMapping[str, object]:
+    if logger is not None:
+        event_dict.setdefault("logger", logger.name)
+    return event_dict
+
+
+def add_log_level(
+    _logger: logging.Logger | None,
+    method_name: str,
+    event_dict: MutableMapping[str, object],
+) -> MutableMapping[str, object]:
+    event_dict.setdefault("level", method_name.upper())
+    return event_dict
+
+
+class ProcessorFormatter(logging.Formatter):
+    """Formatter that consumes event dictionaries from bound loggers."""
+
+    def __init__(
+        self,
+        *,
+        processor: Callable[[logging.Logger | None, str, MutableMapping[str, object]], str],
+        foreign_pre_chain: list[
+            Callable[[logging.Logger | None, str, MutableMapping[str, object]], MutableMapping[str, object]]
+        ] | None = None,
+    ) -> None:
+        super().__init__()
+        self._processor = processor
+        self._foreign_pre_chain = foreign_pre_chain or []
+
+    def format(self, record: logging.LogRecord) -> str:
+        event_dict = dict(getattr(record, "structlog_event_dict", {"event": record.getMessage()}))
+        logger = event_dict.get("_logger") if isinstance(event_dict.get("_logger"), logging.Logger) else None
+        method_name = str(event_dict.get("_method_name", record.levelname.lower()))
+        for processor in self._foreign_pre_chain:
+            event_dict = processor(logger, method_name, event_dict)
+        event_dict.pop("_logger", None)
+        event_dict.pop("_method_name", None)
+        return self._processor(logger, method_name, event_dict)
+
+    @staticmethod
+    def wrap_for_formatter(
+        logger: logging.Logger | None,
+        method_name: str,
+        event_dict: MutableMapping[str, object],
+    ) -> MutableMapping[str, object]:
+        event_dict.setdefault("_logger", logger)
+        event_dict.setdefault("_method_name", method_name)
+        return event_dict
+
+
+@dataclass
+class BoundLogger:
+    """Very small subset of :class:`structlog.stdlib.BoundLogger` functionality."""
+
+    logger: logging.Logger
+    processor: Callable[[logging.Logger | None, str, MutableMapping[str, object]], MutableMapping[str, object] | str]
+    context: MutableMapping[str, object] = field(default_factory=dict)
+
+    def bind(self, **values: object) -> "BoundLogger":
+        if not values:
+            return self
+        merged = dict(self.context)
+        merged.update(values)
+        return self.__class__(logger=self.logger, processor=self.processor, context=merged)
+
+    # ------------------------------------------------------------------
+    def _should_log(self, _levelno: int) -> bool:
+        return True
+
+    def _log(self, method_name: str, levelno: int, event: str, **kwargs: object) -> None:
+        if not self._should_log(levelno):  # pragma: no cover - defensive guard
+            return
+
+        event_dict: MutableMapping[str, object] = {"event": event}
+        if self.context:
+            event_dict.update(self.context)
+        if kwargs:
+            event_dict.update(kwargs)
+
+        processed = self.processor(self.logger, method_name, event_dict)
+        if isinstance(processed, dict):
+            message = processed.get("event", event)
+            extra = {"structlog_event_dict": processed}
+        else:
+            message = processed
+            extra = {"structlog_event_dict": {"event": event}}
+
+        self.logger._log(levelno, message, args=(), extra=extra)
+
+    # Convenience wrappers matching the upstream API -------------------
+    def debug(self, event: str, **kwargs: object) -> None:
+        self._log("debug", logging.DEBUG, event, **kwargs)
+
+    def info(self, event: str, **kwargs: object) -> None:
+        self._log("info", logging.INFO, event, **kwargs)
+
+    def warning(self, event: str, **kwargs: object) -> None:
+        self._log("warning", logging.WARNING, event, **kwargs)
+
+    def error(self, event: str, **kwargs: object) -> None:
+        self._log("error", logging.ERROR, event, **kwargs)
+
+    def critical(self, event: str, **kwargs: object) -> None:
+        self._log("critical", logging.CRITICAL, event, **kwargs)
+
+
+__all__ = [
+    "add_log_level",
+    "add_logger_name",
+    "BoundLogger",
+    "LoggerFactory",
+    "ProcessorFormatter",
+]


### PR DESCRIPTION
## Summary
- add a lightweight structlog compatibility shim so roadmap readiness checks can import runtime FIX modules
- implement minimal context, processor, and stdlib helpers to preserve structured logging behaviour without the external dependency

## Testing
- pytest tests/tools/test_high_impact_roadmap.py -q
- pytest tests/operational/test_structured_logging.py -q

------
https://chatgpt.com/codex/tasks/task_e_68d932d215a0832ca3b5f47f3b44061d