### PR TITLE
Integrate order lifecycle telemetry into FIX pilot

### DIFF
--- a/docs/runbooks/execution_lifecycle.md
+++ b/docs/runbooks/execution_lifecycle.md
@@ -32,6 +32,11 @@ simulation flows.
 6. **PnL & Exposure Dashboard (`scripts/pnl_exposure_dashboard.py`)**
    - Replays the journal to present snapshot exposure totals per Chapter 24
      operational guidelines.
+7. **Fix Integration Pilot (`src/runtime/fix_pilot.py`)**
+   - Automatically attaches the lifecycle processor and position tracker to the
+     FIX broker interface.
+   - Publishes aggregated open order, exposure, and journal metadata for
+     operational telemetry.
 
 ## Sequence Diagram
 

--- a/src/trading/order_management/event_journal.py
+++ b/src/trading/order_management/event_journal.py
@@ -89,6 +89,12 @@ class OrderEventJournal:
         with self._dead_letter_path.open("a", encoding="utf-8") as fh:
             fh.write(json.dumps(record, default=str) + "\n")
 
+    @property
+    def path(self) -> Path:
+        """Path to the primary journal artefact."""
+
+        return self._path
+
     # ------------------------------------------------------------------
     def _append_parquet(self, record: Dict[str, Any]) -> None:
         assert self._pd is not None

--- a/src/trading/order_management/lifecycle_processor.py
+++ b/src/trading/order_management/lifecycle_processor.py
@@ -51,6 +51,18 @@ class OrderLifecycleProcessor:
     def state_machine(self) -> OrderStateMachine:
         return self._state_machine
 
+    @property
+    def journal(self) -> OrderEventJournal | None:
+        """Return the backing journal used for lifecycle persistence."""
+
+        return self._journal
+
+    @property
+    def position_tracker(self) -> PositionTracker | None:
+        """Expose the shared position tracker, if configured."""
+
+        return self._position_tracker
+
     def register_order(self, metadata: OrderMetadata) -> OrderState:
         """Register a new order with the underlying state machine."""
 

--- a/tests/operations/test_fix_pilot_ops.py
+++ b/tests/operations/test_fix_pilot_ops.py
@@ -32,6 +32,7 @@ def test_evaluate_fix_pilot_pass():
     components = {comp.name: comp for comp in snapshot.components}
     assert "broker" in components
     assert components["dropcopy"].status is FixPilotStatus.passed
+    assert "orders" in components
     markdown = format_fix_pilot_markdown(snapshot)
     assert "FIX Pilot Status" in markdown
 
@@ -61,3 +62,4 @@ def test_evaluate_fix_pilot_warn_and_fail():
     assert components["queues"].status is FixPilotStatus.warn
     assert components["compliance"].status is FixPilotStatus.warn
     assert components["dropcopy"].status is FixPilotStatus.warn
+    assert "orders" in components


### PR DESCRIPTION
## Summary
- attach the order lifecycle processor and position tracker to the FIX integration pilot and persist events by default
- expose open orders, position snapshots, and journal metadata to operational snapshots and documentation
- extend runtime and operations tests to cover lifecycle replay and telemetry outputs

## Testing
- pytest tests/runtime/test_fix_pilot.py tests/operations/test_fix_pilot_ops.py

------
https://chatgpt.com/codex/tasks/task_e_68d94d3dabb4832ca1bf803ea999c5e7