### PR TITLE
Add FIX order latency monitoring and lifecycle timestamps

### DIFF
--- a/src/trading/order_management/event_journal.py
+++ b/src/trading/order_management/event_journal.py
@@ -69,6 +69,22 @@ class OrderEventJournal:
             "average_fill_price": snapshot.average_fill_price,
             "last_event": snapshot.last_event,
             "last_update": snapshot.last_update.isoformat(),
+            "created_at": snapshot.created_at.isoformat(),
+            "acknowledged_at": snapshot.acknowledged_at.isoformat()
+            if snapshot.acknowledged_at
+            else None,
+            "first_fill_at": snapshot.first_fill_at.isoformat()
+            if snapshot.first_fill_at
+            else None,
+            "final_fill_at": snapshot.final_fill_at.isoformat()
+            if snapshot.final_fill_at
+            else None,
+            "cancelled_at": snapshot.cancelled_at.isoformat()
+            if snapshot.cancelled_at
+            else None,
+            "rejected_at": snapshot.rejected_at.isoformat()
+            if snapshot.rejected_at
+            else None,
         }
         if extra:
             record.update(extra)
@@ -150,6 +166,12 @@ class InMemoryOrderEventJournal(OrderEventJournal):
                 "remaining_quantity": snapshot.remaining_quantity,
                 "average_fill_price": snapshot.average_fill_price,
                 "last_event": snapshot.last_event,
+                "created_at": snapshot.created_at,
+                "acknowledged_at": snapshot.acknowledged_at,
+                "first_fill_at": snapshot.first_fill_at,
+                "final_fill_at": snapshot.final_fill_at,
+                "cancelled_at": snapshot.cancelled_at,
+                "rejected_at": snapshot.rejected_at,
             },
         }
         if extra:

--- a/src/trading/order_management/monitoring/__init__.py
+++ b/src/trading/order_management/monitoring/__init__.py
@@ -1,3 +1,5 @@
 from __future__ import annotations
 
-__all__: list[str] = []
+from .latency_metrics import LatencyMetrics, OrderLatencyMonitor
+
+__all__ = ["OrderLatencyMonitor", "LatencyMetrics"]

--- a/src/trading/order_management/monitoring/latency_metrics.py
+++ b/src/trading/order_management/monitoring/latency_metrics.py
@@ -1,0 +1,115 @@
+"""Latency monitoring for FIX order lifecycles."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Optional
+
+from src.core.interfaces.metrics import HistogramLike
+from src.operational.metrics_registry import MetricsRegistry, get_registry
+
+from ..order_state_machine import (
+    OrderExecutionEvent,
+    OrderLifecycleSnapshot,
+    OrderState,
+)
+
+__all__ = ["OrderLatencyMonitor", "LatencyMetrics"]
+
+
+@dataclass(slots=True)
+class LatencyMetrics:
+    """Calculated latency artefacts for a lifecycle transition."""
+
+    ack_latency: Optional[float] = None
+    first_fill_latency: Optional[float] = None
+    final_fill_latency: Optional[float] = None
+    cancel_latency: Optional[float] = None
+    reject_latency: Optional[float] = None
+
+
+class OrderLatencyMonitor:
+    """Publish latency metrics for order lifecycles to the metrics registry."""
+
+    def __init__(
+        self,
+        *,
+        registry: MetricsRegistry | None = None,
+        buckets: Optional[list[float]] = None,
+    ) -> None:
+        self._registry = registry or get_registry()
+        histogram_buckets = buckets or [0.01, 0.05, 0.1, 0.25, 0.5, 1.0, 2.0, 5.0, 10.0, 30.0]
+        self._ack_hist = self._registry.get_histogram(
+            "order_ack_latency_seconds",
+            "Latency from order creation to acknowledgement",
+            histogram_buckets,
+            ["venue"],
+        )
+        self._first_fill_hist = self._registry.get_histogram(
+            "order_first_fill_latency_seconds",
+            "Latency from order creation to first fill",
+            histogram_buckets,
+            ["venue"],
+        )
+        self._final_fill_hist = self._registry.get_histogram(
+            "order_final_fill_latency_seconds",
+            "Latency from order creation to final fill",
+            histogram_buckets,
+            ["venue"],
+        )
+        self._cancel_hist = self._registry.get_histogram(
+            "order_cancel_latency_seconds",
+            "Latency from order creation to cancel acknowledgement",
+            histogram_buckets,
+            ["venue"],
+        )
+        self._reject_hist = self._registry.get_histogram(
+            "order_reject_latency_seconds",
+            "Latency from order creation to reject",
+            histogram_buckets,
+            ["venue"],
+        )
+
+    # ------------------------------------------------------------------
+    def record_transition(
+        self,
+        state: OrderState,
+        event: OrderExecutionEvent,
+        snapshot: OrderLifecycleSnapshot,
+    ) -> LatencyMetrics:
+        """Calculate and publish latency metrics for the supplied transition."""
+
+        created_at = state.created_at
+        venue = state.metadata.venue or "unknown"
+        metrics = LatencyMetrics()
+
+        def _observe(hist: HistogramLike, start: Optional[datetime], end: Optional[datetime]) -> Optional[float]:
+            if start is None or end is None:
+                return None
+            latency = (end - start).total_seconds()
+            if latency < 0:
+                return None
+            hist.labels(venue=venue).observe(latency)
+            return latency
+
+        if event.event_type == "acknowledged" and state.acknowledged_at == event.timestamp:
+            metrics.ack_latency = _observe(self._ack_hist, created_at, state.acknowledged_at)
+
+        if event.event_type in {"partial_fill", "filled"} and state.first_fill_at == event.timestamp:
+            metrics.first_fill_latency = _observe(
+                self._first_fill_hist, created_at, state.first_fill_at
+            )
+
+        if event.event_type == "filled" and state.final_fill_at == event.timestamp:
+            metrics.final_fill_latency = _observe(
+                self._final_fill_hist, created_at, state.final_fill_at
+            )
+
+        if event.event_type == "cancelled" and state.cancelled_at == event.timestamp:
+            metrics.cancel_latency = _observe(self._cancel_hist, created_at, state.cancelled_at)
+
+        if event.event_type == "rejected" and state.rejected_at == event.timestamp:
+            metrics.reject_latency = _observe(self._reject_hist, created_at, state.rejected_at)
+
+        return metrics

--- a/tests/trading/test_order_latency_monitor.py
+++ b/tests/trading/test_order_latency_monitor.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+from src.trading.order_management import OrderExecutionEvent, OrderMetadata, OrderStateMachine
+from src.trading.order_management.monitoring import OrderLatencyMonitor
+
+
+class FakeHistogram:
+    def __init__(self, name: str) -> None:
+        self.name = name
+        self.labels_called: list[dict[str, str]] = []
+        self.observations: list[float] = []
+
+    def labels(self, **labels: str) -> "FakeHistogram":
+        self.labels_called.append(labels)
+        return self
+
+    def observe(self, value: float) -> None:
+        self.observations.append(float(value))
+
+
+class FakeRegistry:
+    def __init__(self) -> None:
+        self.histograms: dict[str, FakeHistogram] = {}
+
+    def get_histogram(self, name: str, description: str, buckets, labelnames) -> FakeHistogram:  # type: ignore[override]
+        hist = FakeHistogram(name)
+        self.histograms[name] = hist
+        return hist
+
+
+def test_order_latency_monitor_records_all_latencies() -> None:
+    registry = FakeRegistry()
+    monitor = OrderLatencyMonitor(registry=registry)
+
+    machine = OrderStateMachine()
+    created_at = datetime(2025, 1, 1, tzinfo=timezone.utc)
+    metadata = OrderMetadata(
+        "ORD-1",
+        "EURUSD",
+        "BUY",
+        10,
+        account="SIM",
+        created_at=created_at,
+        venue="ICM",
+    )
+    machine.register_order(metadata)
+
+    def _ts(seconds: int) -> datetime:
+        return created_at + timedelta(seconds=seconds)
+
+    events = [
+        OrderExecutionEvent("ORD-1", "acknowledged", "0", timestamp=_ts(1)),
+        OrderExecutionEvent(
+            "ORD-1",
+            "partial_fill",
+            "1",
+            last_quantity=4,
+            last_price=1.0,
+            cumulative_quantity=4,
+            timestamp=_ts(2),
+        ),
+        OrderExecutionEvent(
+            "ORD-1",
+            "filled",
+            "2",
+            last_quantity=6,
+            cumulative_quantity=10,
+            last_price=1.01,
+            timestamp=_ts(3),
+        ),
+    ]
+
+    for event in events:
+        state = machine.apply_event(event)
+        snapshot = machine.snapshot("ORD-1")
+        monitor.record_transition(state, event, snapshot)
+
+    assert registry.histograms["order_ack_latency_seconds"].observations == [1.0]
+    assert registry.histograms["order_first_fill_latency_seconds"].observations == [2.0]
+    assert registry.histograms["order_final_fill_latency_seconds"].observations == [3.0]
+    assert registry.histograms["order_cancel_latency_seconds"].observations == []
+    assert registry.histograms["order_reject_latency_seconds"].observations == []
+
+    # Ensure venue label applied consistently
+    assert registry.histograms["order_ack_latency_seconds"].labels_called == [{"venue": "ICM"}]


### PR DESCRIPTION
## Summary
- add an order latency monitor that records acknowledgement/fill/cancel timings against the metrics registry
- enrich order lifecycle state with creation and transition timestamps and persist them through journals and snapshots
- extend processor and test coverage to exercise the latency monitor and new timestamp fields

## Testing
- pytest
- pytest tests/trading/test_order_latency_monitor.py

------
https://chatgpt.com/codex/tasks/task_e_68d952890764832cb0b02a5ff08eb1fb