### PR TITLE
Expand high-impact roadmap readiness checks

### DIFF
--- a/tools/roadmap/high_impact.py
+++ b/tools/roadmap/high_impact.py
@@ -79,12 +79,20 @@ def _stream_definitions() -> Sequence[StreamDefinition]:
                     "build_institutional_ingest_config",
                 ),
                 require_module_attr(
+                    "data_foundation.ingest.quality",
+                    "evaluate_ingest_quality",
+                ),
+                require_module_attr(
                     "data_foundation.cache.redis_cache",
                     "ManagedRedisCache",
                 ),
                 require_module_attr(
                     "data_foundation.streaming.kafka_stream",
                     "KafkaIngestEventPublisher",
+                ),
+                require_module_attr(
+                    "data_foundation.streaming.kafka_stream",
+                    "KafkaIngestQualityPublisher",
                 ),
                 require_module_attr(
                     "data_foundation.batch.spark_export",
@@ -134,6 +142,14 @@ def _stream_definitions() -> Sequence[StreamDefinition]:
                 require_module_attr(
                     "orchestration.evolution_cycle", "EvolutionCycleOrchestrator"
                 ),
+                require_module_attr(
+                    "operations.evolution_experiments",
+                    "evaluate_evolution_experiments",
+                ),
+                require_module_attr(
+                    "operations.evolution_tuning",
+                    "evaluate_evolution_tuning",
+                ),
             ),
         ),
         StreamDefinition(
@@ -169,6 +185,13 @@ def _stream_definitions() -> Sequence[StreamDefinition]:
                 ),
                 require_module_attr("compliance.trade_compliance", "TradeComplianceMonitor"),
                 require_module_attr("compliance.kyc", "KycAmlMonitor"),
+                require_module_attr(
+                    "operations.configuration_audit", "evaluate_configuration_audit"
+                ),
+                require_module_attr(
+                    "operations.system_validation", "evaluate_system_validation"
+                ),
+                require_module_attr("operations.slo", "evaluate_ingest_slos"),
             ),
         ),
     )


### PR DESCRIPTION
## Summary
- extend the high-impact roadmap CLI to verify ingest quality scoring and Kafka telemetry publishers for stream A
- require evolution experiment and tuning evaluators for stream B readiness
- add configuration audit, system validation, and SLO telemetry checks to stream C coverage

## Testing
- pytest tests/tools/test_high_impact_roadmap.py


------
https://chatgpt.com/codex/tasks/task_e_68d954f4ee78832c8ef59ae1a4f61b1a