### PR TITLE
Add detailed high-impact roadmap status report

### DIFF
--- a/docs/status/high_impact_roadmap_detail.md
+++ b/docs/status/high_impact_roadmap_detail.md
@@ -1,0 +1,65 @@
+# High-impact roadmap status
+
+## Stream A – Institutional data backbone
+
+**Status:** Ready
+
+**Summary:** Timescale ingest, Redis caching, Kafka streaming, and Spark exports ship with readiness telemetry and failover tooling.
+
+**Next checkpoint:** Exercise cross-region failover and automated scheduler cutover using the readiness feeds.
+
+**Evidence:**
+- data_foundation.ingest.timescale_pipeline.TimescaleBackboneOrchestrator
+- data_foundation.ingest.configuration.build_institutional_ingest_config
+- data_foundation.ingest.quality.evaluate_ingest_quality
+- data_foundation.cache.redis_cache.ManagedRedisCache
+- data_foundation.streaming.kafka_stream.KafkaIngestEventPublisher
+- data_foundation.streaming.kafka_stream.KafkaIngestQualityPublisher
+- data_foundation.batch.spark_export.execute_spark_export_plan
+- operations.data_backbone.evaluate_data_backbone_readiness
+- operations.ingest_trends.evaluate_ingest_trends
+- data_foundation.ingest.failover.decide_ingest_failover
+
+## Stream B – Sensory cortex & evolution uplift
+
+**Status:** Ready
+
+**Summary:** All five sensory organs operate with drift telemetry and catalogue-backed evolution lineage exports.
+
+**Next checkpoint:** Extend live-paper experiments and automated tuning loops using evolution telemetry.
+
+**Evidence:**
+- sensory.how.how_sensor.HowSensor
+- sensory.anomaly.anomaly_sensor.AnomalySensor
+- sensory.when.gamma_exposure.GammaExposureAnalyzer
+- sensory.why.why_sensor.WhySensor
+- operations.sensory_drift.evaluate_sensory_drift
+- genome.catalogue.load_default_catalogue
+- evolution.lineage_telemetry.EvolutionLineageSnapshot
+- orchestration.evolution_cycle.EvolutionCycleOrchestrator
+- operations.evolution_experiments.evaluate_evolution_experiments
+- operations.evolution_tuning.evaluate_evolution_tuning
+
+## Stream C – Execution, risk, compliance, ops readiness
+
+**Status:** Ready
+
+**Summary:** FIX pilots, risk/compliance workflows, ROI telemetry, and operational readiness publish evidence for operators.
+
+**Next checkpoint:** Expand broker connectivity with drop-copy reconciliation and extend regulatory telemetry coverage.
+
+**Evidence:**
+- runtime.fix_pilot.FixIntegrationPilot
+- operations.fix_pilot.evaluate_fix_pilot
+- runtime.fix_dropcopy.FixDropcopyReconciler
+- operations.execution.evaluate_execution_readiness
+- operations.professional_readiness.evaluate_professional_readiness
+- operations.roi.evaluate_roi_posture
+- operations.strategy_performance.evaluate_strategy_performance
+- compliance.workflow.evaluate_compliance_workflows
+- operations.compliance_readiness.evaluate_compliance_readiness
+- compliance.trade_compliance.TradeComplianceMonitor
+- compliance.kyc.KycAmlMonitor
+- operations.configuration_audit.evaluate_configuration_audit
+- operations.system_validation.evaluate_system_validation
+- operations.slo.evaluate_ingest_slos


### PR DESCRIPTION
## Summary
- generate the detailed high-impact roadmap status report via the roadmap helper
- add the resulting markdown snapshot under docs/status for reference alongside the main table

## Testing
- python -m tools.roadmap.high_impact --format detail --output docs/status/high_impact_roadmap_detail.md

------
https://chatgpt.com/codex/tasks/task_e_68d957fdf428832c874a0b49b55b1a75