### PR TITLE
Add Prometheus metrics publisher for position tracker

### DIFF
--- a/src/trading/order_management/monitoring/__init__.py
+++ b/src/trading/order_management/monitoring/__init__.py
@@ -1,5 +1,10 @@
 from __future__ import annotations
 
 from .latency_metrics import LatencyMetrics, OrderLatencyMonitor
+from .pnl_metrics import PositionMetricsPublisher
 
-__all__ = ["OrderLatencyMonitor", "LatencyMetrics"]
+__all__ = [
+    "OrderLatencyMonitor",
+    "LatencyMetrics",
+    "PositionMetricsPublisher",
+]

--- a/src/trading/order_management/monitoring/pnl_metrics.py
+++ b/src/trading/order_management/monitoring/pnl_metrics.py
@@ -1,0 +1,107 @@
+"""Metrics publisher for position and PnL observability."""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from src.operational.metrics_registry import MetricsRegistry, get_registry
+
+from ..position_tracker import PositionSnapshot
+
+__all__ = ["PositionMetricsPublisher"]
+
+
+class PositionMetricsPublisher:
+    """Publish position and PnL metrics to a Prometheus-compatible registry."""
+
+    def __init__(self, *, registry: MetricsRegistry | None = None) -> None:
+        self._registry = registry or get_registry()
+
+        self._net_qty = self._registry.get_gauge(
+            "emp_position_net_quantity",
+            "Net position size per account and symbol",
+            ["account", "symbol"],
+        )
+        self._gross_long = self._registry.get_gauge(
+            "emp_position_gross_long",
+            "Gross long quantity per account and symbol",
+            ["account", "symbol"],
+        )
+        self._gross_short = self._registry.get_gauge(
+            "emp_position_gross_short",
+            "Gross short quantity per account and symbol",
+            ["account", "symbol"],
+        )
+        self._realized_pnl = self._registry.get_gauge(
+            "emp_position_realized_pnl",
+            "Realized PnL per account and symbol",
+            ["account", "symbol"],
+        )
+        self._unrealized_pnl = self._registry.get_gauge(
+            "emp_position_unrealized_pnl",
+            "Unrealized PnL per account and symbol",
+            ["account", "symbol"],
+        )
+        self._exposure = self._registry.get_gauge(
+            "emp_position_notional_exposure",
+            "Notional exposure per account and symbol",
+            ["account", "symbol"],
+        )
+        self._market_value = self._registry.get_gauge(
+            "emp_position_market_value",
+            "Market value per account and symbol",
+            ["account", "symbol"],
+        )
+        self._account_exposure = self._registry.get_gauge(
+            "emp_account_total_exposure",
+            "Aggregated notional exposure per account",
+            ["account"],
+        )
+        self._account_realized = self._registry.get_gauge(
+            "emp_account_total_realized_pnl",
+            "Aggregated realized PnL per account",
+            ["account"],
+        )
+        self._account_unrealized = self._registry.get_gauge(
+            "emp_account_total_unrealized_pnl",
+            "Aggregated unrealized PnL per account",
+            ["account"],
+        )
+
+    # ------------------------------------------------------------------
+    def publish(self, snapshot: PositionSnapshot) -> None:
+        """Publish metrics for a single position snapshot."""
+
+        labels = {"account": snapshot.account, "symbol": snapshot.symbol}
+        self._net_qty.labels(**labels).set(float(snapshot.net_quantity))
+        self._gross_long.labels(**labels).set(float(snapshot.long_quantity))
+        self._gross_short.labels(**labels).set(float(snapshot.short_quantity))
+        self._realized_pnl.labels(**labels).set(float(snapshot.realized_pnl))
+
+        unrealized = float(snapshot.unrealized_pnl) if snapshot.unrealized_pnl is not None else 0.0
+        self._unrealized_pnl.labels(**labels).set(unrealized)
+
+        exposure = float(snapshot.exposure) if snapshot.exposure is not None else 0.0
+        self._exposure.labels(**labels).set(exposure)
+
+        market_value = snapshot.market_value or 0.0
+        self._market_value.labels(**labels).set(float(market_value))
+
+    # ------------------------------------------------------------------
+    def publish_account_totals(
+        self,
+        *,
+        account: str,
+        total_exposure: float,
+        total_realized_pnl: float,
+        total_unrealized_pnl: Optional[float] = None,
+    ) -> None:
+        """Publish aggregated metrics for an account."""
+
+        labels = {"account": account}
+        self._account_exposure.labels(**labels).set(float(total_exposure))
+        self._account_realized.labels(**labels).set(float(total_realized_pnl))
+
+        unrealized = float(total_unrealized_pnl) if total_unrealized_pnl is not None else 0.0
+        self._account_unrealized.labels(**labels).set(unrealized)
+

--- a/tests/trading/test_position_metrics_publisher.py
+++ b/tests/trading/test_position_metrics_publisher.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, Tuple
+
+import pytest
+
+from src.trading.order_management.monitoring.pnl_metrics import PositionMetricsPublisher
+from src.trading.order_management.position_tracker import PositionTracker
+
+
+class _LabeledGauge:
+    def __init__(self, store: Dict[Tuple[Tuple[str, str], ...], float], labels: Dict[str, str]) -> None:
+        self._store = store
+        self._labels = tuple(sorted(labels.items()))
+
+    def set(self, value: float) -> None:
+        self._store[self._labels] = float(value)
+
+
+class _Gauge:
+    def __init__(self) -> None:
+        self.values: Dict[Tuple[Tuple[str, str], ...], float] = {}
+
+    def labels(self, **labels: str) -> _LabeledGauge:
+        return _LabeledGauge(self.values, labels)
+
+
+@dataclass
+class _Registry:
+    gauges: Dict[str, _Gauge]
+
+    def get_gauge(self, name: str, description: str, labelnames=None):  # type: ignore[override]
+        gauge = self.gauges.setdefault(name, _Gauge())
+        return gauge
+
+
+def _metric_value(registry: _Registry, metric: str, **labels: str) -> float:
+    gauge = registry.gauges[metric]
+    key = tuple(sorted(labels.items()))
+    return gauge.values[key]
+
+
+def test_position_tracker_publishes_metrics() -> None:
+    registry = _Registry(gauges={})
+    publisher = PositionMetricsPublisher(registry=registry)
+    tracker = PositionTracker(metrics_publisher=publisher)
+
+    tracker.record_fill("EURUSD", 1.0, 1.1, account="ACC1")
+    tracker.record_fill("EURUSD", -0.4, 1.2, account="ACC1")
+
+    assert pytest.approx(
+        _metric_value(registry, "emp_position_net_quantity", account="ACC1", symbol="EURUSD")
+    ) == 0.6
+    assert pytest.approx(
+        _metric_value(registry, "emp_position_gross_long", account="ACC1", symbol="EURUSD")
+    ) == 0.6
+    assert pytest.approx(
+        _metric_value(registry, "emp_position_gross_short", account="ACC1", symbol="EURUSD")
+    ) == 0.0
+
+    realized = _metric_value(registry, "emp_position_realized_pnl", account="ACC1", symbol="EURUSD")
+    assert pytest.approx(realized, rel=1e-6) == pytest.approx(0.04, rel=1e-6)
+
+    tracker.update_mark_price("EURUSD", 1.25)
+
+    exposure = _metric_value(registry, "emp_position_notional_exposure", account="ACC1", symbol="EURUSD")
+    assert pytest.approx(exposure, rel=1e-6) == pytest.approx(0.75, rel=1e-6)
+
+    unrealized = _metric_value(registry, "emp_position_unrealized_pnl", account="ACC1", symbol="EURUSD")
+    assert pytest.approx(unrealized, rel=1e-6) == pytest.approx(0.09, rel=1e-6)
+
+    total_exposure = _metric_value(registry, "emp_account_total_exposure", account="ACC1")
+    assert pytest.approx(total_exposure, rel=1e-6) == pytest.approx(0.75, rel=1e-6)
+
+    total_realized = _metric_value(registry, "emp_account_total_realized_pnl", account="ACC1")
+    assert pytest.approx(total_realized, rel=1e-6) == pytest.approx(0.04, rel=1e-6)
+
+    total_unrealized = _metric_value(registry, "emp_account_total_unrealized_pnl", account="ACC1")
+    assert pytest.approx(total_unrealized, rel=1e-6) == pytest.approx(0.09, rel=1e-6)
+


### PR DESCRIPTION
## Summary
- add a Prometheus-compatible metrics publisher for order management positions and PnL
- allow the position tracker to push per-symbol and account aggregates to the metrics publisher
- cover the new metrics plumbing with a dedicated unit test and registry stub

## Testing
- pytest tests/trading/test_position_metrics_publisher.py

------
https://chatgpt.com/codex/tasks/task_e_68d95be6e074832cac2f19fcc6a8e4c5