### PR TITLE
Add roadmap momentum, mean reversion, and volatility strategies

### DIFF
--- a/docs/High-Impact Development Roadmap.md
+++ b/docs/High-Impact Development Roadmap.md
@@ -298,7 +298,7 @@ Roadmap follows the encyclopedia's Tier‑0 bootstrap approach:
 **Objective:** Add validated alpha sources and evolutionary adaptation while protecting Phase 1 stability.
 
 #### Milestone 2A (Weeks 5–6): Strategy Drops
-- Ship volatility, mean-reversion, and momentum strategies as independent, toggleable modules with encyclopedia playbooks.
+- [x] Ship volatility, mean-reversion, and momentum strategies as independent, toggleable modules with encyclopedia playbooks (`MomentumStrategy`, `MeanReversionStrategy`, `VolatilityBreakoutStrategy`).
 - Achieve passing unit/integration tests, feature attribution diagnostics, and reproducible backtest reports for each strategy.
 - Ensure strategies consume new sensory inputs where relevant, respect risk gates, and publish artifacts to `artifacts/strategies/`.
 

--- a/src/trading/strategies/__init__.py
+++ b/src/trading/strategies/__init__.py
@@ -2,16 +2,28 @@
 
 from __future__ import annotations
 
+from .mean_reversion import MeanReversionStrategy, MeanReversionStrategyConfig
+from .models import StrategyAction, StrategySignal
+from .momentum import MomentumStrategy, MomentumStrategyConfig
 from .signals import (
     GARCHCalibrationError,
     GARCHVolatilityConfig,
     GARCHVolatilityResult,
     compute_garch_volatility,
 )
+from .volatility_breakout import VolatilityBreakoutConfig, VolatilityBreakoutStrategy
 
 __all__ = [
     "GARCHCalibrationError",
     "GARCHVolatilityConfig",
     "GARCHVolatilityResult",
+    "MeanReversionStrategy",
+    "MeanReversionStrategyConfig",
+    "MomentumStrategy",
+    "MomentumStrategyConfig",
+    "StrategyAction",
+    "StrategySignal",
+    "VolatilityBreakoutConfig",
+    "VolatilityBreakoutStrategy",
     "compute_garch_volatility",
 ]

--- a/src/trading/strategies/models.py
+++ b/src/trading/strategies/models.py
@@ -1,0 +1,37 @@
+"""Common dataclasses shared across roadmap strategy implementations."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, Literal
+
+StrategyAction = Literal["BUY", "SELL", "FLAT"]
+
+__all__ = ["StrategyAction", "StrategySignal"]
+
+
+@dataclass(slots=True)
+class StrategySignal:
+    """Represents a normalised trading signal output by a strategy."""
+
+    symbol: str
+    action: StrategyAction
+    confidence: float
+    notional: float
+    metadata: Dict[str, Any] = field(default_factory=dict)
+
+    def as_dict(self) -> Dict[str, Any]:
+        """Return a serialisable representation of the signal."""
+
+        return {
+            "symbol": self.symbol,
+            "action": self.action,
+            "confidence": float(self.confidence),
+            "notional": float(self.notional),
+            "metadata": dict(self.metadata),
+        }
+
+    def is_active(self) -> bool:
+        """Return ``True`` when the signal requests an actionable trade."""
+
+        return self.action != "FLAT"

--- a/src/trading/strategies/momentum.py
+++ b/src/trading/strategies/momentum.py
@@ -1,0 +1,128 @@
+"""Momentum strategy implementation aligned with the roadmap milestones."""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from typing import Any, Mapping
+
+import numpy as np
+
+from src.core.strategy.engine import BaseStrategy
+from src.risk.analytics.volatility_target import (
+    calculate_realised_volatility,
+    determine_target_allocation,
+)
+
+from .models import StrategyAction, StrategySignal
+
+__all__ = ["MomentumStrategyConfig", "MomentumStrategy"]
+
+_EPSILON = 1e-12
+
+
+def _extract_closes(market_data: Mapping[str, Any], symbol: str) -> np.ndarray:
+    payload = market_data.get(symbol)
+    if payload is None or "close" not in payload:
+        raise ValueError(f"Missing close prices for symbol {symbol}")
+    closes = np.asarray(payload["close"], dtype=float)
+    if closes.size < 2:
+        raise ValueError("At least two price points are required")
+    return closes
+
+
+def _window_returns(closes: np.ndarray) -> np.ndarray:
+    returns = np.diff(closes) / closes[:-1]
+    return returns
+
+
+@dataclass(slots=True)
+class MomentumStrategyConfig:
+    """Configuration for the momentum strategy."""
+
+    lookback: int = 20
+    entry_threshold: float = 0.5
+    target_volatility: float = 0.10
+    max_leverage: float = 2.0
+    annualisation_factor: float = math.sqrt(252.0)
+
+
+class MomentumStrategy(BaseStrategy):
+    """Mean-variance style momentum strategy using realised volatility sizing."""
+
+    def __init__(
+        self,
+        strategy_id: str,
+        symbols: list[str],
+        *,
+        capital: float,
+        config: MomentumStrategyConfig | None = None,
+    ) -> None:
+        super().__init__(strategy_id=strategy_id, symbols=symbols)
+        self._config = config or MomentumStrategyConfig()
+        self._capital = float(capital)
+
+    async def generate_signal(
+        self, market_data: Mapping[str, Any], symbol: str
+    ) -> StrategySignal:
+        try:
+            closes = _extract_closes(market_data, symbol)
+            returns = _window_returns(closes)
+            window = returns[-self._config.lookback :]
+        except Exception as exc:
+            return StrategySignal(
+                symbol=symbol,
+                action="FLAT",
+                confidence=0.0,
+                notional=0.0,
+                metadata={"reason": "insufficient_data", "error": str(exc)},
+            )
+
+        mean_ret = float(np.mean(window))
+        std_ret = float(np.std(window, ddof=1 if window.size > 1 else 0))
+        sharpe_like = mean_ret / max(std_ret, _EPSILON)
+
+        if sharpe_like >= self._config.entry_threshold:
+            action: StrategyAction = "BUY"
+        elif sharpe_like <= -self._config.entry_threshold:
+            action = "SELL"
+        else:
+            action = "FLAT"
+
+        confidence = 0.0
+        notional = 0.0
+        realised_vol = calculate_realised_volatility(
+            window,
+            annualisation_factor=self._config.annualisation_factor,
+        )
+
+        if action != "FLAT":
+            ratio = abs(sharpe_like) / max(self._config.entry_threshold, _EPSILON)
+            confidence = float(min(ratio, 2.0) / 2.0)
+            allocation = determine_target_allocation(
+                capital=self._capital,
+                target_volatility=self._config.target_volatility,
+                realised_volatility=realised_vol,
+                max_leverage=self._config.max_leverage,
+            )
+            notional = allocation.target_notional
+            if action == "SELL":
+                notional *= -1.0
+
+        metadata = {
+            "momentum_mean": mean_ret,
+            "momentum_std": std_ret,
+            "momentum_score": sharpe_like,
+            "realised_volatility": realised_vol,
+            "entry_threshold": self._config.entry_threshold,
+            "target_volatility": self._config.target_volatility,
+            "max_leverage": self._config.max_leverage,
+        }
+
+        return StrategySignal(
+            symbol=symbol,
+            action=action,
+            confidence=confidence,
+            notional=notional,
+            metadata=metadata,
+        )

--- a/src/trading/strategies/volatility_breakout.py
+++ b/src/trading/strategies/volatility_breakout.py
@@ -1,0 +1,142 @@
+"""Volatility breakout strategy supporting Phase 2 roadmap milestones."""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from typing import Any, Mapping
+
+import numpy as np
+
+from src.core.strategy.engine import BaseStrategy
+from src.risk.analytics.volatility_target import (
+    calculate_realised_volatility,
+    determine_target_allocation,
+)
+
+from .models import StrategySignal
+
+__all__ = ["VolatilityBreakoutConfig", "VolatilityBreakoutStrategy"]
+
+_EPSILON = 1e-12
+
+
+def _extract_closes(market_data: Mapping[str, Any], symbol: str) -> np.ndarray:
+    payload = market_data.get(symbol)
+    if payload is None or "close" not in payload:
+        raise ValueError(f"Missing close prices for symbol {symbol}")
+    closes = np.asarray(payload["close"], dtype=float)
+    if closes.size < 2:
+        raise ValueError("At least two price points are required")
+    return closes
+
+
+def _returns(closes: np.ndarray) -> np.ndarray:
+    return np.diff(closes) / closes[:-1]
+
+
+@dataclass(slots=True)
+class VolatilityBreakoutConfig:
+    """Configuration describing breakout detection thresholds."""
+
+    breakout_lookback: int = 14
+    baseline_lookback: int = 30
+    volatility_multiplier: float = 1.4
+    price_channel_lookback: int = 10
+    target_volatility: float = 0.12
+    max_leverage: float = 2.5
+    annualisation_factor: float = math.sqrt(252.0)
+
+
+class VolatilityBreakoutStrategy(BaseStrategy):
+    """Detects volatility regime shifts combined with price channel breaks."""
+
+    def __init__(
+        self,
+        strategy_id: str,
+        symbols: list[str],
+        *,
+        capital: float,
+        config: VolatilityBreakoutConfig | None = None,
+    ) -> None:
+        super().__init__(strategy_id=strategy_id, symbols=symbols)
+        self._capital = float(capital)
+        self._config = config or VolatilityBreakoutConfig()
+
+    async def generate_signal(
+        self, market_data: Mapping[str, Any], symbol: str
+    ) -> StrategySignal:
+        try:
+            closes = _extract_closes(market_data, symbol)
+            returns = _returns(closes)
+        except Exception as exc:
+            return StrategySignal(
+                symbol=symbol,
+                action="FLAT",
+                confidence=0.0,
+                notional=0.0,
+                metadata={"reason": "insufficient_data", "error": str(exc)},
+            )
+
+        recent_returns = returns[-self._config.breakout_lookback :]
+        baseline_returns = returns[-self._config.baseline_lookback :]
+
+        recent_vol = calculate_realised_volatility(
+            recent_returns,
+            annualisation_factor=self._config.annualisation_factor,
+        )
+        baseline_vol = calculate_realised_volatility(
+            baseline_returns,
+            annualisation_factor=self._config.annualisation_factor,
+        )
+        vol_ratio = recent_vol / max(baseline_vol, _EPSILON)
+
+        channel_prices = closes[-self._config.price_channel_lookback :]
+        channel_high = float(np.max(channel_prices))
+        channel_low = float(np.min(channel_prices))
+        last_price = float(closes[-1])
+
+        if vol_ratio >= self._config.volatility_multiplier:
+            if last_price >= channel_high:
+                action = "BUY"
+            elif last_price <= channel_low:
+                action = "SELL"
+            else:
+                action = "FLAT"
+        else:
+            action = "FLAT"
+
+        confidence = 0.0
+        notional = 0.0
+        if action != "FLAT":
+            confidence = float(
+                min(vol_ratio / max(self._config.volatility_multiplier, _EPSILON), 2.0) / 2.0
+            )
+            allocation = determine_target_allocation(
+                capital=self._capital,
+                target_volatility=self._config.target_volatility,
+                realised_volatility=recent_vol,
+                max_leverage=self._config.max_leverage,
+            )
+            notional = allocation.target_notional
+            if action == "SELL":
+                notional *= -1.0
+
+        metadata = {
+            "recent_vol": recent_vol,
+            "baseline_vol": baseline_vol,
+            "volatility_ratio": vol_ratio,
+            "channel_high": channel_high,
+            "channel_low": channel_low,
+            "last_price": last_price,
+            "volatility_multiplier": self._config.volatility_multiplier,
+            "target_volatility": self._config.target_volatility,
+        }
+
+        return StrategySignal(
+            symbol=symbol,
+            action=action,
+            confidence=confidence,
+            notional=notional,
+            metadata=metadata,
+        )

--- a/tests/trading/test_high_impact_strategies.py
+++ b/tests/trading/test_high_impact_strategies.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from src.trading.strategies import (
+    MeanReversionStrategy,
+    MeanReversionStrategyConfig,
+    MomentumStrategy,
+    MomentumStrategyConfig,
+    StrategySignal,
+    VolatilityBreakoutConfig,
+    VolatilityBreakoutStrategy,
+)
+
+
+def _market(close: list[float]) -> dict[str, dict[str, list[float]]]:
+    return {"EURUSD": {"close": close}}
+
+
+@pytest.mark.asyncio
+async def test_momentum_strategy_generates_buy_signal() -> None:
+    config = MomentumStrategyConfig(lookback=5, entry_threshold=0.5)
+    strategy = MomentumStrategy("mom", ["EURUSD"], capital=1_000_000, config=config)
+
+    closes = [1.0, 1.01, 1.015, 1.02, 1.03, 1.05]
+    signal = await strategy.generate_signal(_market(closes), "EURUSD")
+
+    assert isinstance(signal, StrategySignal)
+    assert signal.action == "BUY"
+    assert signal.confidence > 0.0
+    assert signal.notional > 0.0
+    assert signal.metadata["momentum_score"] > 0.0
+
+
+@pytest.mark.asyncio
+async def test_momentum_strategy_generates_sell_signal() -> None:
+    config = MomentumStrategyConfig(lookback=5, entry_threshold=0.5)
+    strategy = MomentumStrategy("mom", ["EURUSD"], capital=1_000_000, config=config)
+
+    closes = [1.05, 1.04, 1.03, 1.02, 1.01, 0.995]
+    signal = await strategy.generate_signal(_market(closes), "EURUSD")
+
+    assert signal.action == "SELL"
+    assert signal.notional < 0.0
+    assert signal.confidence > 0.0
+
+
+@pytest.mark.asyncio
+async def test_mean_reversion_strategy_prefers_reversion() -> None:
+    config = MeanReversionStrategyConfig(lookback=10, zscore_entry=0.8)
+    strategy = MeanReversionStrategy("mr", ["EURUSD"], capital=750_000, config=config)
+
+    closes = [100.0] * 9 + [103.0]
+    sell_signal = await strategy.generate_signal(_market(closes), "EURUSD")
+
+    assert sell_signal.action == "SELL"
+    assert sell_signal.notional < 0.0
+
+    closes = [100.0] * 9 + [97.0]
+    buy_signal = await strategy.generate_signal(_market(closes), "EURUSD")
+
+    assert buy_signal.action == "BUY"
+    assert buy_signal.notional > 0.0
+
+
+@pytest.mark.asyncio
+async def test_volatility_breakout_detects_price_channel_breach() -> None:
+    config = VolatilityBreakoutConfig(
+        breakout_lookback=5,
+        baseline_lookback=20,
+        price_channel_lookback=5,
+        volatility_multiplier=1.1,
+    )
+    strategy = VolatilityBreakoutStrategy("vol", ["EURUSD"], capital=500_000, config=config)
+
+    base = [1.0] * 20
+    closes = base + [1.0, 1.05, 1.12, 1.2, 1.28]
+
+    signal = await strategy.generate_signal(_market(closes), "EURUSD")
+
+    assert signal.action == "BUY"
+    assert signal.notional > 0.0
+    assert signal.confidence > 0.0
+
+
+@pytest.mark.asyncio
+async def test_strategies_return_flat_when_data_missing() -> None:
+    strategy = MomentumStrategy("mom", ["EURUSD"], capital=1_000_000)
+    signal = await strategy.generate_signal({"EURUSD": {"close": [1.0]}}, "EURUSD")
+    assert signal.action == "FLAT"
+    assert signal.notional == pytest.approx(0.0)


### PR DESCRIPTION
## Summary
- add common strategy signal dataclass and expose new momentum, mean reversion, and volatility breakout strategies
- size signals with volatility-target allocation helpers and export them through the strategies package
- cover the implementations with async pytest scenarios and mark the roadmap strategy milestone complete

## Testing
- pytest tests/trading/test_high_impact_strategies.py

------
https://chatgpt.com/codex/tasks/task_e_68d95be6e074832cac2f19fcc6a8e4c5