### PR TITLE
Expose JSON formatter for high-impact roadmap

### DIFF
--- a/tests/tools/test_high_impact_roadmap.py
+++ b/tests/tools/test_high_impact_roadmap.py
@@ -39,7 +39,7 @@ def test_markdown_formatter_outputs_table() -> None:
 
 def test_json_format_includes_evidence() -> None:
     statuses = high_impact.evaluate_streams()
-    payload = json.loads(high_impact._format_json(statuses))
+    payload = json.loads(high_impact.format_json(statuses))
 
     assert isinstance(payload, list)
     assert payload[0]["evidence"], "expected evidence list in JSON output"

--- a/tools/roadmap/high_impact.py
+++ b/tools/roadmap/high_impact.py
@@ -257,8 +257,23 @@ def format_detail(statuses: Iterable[StreamStatus]) -> str:
     return "\n".join(lines).rstrip()
 
 
-def _format_json(statuses: Iterable[StreamStatus]) -> str:
+def format_json(statuses: Iterable[StreamStatus]) -> str:
+    """Return a JSON payload describing the stream statuses.
+
+    The high-impact roadmap report feeds both docs and automation.  External
+    tooling previously had to reach for the private ``_format_json`` helper to
+    reuse the CLI output.  Exposing this public helper keeps those consumers out
+    of the private namespace while preserving a single implementation shared by
+    the CLI and tests.
+    """
+
     return json.dumps([asdict(status) for status in statuses], indent=2)
+
+
+def _format_json(statuses: Iterable[StreamStatus]) -> str:
+    """Backward-compatible alias for :func:`format_json`."""
+
+    return format_json(statuses)
 
 
 def main(argv: Sequence[str] | None = None) -> int:
@@ -280,7 +295,7 @@ def main(argv: Sequence[str] | None = None) -> int:
 
     statuses = evaluate_streams()
     if args.format == "json":
-        output = _format_json(statuses)
+        output = format_json(statuses)
     elif args.format == "detail":
         output = format_detail(statuses)
     else:


### PR DESCRIPTION
## Summary
- add a public JSON formatter for high-impact roadmap stream statuses while keeping the private helper as an alias for backwards compatibility
- update the CLI and tests to rely on the new formatter so downstream tooling can avoid private APIs

## Testing
- pytest tests/tools/test_high_impact_roadmap.py


------
https://chatgpt.com/codex/tasks/task_e_68d95be6e074832cac2f19fcc6a8e4c5