### PR TITLE
Expand high-impact roadmap coverage

### DIFF
--- a/docs/status/high_impact_roadmap_detail.md
+++ b/docs/status/high_impact_roadmap_detail.md
@@ -19,6 +19,8 @@
 - operations.data_backbone.evaluate_data_backbone_readiness
 - operations.ingest_trends.evaluate_ingest_trends
 - data_foundation.ingest.failover.decide_ingest_failover
+- operations.backup.evaluate_backup_readiness
+- operations.spark_stress.execute_spark_stress_drill
 
 ## Stream B – Sensory cortex & evolution uplift
 
@@ -33,6 +35,7 @@
 - sensory.anomaly.anomaly_sensor.AnomalySensor
 - sensory.when.gamma_exposure.GammaExposureAnalyzer
 - sensory.why.why_sensor.WhySensor
+- sensory.what.what_sensor.WhatSensor
 - operations.sensory_drift.evaluate_sensory_drift
 - genome.catalogue.load_default_catalogue
 - evolution.lineage_telemetry.EvolutionLineageSnapshot

--- a/tests/tools/test_high_impact_roadmap.py
+++ b/tests/tools/test_high_impact_roadmap.py
@@ -29,6 +29,25 @@ def test_streams_marked_ready() -> None:
         assert status.evidence, "expected evidence for ready streams"
 
 
+def test_stream_a_includes_resilience_requirements() -> None:
+    status = _status_map()["Stream A – Institutional data backbone"]
+
+    assert "operations.backup.evaluate_backup_readiness" in status.evidence
+    assert "operations.spark_stress.execute_spark_stress_drill" in status.evidence
+
+
+def test_stream_b_lists_all_sensory_organs() -> None:
+    status = _status_map()["Stream B – Sensory cortex & evolution uplift"]
+
+    assert {
+        "sensory.how.how_sensor.HowSensor",
+        "sensory.anomaly.anomaly_sensor.AnomalySensor",
+        "sensory.when.gamma_exposure.GammaExposureAnalyzer",
+        "sensory.why.why_sensor.WhySensor",
+        "sensory.what.what_sensor.WhatSensor",
+    }.issubset(status.evidence)
+
+
 def test_markdown_formatter_outputs_table() -> None:
     statuses = high_impact.evaluate_streams()
     markdown = high_impact.format_markdown(statuses)

--- a/tools/roadmap/high_impact.py
+++ b/tools/roadmap/high_impact.py
@@ -110,6 +110,14 @@ def _stream_definitions() -> Sequence[StreamDefinition]:
                     "data_foundation.ingest.failover",
                     "decide_ingest_failover",
                 ),
+                require_module_attr(
+                    "operations.backup",
+                    "evaluate_backup_readiness",
+                ),
+                require_module_attr(
+                    "operations.spark_stress",
+                    "execute_spark_stress_drill",
+                ),
             ),
         ),
         StreamDefinition(
@@ -132,6 +140,7 @@ def _stream_definitions() -> Sequence[StreamDefinition]:
                     "sensory.when.gamma_exposure", "GammaExposureAnalyzer"
                 ),
                 require_module_attr("sensory.why.why_sensor", "WhySensor"),
+                require_module_attr("sensory.what.what_sensor", "WhatSensor"),
                 require_module_attr(
                     "operations.sensory_drift", "evaluate_sensory_drift"
                 ),


### PR DESCRIPTION
## Summary
- extend the high-impact roadmap CLI so Stream A verifies backup readiness and Spark stress drill helpers
- require the roadmap to recognise the WHAT sensory organ to keep all five sensors accounted for
- refresh the published detail status report and add regression tests for the new evidence items

## Testing
- pytest tests/tools/test_high_impact_roadmap.py -q

------
https://chatgpt.com/codex/tasks/task_e_68d95e0c1138832c8fa3b6ee38901e97