### PR TITLE
Implement data bootstrap workflow and incident template

### DIFF
--- a/docs/High-Impact Development Roadmap.md
+++ b/docs/High-Impact Development Roadmap.md
@@ -128,7 +128,7 @@ To reflect the true scope of institutional-grade trading components, the roadmap
 - [ ] Document operational runbooks in `/docs/runbooks/` and update encyclopedia cross-references.
 - [ ] Ensure paper-trading mode (`scripts/paper_trade_dry_run.py`) logs parity with live flow (no new paper broker abstraction required).
 - [ ] Mirror encyclopedia's "Operations Nerve Center" by adding health-check endpoints for FIX, data feeds, and risk engines.
-- [ ] Add incident postmortem template aligned with Encyclopedia Appendix F and store under `/docs/runbooks/templates/`.
+- [x] Add incident postmortem template aligned with Encyclopedia Appendix F and store under `/docs/runbooks/templates/`.
 - [ ] Wire structured logs into a local OpenTelemetry collector with exporters defined in `config/observability/`.
 
 **Acceptance:** Operators can observe intraday PnL and order health; runbooks cover recovery steps; logging/tests cover happy-path and failure-path scenarios.
@@ -140,7 +140,7 @@ To reflect the true scope of institutional-grade trading components, the roadmap
 - [ ] Implement reference data loader for instruments, sessions, and holidays referenced in Encyclopedia Layer 1 specs.
 - [ ] Add data quality validators (missing candles, stale prices, split/dividend adjustments) with alerts feeding Workstream 1C dashboard.
 - [ ] Cache normalized datasets in `data_foundation/cache/` with retention policies documented for Tier-0 bootstrap.
-- [ ] Ship `scripts/data_bootstrap.py` to hydrate local env and CI with canonical fixtures used by sensors and strategies.
+- [x] Ship `scripts/data_bootstrap.py` to hydrate local env and CI with canonical fixtures used by sensors and strategies.
 - [ ] Cross-link encyclopedia tables for free-vs-premium data trade-offs within `/docs/runbooks/data_foundation.md`.
 
 **Acceptance:** Canonical datasets load without manual intervention; validators surface anomalies; encyclopedia data lineage references stay in sync with implementation.

--- a/docs/runbooks/templates/incident_postmortem_template.md
+++ b/docs/runbooks/templates/incident_postmortem_template.md
@@ -1,0 +1,73 @@
+# Incident Postmortem Template (EMP Encyclopedia Appendix F Alignment)
+
+> **Purpose:** Provide a structured, repeatable format for antifragile
+> operations reviews. Fill within 24 hours of incident close and link the
+> completed document in the Ops Command dashboard.
+
+## 1. Executive Summary
+- **Incident ID:** <!-- e.g. 2025-01-17_FIX_ORDER_STALL -->
+- **Severity:** <!-- Critical | High | Medium | Low -->
+- **Start Time (UTC):**
+- **End Time (UTC):**
+- **Detected By:** <!-- Sensor, alert, operator -->
+- **Primary Owner:**
+- **Status:** <!-- Resolved | Monitoring | Follow-up Required -->
+- **High-Level Summary:** <!-- 1-2 sentences describing symptom & resolution -->
+
+## 2. Impact Assessment
+- **Systems Affected:** <!-- Trading runtime, ingest, risk engine, etc. -->
+- **Client / Capital Impact:** <!-- Quantify PnL, orders blocked, exposure -->
+- **SLO Breach:** <!-- Yes/No, reference SLO metrics -->
+- **Encyclopedia Cross-Refs:** <!-- e.g. Appendix F §2.1 (Incident Taxonomy) -->
+
+## 3. Timeline of Events
+| Timestamp (UTC) | Actor | Event Description |
+|-----------------|-------|-------------------|
+| <!-- 2025-01-17T10:02:11Z --> | <!-- FIX monitor --> | <!-- Alert fired for missing fills --> |
+|  |  |  |
+
+> Include detection, escalations, mitigation attempts, decisions, and recovery.
+> Annotate whether the step was automated, manual, or hybrid.
+
+## 4. Root Cause Analysis (RCA)
+1. **Symptom:** <!-- Observable effect -->
+2. **Proximate Cause:** <!-- Immediate trigger -->
+3. **Contributing Factors:** <!-- Latency, config drift, vendor outage -->
+4. **Systemic Root Cause:** <!-- Map to Encyclopedia Appendix F failure modes -->
+5. **Why Chain:** <!-- 3-5 Whys leading to systemic cause -->
+
+## 5. Mitigation & Recovery
+- **Immediate Actions Taken:** <!-- Fixes applied during incident -->
+- **Risk Mitigations Triggered:** <!-- Circuit breakers, hedges, kill-switch -->
+- **State Validation:** <!-- Reconciliation scripts, order lifecycle dry-run -->
+- **Residual Risk:** <!-- Remaining exposure and monitoring plan -->
+
+## 6. Preventative Actions & Follow-Up
+| Action Item | Owner | Due Date | Status | Notes |
+|-------------|-------|----------|--------|-------|
+| <!-- Harden FIX heartbeat thresholds --> | <!-- ops@ --> | <!-- 2025-01-24 --> | <!-- In Progress --> |  |
+
+- **Capital Efficiency Memo Link:** <!-- If incident impacted budgets -->
+- **Documentation Updates:** <!-- Runbooks, encyclopedia chapters, config -->
+- **Automation Opportunities:** <!-- Tests, alerts, dashboards -->
+
+## 7. Communications
+- **Stakeholder Notifications:** <!-- Clients, leadership, vendors -->
+- **Public Disclosure:** <!-- Blog, status page, regulatory filings -->
+- **Postmortem Review Date:** <!-- When the team will review the document -->
+
+## 8. Attachments & Evidence
+- **Order Event Journal Snapshot:** <!-- Path to data_foundation/events/... -->
+- **Position Reconciliation Report:** <!-- Path to scripts/reconcile_positions output -->
+- **Latency Metrics Export:** <!-- Grafana / Prometheus query link -->
+- **Additional Artefacts:** <!-- Logs, dashboards, GA results -->
+
+## 9. Lessons Learned
+- **What worked well:** <!-- Processes/tools that reduced impact -->
+- **What needs improvement:** <!-- Gaps found in detection or response -->
+- **Encyclopedia Alignment:** <!-- Reinstate antifragile principles strengthened -->
+
+---
+
+*Template version 1.0 — maintained in `/docs/runbooks/templates/`. Submit
+improvements via PR referencing the relevant roadmap workstream.*

--- a/scripts/data_bootstrap.py
+++ b/scripts/data_bootstrap.py
@@ -1,0 +1,279 @@
+"""Hydrate canonical pricing datasets for sensors, strategies, and tests.
+
+This CLI delivers the roadmap requirement for a repeatable "data bootstrap"
+step that seeds local development and CI environments with normalised OHLCV
+fixtures.  It wraps :class:`src.data_foundation.pipelines.pricing_pipeline.PricingPipeline`
+so all vendor implementations share a single validation and formatting path.
+
+Key features:
+* Supports live vendor fetches (default Yahoo) as well as deterministic file
+  based sources for offline runs.
+* Emits canonical Parquet/CSV artefacts alongside JSON metadata so pipelines
+  and documentation can reference reproducible inputs.
+* Surfaces data-quality findings returned by the pricing pipeline and can
+  optionally fail the run when critical issues are detected.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Iterable, Mapping
+
+import pandas as pd
+
+from src.data_foundation.pipelines.pricing_pipeline import (
+    PricingPipeline,
+    PricingPipelineConfig,
+    PricingPipelineResult,
+    PricingQualityIssue,
+    PricingVendor,
+)
+
+
+class _FilePricingVendor:
+    """Minimal vendor adapter that reads pre-downloaded datasets from disk."""
+
+    def __init__(self, path: Path) -> None:
+        self._path = path
+
+    def fetch(self, config: PricingPipelineConfig) -> pd.DataFrame:  # noqa: D401 - protocol match
+        if not self._path.exists():
+            raise FileNotFoundError(f"Source dataset not found: {self._path}")
+
+        suffix = self._path.suffix.lower()
+        if suffix in {".csv", ".txt"}:
+            return pd.read_csv(self._path)
+        if suffix in {".parquet", ".pq"}:
+            return pd.read_parquet(self._path)
+        if suffix in {".json", ".jsonl"}:
+            lines = [json.loads(line) for line in self._path.read_text().splitlines() if line.strip()]
+            return pd.DataFrame.from_records(lines)
+
+        raise ValueError(
+            "Unsupported file extension for pricing vendor: "
+            f"{self._path.suffix}. Expected csv, parquet, or json"
+        )
+
+
+def _parse_symbols(symbols: str | None) -> list[str]:
+    if not symbols:
+        return []
+    return [sym.strip() for sym in symbols.split(",") if sym.strip()]
+
+
+def _parse_datetime(value: str | None) -> datetime | None:
+    if not value:
+        return None
+    try:
+        parsed = datetime.fromisoformat(value)
+    except ValueError as exc:  # pragma: no cover - defensive for CLI misuse
+        raise argparse.ArgumentTypeError(f"Invalid datetime format: {value}") from exc
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def _write_dataframe(
+    frame: pd.DataFrame,
+    output_dir: Path,
+    *,
+    vendor: str,
+    interval: str,
+    preferred_format: str,
+) -> Path:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    base_name = f"pricing_{vendor}_{interval}"
+
+    fmt = preferred_format.lower()
+    if fmt not in {"parquet", "csv"}:
+        raise ValueError(f"Unsupported output format: {preferred_format}")
+
+    if fmt == "parquet":
+        parquet_path = output_dir / f"{base_name}.parquet"
+        try:
+            frame.to_parquet(parquet_path, index=False)
+            return parquet_path
+        except Exception as exc:
+            print(
+                f"[WARN] Failed to write parquet ({exc}). Falling back to CSV.",
+                file=sys.stderr,
+            )
+            fmt = "csv"
+
+    csv_path = output_dir / f"{base_name}.csv"
+    frame.to_csv(csv_path, index=False)
+    return csv_path
+
+
+def _issues_payload(issues: Iterable[PricingQualityIssue]) -> list[Mapping[str, object]]:
+    payload: list[Mapping[str, object]] = []
+    for issue in issues:
+        record = {
+            "code": issue.code,
+            "severity": issue.severity,
+            "message": issue.message,
+            "symbol": issue.symbol,
+            "context": dict(issue.context),
+        }
+        payload.append(record)
+    return payload
+
+
+def _write_json(path: Path, payload: Mapping[str, object]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as fh:
+        json.dump(payload, fh, indent=2, sort_keys=True)
+
+
+def _run_pipeline(args: argparse.Namespace) -> PricingPipelineResult:
+    symbols = _parse_symbols(args.symbols)
+    config = PricingPipelineConfig(
+        symbols=symbols,
+        vendor=args.vendor,
+        interval=args.interval,
+        lookback_days=args.lookback_days,
+        start=_parse_datetime(args.start),
+        end=_parse_datetime(args.end),
+        minimum_coverage_ratio=args.minimum_coverage,
+    )
+
+    vendor_registry: dict[str, PricingVendor] = {}
+    if args.source_path is not None:
+        vendor_registry[args.vendor] = _FilePricingVendor(Path(args.source_path))
+
+    pipeline = PricingPipeline(vendor_registry=vendor_registry)
+    return pipeline.run(config)
+
+
+def run(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--symbols",
+        type=str,
+        default="EURUSD=X,GBPUSD=X,USDJPY=X",
+        help="Comma-separated list of symbols to fetch",
+    )
+    parser.add_argument(
+        "--vendor",
+        type=str,
+        default="yahoo",
+        help="Registered pricing vendor (default: yahoo)",
+    )
+    parser.add_argument(
+        "--interval",
+        type=str,
+        default="1d",
+        help="Bar interval requested from the vendor",
+    )
+    parser.add_argument(
+        "--lookback-days",
+        type=int,
+        default=90,
+        help="Historical window (in days) to request when start/end not provided",
+    )
+    parser.add_argument("--start", type=str, default=None, help="ISO timestamp for start window")
+    parser.add_argument("--end", type=str, default=None, help="ISO timestamp for end window")
+    parser.add_argument(
+        "--minimum-coverage",
+        type=float,
+        default=0.6,
+        help="Minimum ratio of expected candles required before surfacing a warning",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=Path("data_foundation/cache/pricing"),
+        help="Directory where artefacts will be written",
+    )
+    parser.add_argument(
+        "--format",
+        type=str,
+        choices=["parquet", "csv"],
+        default="parquet",
+        help="Preferred output dataset format",
+    )
+    parser.add_argument(
+        "--source-path",
+        type=Path,
+        default=None,
+        help="Optional pre-downloaded dataset used instead of fetching from a vendor",
+    )
+    parser.add_argument(
+        "--metadata-path",
+        type=Path,
+        default=None,
+        help="Optional explicit path for metadata JSON (defaults to <output>/pricing_metadata.json)",
+    )
+    parser.add_argument(
+        "--issues-path",
+        type=Path,
+        default=None,
+        help="Optional explicit path for issues JSON (defaults to <output>/pricing_issues.json)",
+    )
+    parser.add_argument(
+        "--fail-on-quality",
+        action="store_true",
+        help="Exit with status 2 if the pipeline reports error-severity issues",
+    )
+
+    args = parser.parse_args(argv)
+
+    try:
+        result = _run_pipeline(args)
+    except Exception as exc:  # pragma: no cover - CLI level guard
+        print(f"[ERROR] Failed to run pricing pipeline: {exc}", file=sys.stderr)
+        return 1
+
+    dataset_path = _write_dataframe(
+        result.data,
+        args.output,
+        vendor=args.vendor,
+        interval=args.interval,
+        preferred_format=args.format,
+    )
+
+    metadata = {
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "dataset_path": str(dataset_path),
+        "row_count": int(len(result.data)),
+        "symbols": list(result.symbols()),
+        "result_metadata": dict(result.metadata),
+    }
+
+    metadata_path = args.metadata_path or args.output / "pricing_metadata.json"
+    _write_json(metadata_path, metadata)
+
+    issues_payload = _issues_payload(result.issues)
+    issues_path = args.issues_path or args.output / "pricing_issues.json"
+    _write_json(issues_path, {"issues": issues_payload})
+
+    quality_errors = [issue for issue in result.issues if issue.severity.lower() == "error"]
+
+    summary = {
+        "dataset": str(dataset_path),
+        "rows": metadata["row_count"],
+        "symbols": metadata["symbols"],
+        "issues": issues_payload,
+    }
+    print(json.dumps(summary, indent=2))
+
+    if quality_errors and args.fail_on_quality:
+        print(
+            f"[ERROR] {len(quality_errors)} quality issues reported; failing per --fail-on-quality",
+            file=sys.stderr,
+        )
+        return 2
+
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    return run(argv)
+
+
+if __name__ == "__main__":  # pragma: no cover - exercised via CLI execution
+    raise SystemExit(main())

--- a/tests/scripts/test_data_bootstrap.py
+++ b/tests/scripts/test_data_bootstrap.py
@@ -1,0 +1,141 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+import pandas as pd
+
+
+def _load_module():
+    module_path = Path(__file__).resolve().parents[2] / "scripts" / "data_bootstrap.py"
+    spec = importlib.util.spec_from_file_location("scripts.data_bootstrap", module_path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec and spec.loader
+    spec.loader.exec_module(module)  # type: ignore[attr-defined]
+    return module
+
+
+def test_data_bootstrap_generates_pricing_artifacts(tmp_path):
+    module = _load_module()
+
+    raw = pd.DataFrame(
+        [
+            {
+                "timestamp": "2024-01-01T00:00:00Z",
+                "symbol": "EURUSD",
+                "open": 1.05,
+                "high": 1.06,
+                "low": 1.04,
+                "close": 1.055,
+                "adj_close": 1.055,
+                "volume": 1234,
+            },
+            {
+                "timestamp": "2024-01-02T00:00:00Z",
+                "symbol": "EURUSD",
+                "open": 1.06,
+                "high": 1.07,
+                "low": 1.05,
+                "close": 1.065,
+                "adj_close": 1.065,
+                "volume": 1500,
+            },
+        ]
+    )
+
+    source_path = tmp_path / "input.csv"
+    raw.to_csv(source_path, index=False)
+
+    output_dir = tmp_path / "output"
+    exit_code = module.main(
+        [
+            "--vendor",
+            "file",
+            "--source-path",
+            str(source_path),
+            "--symbols",
+            "EURUSD",
+            "--output",
+            str(output_dir),
+            "--format",
+            "csv",
+            "--minimum-coverage",
+            "0.1",
+        ]
+    )
+
+    assert exit_code == 0
+
+    dataset_path = output_dir / "pricing_file_1d.csv"
+    assert dataset_path.exists()
+    dataset = pd.read_csv(dataset_path)
+    assert list(dataset.columns) == [
+        "timestamp",
+        "symbol",
+        "open",
+        "high",
+        "low",
+        "close",
+        "adj_close",
+        "volume",
+        "source",
+    ]
+    assert set(dataset["symbol"]) == {"EURUSD"}
+
+    metadata_path = output_dir / "pricing_metadata.json"
+    issues_path = output_dir / "pricing_issues.json"
+    assert metadata_path.exists()
+    assert issues_path.exists()
+
+    metadata = json.loads(metadata_path.read_text())
+    assert metadata["row_count"] == 2
+    assert metadata["symbols"] == ["EURUSD"]
+
+    issues = json.loads(issues_path.read_text())
+    assert "issues" in issues
+
+
+def test_fail_on_quality_surfaces_error(tmp_path):
+    module = _load_module()
+
+    empty_frame = pd.DataFrame(
+        columns=[
+            "timestamp",
+            "symbol",
+            "open",
+            "high",
+            "low",
+            "close",
+            "adj_close",
+            "volume",
+        ]
+    )
+    source_path = tmp_path / "empty.csv"
+    empty_frame.to_csv(source_path, index=False)
+
+    output_dir = tmp_path / "output"
+    exit_code = module.main(
+        [
+            "--vendor",
+            "file",
+            "--source-path",
+            str(source_path),
+            "--symbols",
+            "EURUSD",
+            "--output",
+            str(output_dir),
+            "--fail-on-quality",
+            "--minimum-coverage",
+            "0.1",
+            "--format",
+            "csv",
+        ]
+    )
+
+    assert exit_code == 2
+
+    issues_path = output_dir / "pricing_issues.json"
+    assert issues_path.exists()
+    issues = json.loads(issues_path.read_text())["issues"]
+    assert any(issue["code"] == "no_data" for issue in issues)


### PR DESCRIPTION
## Summary
- add a `scripts/data_bootstrap.py` CLI to normalise pricing data, emit metadata, and support offline sources
- exercise the bootstrap workflow with focused pytest coverage
- provide an incident postmortem template runbook and mark the roadmap items as complete

## Testing
- pytest tests/scripts/test_data_bootstrap.py

------
https://chatgpt.com/codex/tasks/task_e_68d95e0c1138832c8fa3b6ee38901e97