### PR TITLE
Automate high-impact roadmap doc refresh

### DIFF
--- a/docs/status/high_impact_roadmap.md
+++ b/docs/status/high_impact_roadmap.md
@@ -8,11 +8,20 @@ before demos or reviews:
 python -m tools.roadmap.high_impact --format markdown
 ```
 
+To update both this summary and the detailed evidence companion file in one
+shot, use the refresh flag:
+
+```bash
+python -m tools.roadmap.high_impact --refresh-docs
+```
+
+<!-- HIGH_IMPACT_SUMMARY:START -->
 | Stream | Status | Summary | Next checkpoint |
 | --- | --- | --- | --- |
 | Stream A – Institutional data backbone | Ready | Timescale ingest, Redis caching, Kafka streaming, and Spark exports ship with readiness telemetry and failover tooling. | Exercise cross-region failover and automated scheduler cutover using the readiness feeds. |
 | Stream B – Sensory cortex & evolution uplift | Ready | All five sensory organs operate with drift telemetry and catalogue-backed evolution lineage exports. | Extend live-paper experiments and automated tuning loops using evolution telemetry. |
 | Stream C – Execution, risk, compliance, ops readiness | Ready | FIX pilots, risk/compliance workflows, ROI telemetry, and operational readiness publish evidence for operators. | Expand broker connectivity with drop-copy reconciliation and extend regulatory telemetry coverage. |
+<!-- HIGH_IMPACT_SUMMARY:END -->
 
 For narrative reports or dashboards, export the detailed format to a companion
 file:


### PR DESCRIPTION
## Summary
- add a summary-table injection helper and refresh_docs routine to tools.roadmap.high_impact, wiring it to a new --refresh-docs CLI flag
- update docs/status/high_impact_roadmap.md with automation markers and instructions for the refresh workflow
- cover the documentation refresh helper with focused pytest cases

## Testing
- pytest tests/tools/test_high_impact_roadmap.py

------
https://chatgpt.com/codex/tasks/task_e_68d95e0c1138832c8fa3b6ee38901e97