### PR TITLE
Add performance attribution analytics for strategies

### DIFF
--- a/docs/High-Impact Development Roadmap.md
+++ b/docs/High-Impact Development Roadmap.md
@@ -166,7 +166,7 @@ To reflect the true scope of institutional-grade trading components, the roadmap
   - [ ] Add scenario backtests demonstrating uplift vs baseline MA strategy.
 - **Alpha Ops**
   - [ ] Document encyclopedia-aligned playbooks for each strategy archetype, including regime suitability.
-  - [ ] Register feature importance & diagnostics pipeline in `src/strategies/analytics/performance_attribution.py`.
+  - [x] Register feature importance & diagnostics pipeline in `src/trading/strategies/analytics/performance_attribution.py`.
   - [ ] Store canonical backtest artifacts (equity curve, risk metrics, configs) under `artifacts/strategies/` for reproducibility.
 
 **Acceptance:** Each strategy passes unit/integration tests, is documented, and can be toggled via configuration.

--- a/src/trading/strategies/__init__.py
+++ b/src/trading/strategies/__init__.py
@@ -2,6 +2,12 @@
 
 from __future__ import annotations
 
+from .analytics import (
+    AttributionResult,
+    FeatureContribution,
+    compute_performance_attribution,
+    result_to_dataframe,
+)
 from .mean_reversion import MeanReversionStrategy, MeanReversionStrategyConfig
 from .models import StrategyAction, StrategySignal
 from .momentum import MomentumStrategy, MomentumStrategyConfig
@@ -15,6 +21,8 @@ from .signals import (
 from .volatility_breakout import VolatilityBreakoutConfig, VolatilityBreakoutStrategy
 
 __all__ = [
+    "AttributionResult",
+    "FeatureContribution",
     "GARCHCalibrationError",
     "GARCHVolatilityConfig",
     "GARCHVolatilityResult",
@@ -28,5 +36,7 @@ __all__ = [
     "StrategySignal",
     "VolatilityBreakoutConfig",
     "VolatilityBreakoutStrategy",
+    "compute_performance_attribution",
     "compute_garch_volatility",
+    "result_to_dataframe",
 ]

--- a/src/trading/strategies/analytics/__init__.py
+++ b/src/trading/strategies/analytics/__init__.py
@@ -1,0 +1,17 @@
+"""Analytics utilities for evaluating trading strategy performance."""
+
+from __future__ import annotations
+
+from .performance_attribution import (
+    AttributionResult,
+    FeatureContribution,
+    compute_performance_attribution,
+    result_to_dataframe,
+)
+
+__all__ = [
+    "AttributionResult",
+    "FeatureContribution",
+    "compute_performance_attribution",
+    "result_to_dataframe",
+]

--- a/src/trading/strategies/analytics/performance_attribution.py
+++ b/src/trading/strategies/analytics/performance_attribution.py
@@ -1,0 +1,250 @@
+"""Performance attribution utilities for roadmap Phase 2 alpha operations.
+
+This module provides a light-weight feature attribution pipeline that converts
+strategy backtest outputs into interpretable diagnostics.  It intentionally
+avoids external dependencies beyond ``numpy`` so it can run inside CI during
+nightly backtests while remaining easy to extend for richer analytics.
+
+The implementation follows a pragmatic linear attribution approach:
+
+* Align return series with feature exposure time-series supplied by
+  strategies (e.g. momentum score, volatility estimate, risk budget).
+* Perform a ridge-regularised least-squares regression to estimate the
+  marginal contribution of each feature to realised returns.
+* Derive summary statistics (Sharpe-like ratio, t-stats, residual drift)
+  and expose helpers for producing DataFrame-friendly payloads.
+
+Although simplified, the workflow mirrors the encyclopedia guidance for
+"Alpha Ops" diagnostics and provides a foundation for richer explainability
+work in later roadmap phases.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Mapping, Sequence
+
+import numpy as np
+
+__all__ = [
+    "FeatureContribution",
+    "AttributionResult",
+    "compute_performance_attribution",
+    "result_to_dataframe",
+]
+
+
+@dataclass(slots=True)
+class FeatureContribution:
+    """Represents the marginal contribution of a feature to strategy returns."""
+
+    name: str
+    coefficient: float
+    mean_exposure: float
+    contribution: float
+    t_stat: float | None = None
+
+    def as_dict(self) -> dict[str, float]:
+        return {
+            "name": self.name,
+            "coefficient": float(self.coefficient),
+            "mean_exposure": float(self.mean_exposure),
+            "contribution": float(self.contribution),
+            "t_stat": float(self.t_stat) if self.t_stat is not None else None,
+        }
+
+
+@dataclass(slots=True)
+class AttributionResult:
+    """Container describing the outcome of a performance attribution run."""
+
+    total_return: float
+    average_return: float
+    total_volatility: float
+    sharpe_ratio: float | None
+    residual_mean: float
+    r_squared: float
+    intercept: float
+    contributions: tuple[FeatureContribution, ...]
+
+    def as_dict(self) -> dict[str, object]:
+        return {
+            "total_return": self.total_return,
+            "average_return": self.average_return,
+            "total_volatility": self.total_volatility,
+            "sharpe_ratio": self.sharpe_ratio,
+            "residual_mean": self.residual_mean,
+            "r_squared": self.r_squared,
+            "intercept": self.intercept,
+            "contributions": [contrib.as_dict() for contrib in self.contributions],
+        }
+
+
+class _AlignedArrays:
+    """Helper structure bundling aligned returns and feature exposures."""
+
+    def __init__(
+        self,
+        returns: Sequence[float] | np.ndarray,
+        features: Mapping[str, Sequence[float] | np.ndarray],
+    ) -> None:
+        self.names = tuple(features.keys())
+        self.returns, self.exposures = self._align(returns, features)
+
+    @staticmethod
+    def _align(
+        returns: Sequence[float] | np.ndarray,
+        features: Mapping[str, Sequence[float] | np.ndarray],
+    ) -> tuple[np.ndarray, np.ndarray]:
+        returns_array = np.asarray(returns, dtype=float)
+        if returns_array.ndim != 1:
+            raise ValueError("returns must be a one-dimensional sequence")
+        if returns_array.size == 0:
+            raise ValueError("returns must contain at least one observation")
+
+        exposures: list[np.ndarray] = []
+        valid_mask = np.isfinite(returns_array)
+        for name, series in features.items():
+            series_array = np.asarray(series, dtype=float)
+            if series_array.shape != returns_array.shape:
+                raise ValueError(
+                    f"feature '{name}' must have the same length as returns"
+                )
+            valid_mask &= np.isfinite(series_array)
+            exposures.append(series_array)
+
+        returns_array = returns_array[valid_mask]
+        if returns_array.size == 0:
+            raise ValueError("no valid observations after dropping NaNs")
+
+        exposure_matrix = np.vstack(exposures).T[valid_mask]
+        return returns_array, exposure_matrix
+
+
+def _ridge_regression(
+    y: np.ndarray, X: np.ndarray, *, regularisation: float
+) -> tuple[np.ndarray, float, np.ndarray]:
+    """Solve a ridge regression and return coefficients, intercept, covariance."""
+
+    if y.ndim != 1:
+        raise ValueError("y must be a one-dimensional array")
+    if X.ndim != 2:
+        raise ValueError("X must be a two-dimensional matrix")
+    if len(y) != len(X):
+        raise ValueError("X and y must contain the same number of observations")
+
+    n, k = X.shape
+    design = np.column_stack([X, np.ones(n)])
+    identity = np.eye(k + 1)
+    identity[-1, -1] = 0.0  # do not regularise the intercept
+    gram = design.T @ design + regularisation * identity
+    try:
+        inv_gram = np.linalg.inv(gram)
+    except np.linalg.LinAlgError as exc:  # pragma: no cover - defensive
+        raise ValueError("design matrix is singular") from exc
+
+    beta = inv_gram @ design.T @ y
+    coefficients = beta[:-1]
+    intercept = float(beta[-1])
+    residuals = y - design @ beta
+    dof = max(n - (k + 1), 1)
+    sigma2 = float(residuals.T @ residuals) / dof
+    covariance = inv_gram * sigma2
+    return coefficients, intercept, covariance
+
+
+def compute_performance_attribution(
+    returns: Sequence[float] | np.ndarray,
+    features: Mapping[str, Sequence[float] | np.ndarray],
+    *,
+    regularisation: float = 1e-6,
+) -> AttributionResult:
+    """Estimate feature contributions to strategy returns.
+
+    Args:
+        returns: Sequence of realised returns for the strategy.
+        features: Mapping of feature name -> exposure sequence.
+        regularisation: Ridge penalty applied to stabilise the regression.
+
+    Returns:
+        AttributionResult summarising aggregate statistics and contributions.
+    """
+
+    if regularisation < 0:
+        raise ValueError("regularisation must be non-negative")
+
+    aligned = _AlignedArrays(returns, features)
+    coeffs, intercept, covariance = _ridge_regression(
+        aligned.returns, aligned.exposures, regularisation=regularisation
+    )
+
+    predictions = aligned.exposures @ coeffs + intercept
+    residuals = aligned.returns - predictions
+    total_return = float(np.sum(aligned.returns))
+    average_return = float(np.mean(aligned.returns))
+    total_volatility = float(np.std(aligned.returns, ddof=1 if len(aligned.returns) > 1 else 0))
+    sharpe_ratio: float | None
+    if total_volatility > 0:
+        sharpe_ratio = average_return / total_volatility * np.sqrt(252.0)
+    else:
+        sharpe_ratio = None
+
+    ss_total = float(np.sum((aligned.returns - average_return) ** 2))
+    ss_residual = float(np.sum(residuals**2))
+    r_squared = 0.0 if ss_total == 0 else 1.0 - ss_residual / ss_total
+    residual_mean = float(np.mean(residuals))
+
+    contributions: list[FeatureContribution] = []
+    for idx, name in enumerate(aligned.names):
+        exposure = aligned.exposures[:, idx]
+        mean_exposure = float(np.mean(exposure))
+        contribution = float(coeffs[idx] * mean_exposure)
+        variance = float(covariance[idx, idx])
+        if variance > 0:
+            t_stat = float(coeffs[idx] / np.sqrt(variance))
+        else:
+            t_stat = None
+        contributions.append(
+            FeatureContribution(
+                name=name,
+                coefficient=float(coeffs[idx]),
+                mean_exposure=mean_exposure,
+                contribution=contribution,
+                t_stat=t_stat,
+            )
+        )
+
+    return AttributionResult(
+        total_return=total_return,
+        average_return=average_return,
+        total_volatility=total_volatility,
+        sharpe_ratio=sharpe_ratio,
+        residual_mean=residual_mean,
+        r_squared=float(max(min(r_squared, 1.0), -1.0)),
+        intercept=float(intercept),
+        contributions=tuple(contributions),
+    )
+
+
+def result_to_dataframe(result: AttributionResult) -> "np.ndarray":
+    """Return a numpy structured array suited for DataFrame construction."""
+
+    dtype = [
+        ("name", "U64"),
+        ("coefficient", "f8"),
+        ("mean_exposure", "f8"),
+        ("contribution", "f8"),
+        ("t_stat", "f8"),
+    ]
+    rows = []
+    for contrib in result.contributions:
+        rows.append(
+            (
+                contrib.name,
+                contrib.coefficient,
+                contrib.mean_exposure,
+                contrib.contribution,
+                contrib.t_stat if contrib.t_stat is not None else np.nan,
+            )
+        )
+    return np.array(rows, dtype=dtype)

--- a/tests/trading/test_performance_attribution.py
+++ b/tests/trading/test_performance_attribution.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from src.trading.strategies.analytics import (
+    compute_performance_attribution,
+    result_to_dataframe,
+)
+
+
+def test_performance_attribution_basic() -> None:
+    returns = [0.01, 0.015, -0.005, 0.02, 0.0]
+    features = {
+        "momentum": [1.2, 0.9, -0.5, 1.1, 0.0],
+        "volatility": [0.5, 0.4, 0.6, 0.7, 0.2],
+    }
+
+    result = compute_performance_attribution(returns, features)
+
+    assert result.total_return == pytest.approx(sum(returns))
+    assert len(result.contributions) == 2
+    assert {contrib.name for contrib in result.contributions} == {"momentum", "volatility"}
+
+    predicted_mean = result.intercept + sum(c.contribution for c in result.contributions)
+    assert predicted_mean == pytest.approx(result.average_return, rel=1e-6, abs=1e-9)
+
+    table = result_to_dataframe(result)
+    assert set(table["name"]) == {"momentum", "volatility"}
+    assert table["coefficient"].dtype == np.float64
+
+
+def test_performance_attribution_handles_nans() -> None:
+    returns = [0.01, np.nan, 0.02, -0.01]
+    features = {
+        "signal": [0.5, 0.6, np.nan, 0.4],
+    }
+
+    result = compute_performance_attribution(returns, features)
+    assert len(result.contributions) == 1
+    # Only two valid observations should remain after dropping NaNs
+    assert result.total_return == pytest.approx(0.01 - 0.01)
+
+
+def test_performance_attribution_regularisation_validation() -> None:
+    with pytest.raises(ValueError):
+        compute_performance_attribution([0.01, 0.02], {"x": [1.0, 2.0]}, regularisation=-1.0)


### PR DESCRIPTION
## Summary
- add a performance attribution analytics module for strategy diagnostics and expose it through the trading strategies package
- provide helpers for converting attribution results into tabular form and cover them with targeted tests
- update the high-impact roadmap to mark the analytics pipeline as complete

## Testing
- pytest tests/trading/test_performance_attribution.py

------
https://chatgpt.com/codex/tasks/task_e_68d9603b3c98832ca287cb22ca07385a