### PR TITLE
Include cross-region failover in high-impact roadmap checks

### DIFF
--- a/docs/status/high_impact_roadmap_detail.md
+++ b/docs/status/high_impact_roadmap_detail.md
@@ -19,6 +19,7 @@
 - operations.data_backbone.evaluate_data_backbone_readiness
 - operations.ingest_trends.evaluate_ingest_trends
 - data_foundation.ingest.failover.decide_ingest_failover
+- operations.cross_region_failover.evaluate_cross_region_failover
 - operations.backup.evaluate_backup_readiness
 - operations.spark_stress.execute_spark_stress_drill
 

--- a/tools/roadmap/high_impact.py
+++ b/tools/roadmap/high_impact.py
@@ -115,6 +115,10 @@ def _stream_definitions() -> Sequence[StreamDefinition]:
                     "decide_ingest_failover",
                 ),
                 require_module_attr(
+                    "operations.cross_region_failover",
+                    "evaluate_cross_region_failover",
+                ),
+                require_module_attr(
                     "operations.backup",
                     "evaluate_backup_readiness",
                 ),


### PR DESCRIPTION
## Summary
- ensure the high-impact roadmap marks Stream A ready only when cross-region failover telemetry is present
- refresh the detailed roadmap evidence to list the cross-region failover evaluator alongside other backbone artifacts

## Testing
- pytest tests/tools/test_high_impact_roadmap.py -q

------
https://chatgpt.com/codex/tasks/task_e_68d9603b3c98832ca287cb22ca07385a