### PR TITLE
Add reference data loader and pricing cache for roadmap data foundation

### DIFF
--- a/config/reference/holidays.json
+++ b/config/reference/holidays.json
@@ -1,0 +1,14 @@
+[
+  {
+    "date": "2025-01-01",
+    "name": "New Year's Day",
+    "venues": ["LONDON", "NEW_YORK", "TOKYO"],
+    "description": "Global markets closed for New Year observance."
+  },
+  {
+    "date": "2025-12-25",
+    "name": "Christmas Day",
+    "venues": ["LONDON", "NEW_YORK"],
+    "description": "Major Western venues closed; Tokyo operates half-day."
+  }
+]

--- a/config/reference/sessions.json
+++ b/config/reference/sessions.json
@@ -1,0 +1,29 @@
+{
+  "london_fx": {
+    "name": "London FX Core Session",
+    "timezone": "Europe/London",
+    "open_time": "07:00",
+    "close_time": "16:30",
+    "days": ["Mon", "Tue", "Wed", "Thu", "Fri"],
+    "venue": "LONDON",
+    "description": "Primary liquidity window for GBP and EUR pairs."
+  },
+  "new_york_fx": {
+    "name": "New York FX Session",
+    "timezone": "America/New_York",
+    "open_time": "08:00",
+    "close_time": "17:00",
+    "days": ["Mon", "Tue", "Wed", "Thu", "Fri"],
+    "venue": "NEW_YORK",
+    "description": "North American overlap session – highest USD liquidity."
+  },
+  "tokyo_fx": {
+    "name": "Tokyo FX Session",
+    "timezone": "Asia/Tokyo",
+    "open_time": "09:00",
+    "close_time": "18:00",
+    "days": ["Mon", "Tue", "Wed", "Thu", "Fri"],
+    "venue": "TOKYO",
+    "description": "Asian liquidity window – anchors pre-London positioning."
+  }
+}

--- a/docs/runbooks/data_foundation.md
+++ b/docs/runbooks/data_foundation.md
@@ -1,0 +1,67 @@
+# Data Foundation Runbook
+
+This runbook captures the operational workflows that back the roadmap's
+"Data Foundation Hardening" track.  The goal is to ensure every developer and
+operator can hydrate, inspect, and validate datasets without bespoke scripts.
+
+## Canonical Pricing Pipeline
+
+* Entrypoint: `scripts/data_bootstrap.py`
+* Core logic: `src/data_foundation/pipelines/pricing_pipeline.py`
+
+The bootstrap CLI wraps the `PricingPipeline` so Yahoo, Alpha Vantage, and
+deterministic file vendors share the same normalisation and validation flow.
+It persists artefacts via `PricingCache`, which writes Parquet (with CSV
+fallback) plus JSON metadata into `data_foundation/cache/pricing/`.  Retention
+and entry limits can be configured from the CLI (`--cache-retention-days` and
+`--cache-max-entries`).
+
+Common usage:
+
+```bash
+poetry run python scripts/data_bootstrap.py \
+  --symbols "EURUSD=X,GBPUSD=X" \
+  --vendor yahoo \
+  --lookback-days 120 \
+  --cache-retention-days 7
+```
+
+The command prints a JSON summary with dataset location, row counts, and any
+quality issues raised by the pipeline validators.
+
+## Reference Data Loader
+
+* Module: `src/data_foundation/reference/reference_data_loader.py`
+
+The `ReferenceDataLoader` consolidates instrument metadata, trading sessions,
+and holiday calendars.  It defaults to the repository configs:
+
+* Instruments — `config/system/instruments.json`
+* Sessions — `config/reference/sessions.json`
+* Holidays — `config/reference/holidays.json`
+
+The loader memoizes results and exposes a `refresh` flag when changes need to
+be detected at runtime.  Use it to seed services such as the strategy registry
+or risk engine with a single, validated source of truth:
+
+```python
+from src.data_foundation.reference import ReferenceDataLoader
+
+loader = ReferenceDataLoader()
+dataset = loader.load_all()
+instrument = dataset.instruments["EURUSD"]
+```
+
+Custom deployments can override the config paths when integrating with managed
+data stores.
+
+## Artefact Expectations
+
+* Parquet/CSV datasets stored under `data_foundation/cache/pricing/`
+* Metadata JSON files suffixed with `_metadata.json`
+* Issues JSON files suffixed with `_issues.json`
+* Reference data lives under `config/reference/`
+
+All artefacts are Git-ignored and regenerated on demand; the runbook ensures a
+repeatable workflow for onboarding new venues or data vendors without drifting
+from the encyclopedia baseline.

--- a/src/data_foundation/cache/pricing_cache.py
+++ b/src/data_foundation/cache/pricing_cache.py
@@ -1,0 +1,187 @@
+"""Utilities for persisting normalised pricing datasets in a local cache."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from typing import Mapping, Sequence
+
+import pandas as pd
+
+from src.data_foundation.pipelines.pricing_pipeline import (
+    PricingPipelineConfig,
+    PricingPipelineResult,
+    PricingQualityIssue,
+)
+
+__all__ = ["PricingCache", "PricingCacheEntry"]
+
+
+@dataclass(frozen=True, slots=True)
+class PricingCacheEntry:
+    """Describes a cached pricing dataset and supporting artefacts."""
+
+    dataset_path: Path
+    metadata_path: Path
+    issues_path: Path
+    created_at: datetime
+    metadata: Mapping[str, object]
+    issues_payload: Sequence[Mapping[str, object]]
+
+
+class PricingCache:
+    """Persist pricing pipeline results with retention-aware helpers."""
+
+    def __init__(self, root: Path | str = Path("data_foundation/cache/pricing")) -> None:
+        self._root = Path(root)
+        self._root.mkdir(parents=True, exist_ok=True)
+
+    # ------------------------------------------------------------------
+    def store(
+        self,
+        config: PricingPipelineConfig,
+        result: PricingPipelineResult,
+        *,
+        issues: Sequence[PricingQualityIssue] | None = None,
+        retention_days: int | None = None,
+        max_entries: int | None = None,
+    ) -> PricingCacheEntry:
+        """Persist the result and return the created cache entry."""
+
+        created_at = datetime.now(tz=UTC)
+        key = json.dumps(
+            {
+                "symbols": config.normalised_symbols(),
+                "vendor": config.vendor,
+                "interval": config.interval,
+                "start": config.window_start().isoformat(),
+                "end": config.window_end().isoformat(),
+            },
+            sort_keys=True,
+        ).encode("utf-8")
+        digest = hashlib.sha1(key).hexdigest()[:12]
+
+        timestamp = created_at.strftime("%Y%m%dT%H%M%SZ")
+        base_name = f"{timestamp}_{config.vendor}_{config.interval}_{digest}"
+        dataset_path = self._write_dataset(result.data, base_name)
+
+        metadata_payload = {
+            "created_at": created_at.isoformat(),
+            "dataset_path": str(dataset_path),
+            "symbols": config.normalised_symbols(),
+            "vendor": config.vendor,
+            "interval": config.interval,
+            "window_start": config.window_start().isoformat(),
+            "window_end": config.window_end().isoformat(),
+            "rows": int(len(result.data)),
+            "metadata": dict(result.metadata),
+        }
+
+        issues_payload = [
+            {
+                "code": issue.code,
+                "severity": issue.severity,
+                "message": issue.message,
+                "symbol": issue.symbol,
+                "context": dict(issue.context),
+            }
+            for issue in (issues or result.issues)
+        ]
+
+        metadata_path = self._write_json(base_name + "_metadata.json", metadata_payload)
+        issues_path = self._write_json(base_name + "_issues.json", {"issues": issues_payload})
+
+        entry = PricingCacheEntry(
+            dataset_path=dataset_path,
+            metadata_path=metadata_path,
+            issues_path=issues_path,
+            created_at=created_at,
+            metadata=metadata_payload,
+            issues_payload=issues_payload,
+        )
+
+        if retention_days is not None or max_entries is not None:
+            self.prune(retention_days=retention_days, max_entries=max_entries)
+
+        return entry
+
+    # ------------------------------------------------------------------
+    def list_entries(self) -> list[PricingCacheEntry]:
+        """Return cache entries discovered on disk sorted by creation time."""
+
+        entries: list[PricingCacheEntry] = []
+        for metadata_file in sorted(self._root.glob("*_metadata.json")):
+            payload = json.loads(metadata_file.read_text(encoding="utf-8"))
+            created_at = datetime.fromisoformat(payload["created_at"])
+            dataset_path = Path(payload["dataset_path"])
+            issues_path = metadata_file.with_name(metadata_file.name.replace("_metadata", "_issues"))
+            issues_payload = json.loads(issues_path.read_text(encoding="utf-8"))["issues"]
+            entries.append(
+                PricingCacheEntry(
+                    dataset_path=dataset_path,
+                    metadata_path=metadata_file,
+                    issues_path=issues_path,
+                    created_at=created_at,
+                    metadata=payload,
+                    issues_payload=issues_payload,
+                )
+            )
+
+        entries.sort(key=lambda item: item.created_at, reverse=True)
+        return entries
+
+    # ------------------------------------------------------------------
+    def prune(
+        self,
+        *,
+        retention_days: int | None = None,
+        max_entries: int | None = None,
+    ) -> None:
+        """Apply retention and max-entry policies to the cache directory."""
+
+        entries = self.list_entries()
+        now = datetime.now(tz=UTC)
+
+        to_delete: list[PricingCacheEntry] = []
+        if retention_days is not None:
+            cutoff = now - timedelta(days=retention_days)
+            to_delete.extend(entry for entry in entries if entry.created_at < cutoff)
+
+        if max_entries is not None and len(entries) > max_entries:
+            to_delete.extend(entries[max_entries:])
+
+        seen = set()
+        for entry in to_delete:
+            if entry.metadata_path in seen:
+                continue
+            seen.add(entry.metadata_path)
+            for path in (
+                entry.metadata_path,
+                entry.issues_path,
+                entry.dataset_path,
+            ):
+                try:
+                    Path(path).unlink(missing_ok=True)
+                except Exception:
+                    continue
+
+    # ------------------------------------------------------------------
+    def _write_dataset(self, frame: pd.DataFrame, base_name: str) -> Path:
+        self._root.mkdir(parents=True, exist_ok=True)
+        parquet_path = self._root / f"{base_name}.parquet"
+        try:
+            frame.to_parquet(parquet_path, index=False)
+            return parquet_path
+        except Exception:
+            csv_path = parquet_path.with_suffix(".csv")
+            frame.to_csv(csv_path, index=False)
+            return csv_path
+
+    def _write_json(self, file_name: str, payload: Mapping[str, object]) -> Path:
+        path = self._root / file_name
+        path.write_text(json.dumps(payload, indent=2, sort_keys=True), encoding="utf-8")
+        return path
+

--- a/src/data_foundation/reference/__init__.py
+++ b/src/data_foundation/reference/__init__.py
@@ -1,0 +1,17 @@
+"""Reference data loaders for instruments, sessions, and holiday calendars."""
+
+from .reference_data_loader import (
+    Holiday,
+    InstrumentDefinition,
+    ReferenceDataLoader,
+    ReferenceDataSet,
+    TradingSession,
+)
+
+__all__ = [
+    "ReferenceDataLoader",
+    "ReferenceDataSet",
+    "InstrumentDefinition",
+    "TradingSession",
+    "Holiday",
+]

--- a/src/data_foundation/reference/reference_data_loader.py
+++ b/src/data_foundation/reference/reference_data_loader.py
@@ -1,0 +1,314 @@
+"""Load canonical reference data aligned with the high-impact roadmap."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from datetime import date, datetime, time
+from decimal import Decimal
+from pathlib import Path
+from typing import Dict, Iterable, Mapping, Sequence
+
+__all__ = [
+    "InstrumentDefinition",
+    "TradingSession",
+    "Holiday",
+    "ReferenceDataSet",
+    "ReferenceDataLoader",
+]
+
+
+# ---------------------------------------------------------------------------
+# Data models
+
+
+@dataclass(frozen=True, slots=True)
+class InstrumentDefinition:
+    """Describes a tradeable instrument and core risk parameters."""
+
+    symbol: str
+    contract_size: Decimal
+    pip_decimal_places: int
+    margin_currency: str
+    long_swap_rate: Decimal | None = None
+    short_swap_rate: Decimal | None = None
+    swap_time: time | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class TradingSession:
+    """Represents a trading session window for a venue or geography."""
+
+    name: str
+    timezone: str
+    open_time: time
+    close_time: time
+    days: tuple[str, ...]
+    venue: str | None = None
+    description: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class Holiday:
+    """Holiday entry indicating when venues are closed or observing half-days."""
+
+    date: date
+    name: str
+    venues: tuple[str, ...]
+    description: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class ReferenceDataSet:
+    """Bundle of reference artefacts consumed by downstream components."""
+
+    instruments: Mapping[str, InstrumentDefinition]
+    sessions: Mapping[str, TradingSession]
+    holidays: tuple[Holiday, ...]
+
+
+# ---------------------------------------------------------------------------
+# Loader implementation
+
+
+class ReferenceDataLoader:
+    """Load reference data (instruments, sessions, holidays) from disk."""
+
+    _SUPPORTED_SUFFIXES = (".json", ".yaml", ".yml")
+
+    def __init__(
+        self,
+        *,
+        config_root: Path | str | None = None,
+        instrument_path: Path | str | None = None,
+        session_path: Path | str | None = None,
+        holiday_path: Path | str | None = None,
+    ) -> None:
+        project_root = Path(__file__).resolve().parents[3]
+        default_root = project_root / "config"
+        self._config_root = Path(config_root) if config_root is not None else default_root
+
+        self._instrument_path = self._resolve_path(
+            instrument_path,
+            [self._config_root / "system" / "instruments.json"],
+        )
+        self._session_path = self._resolve_path(
+            session_path,
+            [self._config_root / "reference" / "sessions"],
+        )
+        self._holiday_path = self._resolve_path(
+            holiday_path,
+            [self._config_root / "reference" / "holidays"],
+        )
+
+        self._instrument_cache: Mapping[str, InstrumentDefinition] | None = None
+        self._session_cache: Mapping[str, TradingSession] | None = None
+        self._holiday_cache: tuple[Holiday, ...] | None = None
+
+    # ------------------------------------------------------------------
+    def load_instruments(self, *, refresh: bool = False) -> Mapping[str, InstrumentDefinition]:
+        """Return instrument definitions keyed by symbol."""
+
+        if not refresh and self._instrument_cache is not None:
+            return self._instrument_cache
+
+        payload = self._read_structured(self._instrument_path)
+        if not isinstance(payload, Mapping):
+            raise TypeError("Instrument config must contain a mapping of symbol -> payload")
+
+        instruments: Dict[str, InstrumentDefinition] = {}
+        for symbol, raw in payload.items():
+            if not isinstance(raw, Mapping):
+                continue
+            try:
+                instruments[str(symbol).upper()] = self._parse_instrument(symbol, raw)
+            except Exception as exc:  # pragma: no cover - defensive guard
+                raise ValueError(f"Invalid instrument payload for {symbol!r}: {exc}") from exc
+
+        self._instrument_cache = instruments
+        return instruments
+
+    def load_sessions(self, *, refresh: bool = False) -> Mapping[str, TradingSession]:
+        """Return trading sessions keyed by identifier."""
+
+        if not refresh and self._session_cache is not None:
+            return self._session_cache
+
+        payload = self._read_structured(self._session_path)
+        if not isinstance(payload, Mapping):
+            raise TypeError("Session config must contain a mapping of id -> payload")
+
+        sessions: Dict[str, TradingSession] = {}
+        for key, raw in payload.items():
+            if not isinstance(raw, Mapping):
+                continue
+            try:
+                sessions[str(key)] = self._parse_session(raw)
+            except Exception as exc:  # pragma: no cover - defensive guard
+                raise ValueError(f"Invalid session payload for {key!r}: {exc}") from exc
+
+        self._session_cache = sessions
+        return sessions
+
+    def load_holidays(self, *, refresh: bool = False) -> tuple[Holiday, ...]:
+        """Return holiday entries sorted chronologically."""
+
+        if not refresh and self._holiday_cache is not None:
+            return self._holiday_cache
+
+        payload = self._read_structured(self._holiday_path)
+        if isinstance(payload, Mapping):
+            records: Iterable[Mapping[str, object]] = payload.values()  # pragma: no cover - alt schema
+        elif isinstance(payload, Sequence):
+            records = [item for item in payload if isinstance(item, Mapping)]
+        else:
+            raise TypeError("Holiday config must be a list or mapping of entries")
+
+        holidays: list[Holiday] = []
+        for entry in records:
+            try:
+                holidays.append(self._parse_holiday(entry))
+            except Exception as exc:  # pragma: no cover - defensive guard
+                raise ValueError(f"Invalid holiday payload {entry}: {exc}") from exc
+
+        holidays.sort(key=lambda item: item.date)
+        self._holiday_cache = tuple(holidays)
+        return self._holiday_cache
+
+    def load_all(self, *, refresh: bool = False) -> ReferenceDataSet:
+        """Return a combined reference dataset."""
+
+        instruments = self.load_instruments(refresh=refresh)
+        sessions = self.load_sessions(refresh=refresh)
+        holidays = self.load_holidays(refresh=refresh)
+        return ReferenceDataSet(
+            instruments=instruments,
+            sessions=sessions,
+            holidays=holidays,
+        )
+
+    # ------------------------------------------------------------------
+    def _resolve_path(
+        self,
+        explicit: Path | str | None,
+        candidates: Sequence[Path],
+    ) -> Path:
+        if explicit is not None:
+            explicit_path = Path(explicit)
+            if not explicit_path.exists():
+                raise FileNotFoundError(f"Reference data file not found: {explicit_path}")
+            return explicit_path
+
+        for candidate in candidates:
+            if candidate.exists():
+                return candidate
+            for suffix in self._SUPPORTED_SUFFIXES:
+                alt = candidate.with_suffix(suffix)
+                if alt.exists():
+                    return alt
+        raise FileNotFoundError(
+            f"Reference data file not found. Tried: {', '.join(str(path) for path in candidates)}"
+        )
+
+    @staticmethod
+    def _read_structured(path: Path) -> object:
+        data = path.read_text(encoding="utf-8")
+        if path.suffix.lower() in {".yaml", ".yml"}:
+            try:  # pragma: no cover - optional dependency
+                import yaml  # type: ignore
+
+                return yaml.safe_load(data)
+            except Exception as exc:  # pragma: no cover - degrade gracefully
+                raise RuntimeError(f"Unable to parse YAML reference data: {path}") from exc
+        return json.loads(data)
+
+    @staticmethod
+    def _parse_decimal(value: object | None) -> Decimal | None:
+        if value is None:
+            return None
+        return Decimal(str(value))
+
+    @staticmethod
+    def _parse_time(value: object | None) -> time | None:
+        if value in (None, "", False):
+            return None
+        text = str(value)
+        for fmt in ("%H:%M", "%H:%M:%S"):
+            try:
+                return datetime.strptime(text, fmt).time()
+            except ValueError:
+                continue
+        raise ValueError(f"Invalid time format: {text}")
+
+    def _parse_instrument(self, symbol: str, payload: Mapping[str, object]) -> InstrumentDefinition:
+        contract_size = self._parse_decimal(payload.get("contract_size")) or Decimal("0")
+        pip_places = int(payload.get("pip_decimal_places", 0))
+        margin_currency = str(payload.get("margin_currency", "")).upper()
+        long_swap = self._parse_decimal(payload.get("long_swap_rate"))
+        short_swap = self._parse_decimal(payload.get("short_swap_rate"))
+        swap_time = self._parse_time(payload.get("swap_time"))
+
+        return InstrumentDefinition(
+            symbol=str(symbol).upper(),
+            contract_size=contract_size,
+            pip_decimal_places=pip_places,
+            margin_currency=margin_currency,
+            long_swap_rate=long_swap,
+            short_swap_rate=short_swap,
+            swap_time=swap_time,
+        )
+
+    def _parse_session(self, payload: Mapping[str, object]) -> TradingSession:
+        name = str(payload.get("name", "")).strip()
+        timezone_name = str(payload.get("timezone", "UTC"))
+        open_time = self._parse_time(payload.get("open_time"))
+        close_time = self._parse_time(payload.get("close_time"))
+        if open_time is None or close_time is None:
+            raise ValueError("Session requires open_time and close_time")
+
+        raw_days = payload.get("days") or ("Mon", "Tue", "Wed", "Thu", "Fri")
+        if isinstance(raw_days, Sequence) and not isinstance(raw_days, (str, bytes)):
+            days: tuple[str, ...] = tuple(str(day) for day in raw_days)
+        else:
+            days = (str(raw_days),)
+
+        venue = payload.get("venue")
+        description = payload.get("description")
+
+        return TradingSession(
+            name=name or "Session",
+            timezone=timezone_name,
+            open_time=open_time,
+            close_time=close_time,
+            days=days,
+            venue=str(venue) if venue is not None else None,
+            description=str(description) if description is not None else None,
+        )
+
+    def _parse_holiday(self, payload: Mapping[str, object]) -> Holiday:
+        raw_date = payload.get("date")
+        if isinstance(raw_date, date):
+            holiday_date = raw_date
+        elif isinstance(raw_date, datetime):
+            holiday_date = raw_date.date()
+        else:
+            holiday_date = datetime.fromisoformat(str(raw_date)).date()
+
+        venues_field = payload.get("venues") or payload.get("markets")
+        venues: tuple[str, ...]
+        if isinstance(venues_field, Sequence) and not isinstance(venues_field, (str, bytes)):
+            venues = tuple(str(venue).upper() for venue in venues_field)
+        elif venues_field:
+            venues = (str(venues_field).upper(),)
+        else:
+            venues = tuple()
+
+        description = payload.get("description")
+
+        return Holiday(
+            date=holiday_date,
+            name=str(payload.get("name", "")),
+            venues=venues,
+            description=str(description) if description is not None else None,
+        )
+

--- a/tests/data_foundation/test_pricing_cache.py
+++ b/tests/data_foundation/test_pricing_cache.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pandas as pd
+
+from src.data_foundation.cache.pricing_cache import PricingCache
+from src.data_foundation.pipelines.pricing_pipeline import (
+    PricingPipelineConfig,
+    PricingPipelineResult,
+    PricingQualityIssue,
+)
+
+
+def _make_result() -> PricingPipelineResult:
+    frame = pd.DataFrame(
+        {
+            "timestamp": pd.date_range("2025-01-01", periods=3, freq="D", tz="UTC"),
+            "symbol": ["EURUSD=X", "EURUSD=X", "EURUSD=X"],
+            "open": [1.0, 1.1, 1.2],
+            "high": [1.1, 1.2, 1.3],
+            "low": [0.9, 1.0, 1.1],
+            "close": [1.05, 1.15, 1.25],
+            "adj_close": [1.05, 1.15, 1.25],
+            "volume": [100, 110, 120],
+            "source": ["test"] * 3,
+        }
+    )
+    issues = (
+        PricingQualityIssue(
+            code="duplicate_rows",
+            severity="warning",
+            message="Test warning",
+            symbol="EURUSD=X",
+        ),
+    )
+    return PricingPipelineResult(data=frame, issues=issues, metadata={"test": True})
+
+
+def test_pricing_cache_store_creates_expected_files(tmp_path: Path) -> None:
+    cache = PricingCache(tmp_path)
+    config = PricingPipelineConfig(symbols=["EURUSD=X"], vendor="demo", interval="1d")
+    result = _make_result()
+
+    entry = cache.store(config, result)
+
+    assert entry.dataset_path.exists()
+    assert entry.metadata_path.exists()
+    assert entry.issues_path.exists()
+
+    metadata = json.loads(entry.metadata_path.read_text(encoding="utf-8"))
+    assert metadata["symbols"] == ["EURUSD=X"]
+    assert metadata["rows"] == len(result.data)
+
+    issues_payload = json.loads(entry.issues_path.read_text(encoding="utf-8"))
+    assert issues_payload["issues"][0]["code"] == "duplicate_rows"
+
+
+def test_pricing_cache_prune_respects_retention(tmp_path: Path) -> None:
+    cache = PricingCache(tmp_path)
+    config = PricingPipelineConfig(symbols=["EURUSD=X"], vendor="demo", interval="1d")
+    result = _make_result()
+
+    old_entry = cache.store(config, result)
+    metadata = json.loads(old_entry.metadata_path.read_text(encoding="utf-8"))
+    metadata["created_at"] = "2000-01-01T00:00:00+00:00"
+    old_entry.metadata_path.write_text(json.dumps(metadata), encoding="utf-8")
+
+    new_entry = cache.store(config, result)
+    cache.prune(retention_days=1, max_entries=1)
+
+    assert not old_entry.metadata_path.exists()
+    assert not old_entry.dataset_path.exists()
+    assert new_entry.metadata_path.exists()
+

--- a/tests/data_foundation/test_reference_loader.py
+++ b/tests/data_foundation/test_reference_loader.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+from datetime import date, time
+from pathlib import Path
+
+import json
+import pytest
+
+from src.data_foundation.reference import ReferenceDataLoader
+
+
+def test_default_reference_loader_reads_repo_configs() -> None:
+    loader = ReferenceDataLoader()
+
+    instruments = loader.load_instruments()
+    assert "EURUSD" in instruments
+    eurusd = instruments["EURUSD"]
+    assert float(eurusd.contract_size) == pytest.approx(100000)
+    assert eurusd.pip_decimal_places == 4
+    assert eurusd.swap_time == time(hour=22)
+
+    sessions = loader.load_sessions()
+    assert set(sessions.keys()) >= {"london_fx", "tokyo_fx", "new_york_fx"}
+    london = sessions["london_fx"]
+    assert london.open_time == time(hour=7)
+    assert london.close_time == time(hour=16, minute=30)
+    assert london.days == ("Mon", "Tue", "Wed", "Thu", "Fri")
+
+    holidays = loader.load_holidays()
+    assert holidays[0].date == date(2025, 1, 1)
+    assert {"LONDON", "NEW_YORK", "TOKYO"}.issubset(set(holidays[0].venues))
+
+
+def test_loader_refresh_reads_modified_files(tmp_path: Path) -> None:
+    instrument_path = tmp_path / "instruments.json"
+    sessions_path = tmp_path / "sessions.json"
+    holidays_path = tmp_path / "holidays.json"
+
+    instrument_path.write_text(
+        json.dumps(
+            {
+                "TESTFX": {
+                    "contract_size": "1000",
+                    "pip_decimal_places": 3,
+                    "margin_currency": "USD",
+                    "swap_time": "21:00",
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    sessions_path.write_text(
+        json.dumps(
+            {
+                "test": {
+                    "name": "Test Session",
+                    "timezone": "UTC",
+                    "open_time": "01:00",
+                    "close_time": "02:00",
+                    "days": ["Mon"],
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    holidays_path.write_text(
+        json.dumps(
+            [
+                {
+                    "date": "2025-05-01",
+                    "name": "Test Holiday",
+                    "venues": ["TEST"],
+                }
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    loader = ReferenceDataLoader(
+        instrument_path=instrument_path,
+        session_path=sessions_path,
+        holiday_path=holidays_path,
+    )
+
+    instruments = loader.load_instruments()
+    assert set(instruments.keys()) == {"TESTFX"}
+
+    # Modify the instrument file and ensure cached call still returns original until refresh
+    instrument_path.write_text(
+        json.dumps(
+            {
+                "TESTFX": {
+                    "contract_size": "2000",
+                    "pip_decimal_places": 3,
+                    "margin_currency": "USD",
+                    "swap_time": "22:00",
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    cached = loader.load_instruments()
+    assert float(cached["TESTFX"].contract_size) == pytest.approx(1000)
+
+    refreshed = loader.load_instruments(refresh=True)
+    assert float(refreshed["TESTFX"].contract_size) == pytest.approx(2000)
+
+    holidays = loader.load_holidays(refresh=True)
+    assert holidays == loader.load_holidays()
+
+
+def test_loader_rejects_missing_files(tmp_path: Path) -> None:
+    missing = tmp_path / "missing.json"
+    with pytest.raises(FileNotFoundError):
+        ReferenceDataLoader(instrument_path=missing)


### PR DESCRIPTION
## Summary
- add repository-backed reference data loader for instruments, sessions, and holidays
- persist pricing pipeline results through a retention-aware cache and document the workflow
- extend data bootstrap CLI and add unit tests covering the new loader and cache utilities

## Testing
- `pytest tests/data_foundation/test_reference_loader.py tests/data_foundation/test_pricing_cache.py`


------
https://chatgpt.com/codex/tasks/task_e_68d9604af2d8832ca1ee7825a1087522