### PR TITLE
Add stream filtering to high-impact roadmap CLI

### DIFF
--- a/docs/status/high_impact_roadmap.md
+++ b/docs/status/high_impact_roadmap.md
@@ -8,6 +8,12 @@ before demos or reviews:
 python -m tools.roadmap.high_impact --format markdown
 ```
 
+To focus on specific streams, provide one or more ``--stream`` flags:
+
+```bash
+python -m tools.roadmap.high_impact --stream "Stream A – Institutional data backbone" --format detail
+```
+
 To update both this summary and the detailed evidence companion file in one
 shot, use the refresh flag:
 

--- a/tests/tools/test_high_impact_roadmap.py
+++ b/tests/tools/test_high_impact_roadmap.py
@@ -73,6 +73,24 @@ def test_cli_supports_json_format(capsys: pytest.CaptureFixture[str]) -> None:
     assert decoded[0]["status"] == "Ready"
 
 
+def test_evaluate_streams_can_filter() -> None:
+    [status] = high_impact.evaluate_streams(
+        ["Stream A – Institutional data backbone"]
+    )
+
+    assert status.stream == "Stream A – Institutional data backbone"
+
+
+def test_cli_rejects_unknown_stream(capsys: pytest.CaptureFixture[str]) -> None:
+    with pytest.raises(SystemExit) as excinfo:
+        high_impact.main(["--stream", "unknown stream"])
+
+    assert excinfo.value.code == 2
+    out, err = capsys.readouterr()
+    assert not out
+    assert "Unknown stream" in err
+
+
 def test_detail_formatter_includes_evidence() -> None:
     statuses = high_impact.evaluate_streams()
     report = high_impact.format_detail(statuses)


### PR DESCRIPTION
## Summary
- allow the high-impact roadmap evaluator to filter and validate requested stream names
- add a CLI flag for selecting specific streams and document the usage in the roadmap status page
- extend roadmap tests to cover stream filtering and unknown-stream handling

## Testing
- pytest tests/tools/test_high_impact_roadmap.py

------
https://chatgpt.com/codex/tasks/task_e_68d9605c47b4832cb6ae6381ac7b70dc