### PR TITLE
Add multi-timeframe and Donchian breakout strategies

### DIFF
--- a/docs/High-Impact Development Roadmap.md
+++ b/docs/High-Impact Development Roadmap.md
@@ -159,8 +159,8 @@ To reflect the true scope of institutional-grade trading components, the roadmap
   - [x] Pair-trading z-score spread model with cointegration tests.
     - [x] Unit & integration tests covering signal generation, entry/exit, and conflicts with risk rules.
 - **Momentum & Breakout**
-  - [ ] Multi-timeframe momentum stack (e.g., 15m/1h/1d) with confirmation logic.
-  - [ ] Donchian/ATR breakout module and trailing stop handler.
+  - [x] Multi-timeframe momentum stack (e.g., 15m/1h/1d) with confirmation logic (`MultiTimeframeMomentumStrategy`).
+  - [x] Donchian/ATR breakout module and trailing stop handler (`DonchianATRBreakoutStrategy`).
 - **Strategy Integration**
   - [ ] Update strategy registry/config templates.
   - [ ] Add scenario backtests demonstrating uplift vs baseline MA strategy.

--- a/src/trading/strategies/__init__.py
+++ b/src/trading/strategies/__init__.py
@@ -2,9 +2,17 @@
 
 from __future__ import annotations
 
+from .donchian_atr_breakout import (
+    DonchianATRBreakoutConfig,
+    DonchianATRBreakoutStrategy,
+)
 from .mean_reversion import MeanReversionStrategy, MeanReversionStrategyConfig
 from .models import StrategyAction, StrategySignal
 from .momentum import MomentumStrategy, MomentumStrategyConfig
+from .multi_timeframe_momentum import (
+    MultiTimeframeMomentumConfig,
+    MultiTimeframeMomentumStrategy,
+)
 from .pairs import PairTradingConfig, PairTradingStrategy
 from .signals import (
     GARCHCalibrationError,
@@ -18,10 +26,14 @@ __all__ = [
     "GARCHCalibrationError",
     "GARCHVolatilityConfig",
     "GARCHVolatilityResult",
+    "DonchianATRBreakoutConfig",
+    "DonchianATRBreakoutStrategy",
     "MeanReversionStrategy",
     "MeanReversionStrategyConfig",
     "MomentumStrategy",
     "MomentumStrategyConfig",
+    "MultiTimeframeMomentumConfig",
+    "MultiTimeframeMomentumStrategy",
     "PairTradingConfig",
     "PairTradingStrategy",
     "StrategyAction",

--- a/src/trading/strategies/donchian_atr_breakout.py
+++ b/src/trading/strategies/donchian_atr_breakout.py
@@ -1,0 +1,186 @@
+"""Donchian channel breakout with ATR-based trailing stop."""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from typing import Mapping
+
+import numpy as np
+
+from src.core.strategy.engine import BaseStrategy
+from src.risk.analytics.volatility_target import (
+    calculate_realised_volatility,
+    determine_target_allocation,
+)
+
+from .models import StrategySignal
+
+__all__ = ["DonchianATRBreakoutConfig", "DonchianATRBreakoutStrategy"]
+
+_EPSILON = 1e-12
+
+
+def _extract_array(payload: Mapping[str, object], key: str) -> np.ndarray | None:
+    values = payload.get(key)
+    if values is None:
+        return None
+    return np.asarray(values, dtype=float)
+
+
+@dataclass(slots=True)
+class DonchianATRBreakoutConfig:
+    """Configuration for Donchian breakout strategy with ATR guardrails."""
+
+    channel_lookback: int = 20
+    atr_lookback: int = 14
+    breakout_buffer_atr: float = 0.5
+    trailing_stop_atr: float = 2.0
+    target_volatility: float = 0.11
+    max_leverage: float = 2.0
+    annualisation_factor: float = math.sqrt(252.0)
+
+
+class DonchianATRBreakoutStrategy(BaseStrategy):
+    """Generate breakout signals using Donchian channels and ATR trailing stops."""
+
+    def __init__(
+        self,
+        strategy_id: str,
+        symbols: list[str],
+        *,
+        capital: float,
+        config: DonchianATRBreakoutConfig | None = None,
+    ) -> None:
+        super().__init__(strategy_id=strategy_id, symbols=symbols)
+        self._capital = float(capital)
+        self._config = config or DonchianATRBreakoutConfig()
+
+    async def generate_signal(
+        self, market_data: Mapping[str, object], symbol: str
+    ) -> StrategySignal:
+        payload_obj = market_data.get(symbol)
+        if not isinstance(payload_obj, Mapping):
+            return StrategySignal(
+                symbol=symbol,
+                action="FLAT",
+                confidence=0.0,
+                notional=0.0,
+                metadata={"reason": "missing_market_data"},
+            )
+
+        closes = _extract_array(payload_obj, "close")
+        if closes is None or closes.size < max(self._config.channel_lookback, self._config.atr_lookback) + 1:
+            return StrategySignal(
+                symbol=symbol,
+                action="FLAT",
+                confidence=0.0,
+                notional=0.0,
+                metadata={"reason": "insufficient_data"},
+            )
+
+        highs = _extract_array(payload_obj, "high")
+        lows = _extract_array(payload_obj, "low")
+        if highs is None:
+            highs = closes
+        if lows is None:
+            lows = closes
+
+        channel_window = closes[-(self._config.channel_lookback + 1) : -1]
+        if channel_window.size == 0:
+            channel_window = closes[-self._config.channel_lookback :]
+        channel_high = float(np.max(channel_window))
+        channel_low = float(np.min(channel_window))
+        last_close = float(closes[-1])
+
+        atr = self._compute_atr(closes, highs, lows)
+
+        breakout_buffer = self._config.breakout_buffer_atr * max(atr, _EPSILON)
+        upper_trigger = channel_high + breakout_buffer
+        lower_trigger = channel_low - breakout_buffer
+
+        if last_close >= upper_trigger:
+            action = "BUY"
+        elif last_close <= lower_trigger:
+            action = "SELL"
+        else:
+            action = "FLAT"
+
+        returns = np.diff(closes) / closes[:-1]
+        realised_vol = calculate_realised_volatility(
+            returns[-max(self._config.channel_lookback, self._config.atr_lookback) :],
+            annualisation_factor=self._config.annualisation_factor,
+        )
+
+        confidence = 0.0
+        notional = 0.0
+        trailing_stop: float | None = None
+
+        if action != "FLAT":
+            if action == "BUY":
+                excess = last_close - upper_trigger
+                trailing_stop = last_close - self._config.trailing_stop_atr * atr
+            else:
+                excess = lower_trigger - last_close
+                trailing_stop = last_close + self._config.trailing_stop_atr * atr
+
+            threshold = max(breakout_buffer, _EPSILON)
+            ratio = max(excess, 0.0) / threshold
+            confidence = float(min(ratio, 2.0) / 2.0)
+            allocation = determine_target_allocation(
+                capital=self._capital,
+                target_volatility=self._config.target_volatility,
+                realised_volatility=realised_vol,
+                max_leverage=self._config.max_leverage,
+            )
+            notional = allocation.target_notional
+            if action == "SELL":
+                notional *= -1.0
+
+        metadata = {
+            "channel_high": channel_high,
+            "channel_low": channel_low,
+            "atr": atr,
+            "upper_trigger": upper_trigger,
+            "lower_trigger": lower_trigger,
+            "target_volatility": self._config.target_volatility,
+            "max_leverage": self._config.max_leverage,
+            "trailing_stop": trailing_stop,
+        }
+
+        return StrategySignal(
+            symbol=symbol,
+            action=action,
+            confidence=confidence,
+            notional=notional,
+            metadata=metadata,
+        )
+
+    def _compute_atr(
+        self, closes: np.ndarray, highs: np.ndarray, lows: np.ndarray
+    ) -> float:
+        lookback = self._config.atr_lookback
+        if lookback <= 1:
+            return float(np.std(np.diff(closes)))
+
+        highs = highs[-lookback:]
+        lows = lows[-lookback:]
+        closes_window = closes[-(lookback + 1) :]
+
+        true_ranges = []
+        for idx in range(1, closes_window.size):
+            current_high = float(highs[idx - 1])
+            current_low = float(lows[idx - 1])
+            prev_close = float(closes_window[idx - 1])
+            current_close = float(closes_window[idx])
+            tr_components = [
+                current_high - current_low,
+                abs(current_high - prev_close),
+                abs(current_low - prev_close),
+                abs(current_close - prev_close),
+            ]
+            true_ranges.append(max(tr_components))
+
+        if not true_ranges:
+            return 0.0
+        return float(np.mean(true_ranges))

--- a/src/trading/strategies/multi_timeframe_momentum.py
+++ b/src/trading/strategies/multi_timeframe_momentum.py
@@ -1,0 +1,189 @@
+"""Multi-timeframe momentum stack for roadmap phase 2A."""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from typing import Mapping, Sequence
+
+import numpy as np
+
+from src.core.strategy.engine import BaseStrategy
+from src.risk.analytics.volatility_target import (
+    calculate_realised_volatility,
+    determine_target_allocation,
+)
+
+from .models import StrategyAction, StrategySignal
+
+__all__ = [
+    "MultiTimeframeMomentumConfig",
+    "MultiTimeframeMomentumStrategy",
+]
+
+_EPSILON = 1e-12
+
+
+def _extract_closes(market_data: Mapping[str, object], symbol: str) -> np.ndarray:
+    payload = market_data.get(symbol)
+    if not isinstance(payload, Mapping):
+        raise ValueError(f"Missing payload for symbol {symbol}")
+    closes = payload.get("close")
+    if closes is None:
+        raise ValueError(f"Missing close prices for symbol {symbol}")
+    array = np.asarray(closes, dtype=float)
+    if array.size < 3:
+        raise ValueError("At least three price points are required")
+    return array
+
+
+def _returns(closes: np.ndarray) -> np.ndarray:
+    return np.diff(closes) / closes[:-1]
+
+
+def _default_weights(lookbacks: Sequence[int]) -> np.ndarray:
+    weights = np.asarray([1.0 / math.sqrt(max(lb, 1)) for lb in lookbacks], dtype=float)
+    total = float(np.sum(np.abs(weights)))
+    if total <= _EPSILON:
+        return np.ones(len(lookbacks), dtype=float)
+    return weights / total
+
+
+@dataclass(slots=True)
+class MultiTimeframeMomentumConfig:
+    """Configuration for the multi-timeframe momentum stack."""
+
+    lookbacks: tuple[int, ...] = (10, 30, 90)
+    entry_threshold: float = 0.35
+    min_alignment: int = 2
+    target_volatility: float = 0.10
+    max_leverage: float = 2.0
+    annualisation_factor: float = math.sqrt(252.0)
+    weights: tuple[float, ...] | None = None
+
+    def normalised_weights(self) -> np.ndarray:
+        if self.weights is not None:
+            if len(self.weights) != len(self.lookbacks):
+                raise ValueError("weights must match lookbacks length")
+            weights = np.asarray(self.weights, dtype=float)
+            total = float(np.sum(np.abs(weights)))
+            if total <= _EPSILON:
+                raise ValueError("weights must not all be zero")
+            return weights / total
+        return _default_weights(self.lookbacks)
+
+
+class MultiTimeframeMomentumStrategy(BaseStrategy):
+    """Aggregates momentum signals across multiple timeframes."""
+
+    def __init__(
+        self,
+        strategy_id: str,
+        symbols: list[str],
+        *,
+        capital: float,
+        config: MultiTimeframeMomentumConfig | None = None,
+    ) -> None:
+        super().__init__(strategy_id=strategy_id, symbols=symbols)
+        self._config = config or MultiTimeframeMomentumConfig()
+        self._capital = float(capital)
+
+    async def generate_signal(
+        self, market_data: Mapping[str, object], symbol: str
+    ) -> StrategySignal:
+        try:
+            closes = _extract_closes(market_data, symbol)
+            returns = _returns(closes)
+        except Exception as exc:
+            return StrategySignal(
+                symbol=symbol,
+                action="FLAT",
+                confidence=0.0,
+                notional=0.0,
+                metadata={"reason": "insufficient_data", "error": str(exc)},
+            )
+
+        lookbacks = self._config.lookbacks
+        weights = self._config.normalised_weights()
+        if len(lookbacks) == 0:
+            return StrategySignal(
+                symbol=symbol,
+                action="FLAT",
+                confidence=0.0,
+                notional=0.0,
+                metadata={"reason": "no_lookbacks_configured"},
+            )
+
+        scores: list[float] = []
+        momentum_summary: dict[str, float] = {}
+        for lookback, weight in zip(lookbacks, weights):
+            if lookback <= 0:
+                continue
+            if returns.size < lookback:
+                raise ValueError(
+                    f"Not enough return observations for lookback {lookback}"
+                )
+            window = returns[-lookback:]
+            mean_ret = float(np.mean(window))
+            std_ret = float(np.std(window, ddof=1 if window.size > 1 else 0))
+            score = mean_ret / max(std_ret, _EPSILON)
+            scores.append(score * weight)
+            momentum_summary[str(lookback)] = score
+
+        if not scores:
+            return StrategySignal(
+                symbol=symbol,
+                action="FLAT",
+                confidence=0.0,
+                notional=0.0,
+                metadata={"reason": "no_valid_scores"},
+            )
+
+        aggregated_score = float(np.sum(scores))
+        positive = sum(1 for score in momentum_summary.values() if score > 0.0)
+        negative = sum(1 for score in momentum_summary.values() if score < 0.0)
+
+        alignment_required = max(1, self._config.min_alignment)
+        action: StrategyAction = "FLAT"
+        if aggregated_score >= self._config.entry_threshold and positive >= alignment_required:
+            action = "BUY"
+        elif aggregated_score <= -self._config.entry_threshold and negative >= alignment_required:
+            action = "SELL"
+
+        confidence = 0.0
+        notional = 0.0
+        longest_lookback = max(lookbacks)
+        realised_vol = calculate_realised_volatility(
+            returns[-longest_lookback:],
+            annualisation_factor=self._config.annualisation_factor,
+        )
+
+        if action != "FLAT":
+            ratio = abs(aggregated_score) / max(self._config.entry_threshold, _EPSILON)
+            confidence = float(min(ratio, 2.0) / 2.0)
+            allocation = determine_target_allocation(
+                capital=self._capital,
+                target_volatility=self._config.target_volatility,
+                realised_volatility=realised_vol,
+                max_leverage=self._config.max_leverage,
+            )
+            notional = allocation.target_notional
+            if action == "SELL":
+                notional *= -1.0
+
+        metadata = {
+            "aggregated_score": aggregated_score,
+            "window_scores": momentum_summary,
+            "alignment": {"positive": positive, "negative": negative},
+            "target_volatility": self._config.target_volatility,
+            "max_leverage": self._config.max_leverage,
+            "realised_volatility": realised_vol,
+        }
+
+        return StrategySignal(
+            symbol=symbol,
+            action=action,
+            confidence=confidence,
+            notional=notional,
+            metadata=metadata,
+        )

--- a/tests/trading/test_high_impact_strategies.py
+++ b/tests/trading/test_high_impact_strategies.py
@@ -1,13 +1,16 @@
 from __future__ import annotations
 
-import numpy as np
 import pytest
 
 from src.trading.strategies import (
+    DonchianATRBreakoutConfig,
+    DonchianATRBreakoutStrategy,
     MeanReversionStrategy,
     MeanReversionStrategyConfig,
     MomentumStrategy,
     MomentumStrategyConfig,
+    MultiTimeframeMomentumConfig,
+    MultiTimeframeMomentumStrategy,
     StrategySignal,
     VolatilityBreakoutConfig,
     VolatilityBreakoutStrategy,
@@ -82,6 +85,96 @@ async def test_volatility_breakout_detects_price_channel_breach() -> None:
     assert signal.action == "BUY"
     assert signal.notional > 0.0
     assert signal.confidence > 0.0
+
+
+@pytest.mark.asyncio
+async def test_multi_timeframe_momentum_requires_alignment() -> None:
+    config = MultiTimeframeMomentumConfig(
+        lookbacks=(5, 10, 20),
+        entry_threshold=0.25,
+        min_alignment=2,
+    )
+    strategy = MultiTimeframeMomentumStrategy(
+        "mtm",
+        ["EURUSD"],
+        capital=1_500_000,
+        config=config,
+    )
+
+    closes = [1.0 + 0.003 * idx for idx in range(25)]
+    signal = await strategy.generate_signal(_market(closes), "EURUSD")
+
+    assert signal.action == "BUY"
+    assert signal.confidence > 0.0
+    assert signal.notional > 0.0
+    assert signal.metadata["alignment"]["positive"] >= 2
+
+
+@pytest.mark.asyncio
+async def test_multi_timeframe_momentum_flats_on_misalignment() -> None:
+    config = MultiTimeframeMomentumConfig(lookbacks=(3, 6, 12), entry_threshold=0.2, min_alignment=3)
+    strategy = MultiTimeframeMomentumStrategy(
+        "mtm",
+        ["EURUSD"],
+        capital=500_000,
+        config=config,
+    )
+
+    closes = [
+        1.20,
+        1.18,
+        1.16,
+        1.14,
+        1.12,
+        1.10,
+        1.08,
+        1.06,
+        1.05,
+        1.04,
+        1.045,
+        1.05,
+        1.055,
+        1.06,
+        1.065,
+        1.07,
+    ]
+    signal = await strategy.generate_signal(_market(closes), "EURUSD")
+
+    assert signal.action == "FLAT"
+    assert signal.notional == pytest.approx(0.0)
+
+
+@pytest.mark.asyncio
+async def test_donchian_breakout_produces_trailing_stop() -> None:
+    config = DonchianATRBreakoutConfig(
+        channel_lookback=5,
+        atr_lookback=5,
+        breakout_buffer_atr=0.2,
+        trailing_stop_atr=1.5,
+    )
+    strategy = DonchianATRBreakoutStrategy(
+        "donchian",
+        ["EURUSD"],
+        capital=2_000_000,
+        config=config,
+    )
+
+    closes = [1.0, 1.01, 1.012, 1.015, 1.017, 1.02, 1.025, 1.06]
+    market = {"EURUSD": {"close": closes}}
+    signal = await strategy.generate_signal(market, "EURUSD")
+
+    assert signal.action == "BUY"
+    assert signal.metadata["trailing_stop"] is not None
+    assert signal.metadata["trailing_stop"] < closes[-1]
+
+
+@pytest.mark.asyncio
+async def test_donchian_breakout_handles_missing_data() -> None:
+    strategy = DonchianATRBreakoutStrategy("donchian", ["EURUSD"], capital=1_000_000)
+    signal = await strategy.generate_signal({"EURUSD": {"close": [1.0, 1.01]}}, "EURUSD")
+
+    assert signal.action == "FLAT"
+    assert signal.metadata["reason"] == "insufficient_data"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- add a multi-timeframe momentum strategy with configurable alignment and risk sizing controls
- introduce a Donchian + ATR breakout strategy that exposes trailing stop guidance and integrates with existing sizing utilities
- document roadmap progress and expand the strategy regression suite for the new behaviours

## Testing
- pytest tests/trading/test_high_impact_strategies.py

------
https://chatgpt.com/codex/tasks/task_e_68d960525c40832c9cefd4a53611181c