### PR TITLE
Expand high-impact roadmap execution checks

### DIFF
--- a/docs/status/high_impact_roadmap_detail.md
+++ b/docs/status/high_impact_roadmap_detail.md
@@ -66,3 +66,12 @@
 - operations.configuration_audit.evaluate_configuration_audit
 - operations.system_validation.evaluate_system_validation
 - operations.slo.evaluate_ingest_slos
+- operations.event_bus_health.evaluate_event_bus_health
+- operations.failover_drill.execute_failover_drill
+- trading.order_management.lifecycle_processor.OrderLifecycleProcessor
+- trading.order_management.position_tracker.PositionTracker
+- trading.order_management.event_journal.OrderEventJournal
+- trading.order_management.reconciliation.replay_order_events
+- scripts/order_lifecycle_dry_run.py
+- scripts/reconcile_positions.py
+- docs/runbooks/execution_lifecycle.md

--- a/tests/tools/test_high_impact_roadmap.py
+++ b/tests/tools/test_high_impact_roadmap.py
@@ -48,6 +48,27 @@ def test_stream_b_lists_all_sensory_organs() -> None:
     }.issubset(status.evidence)
 
 
+def test_stream_c_covers_execution_lifecycle_artifacts() -> None:
+    status = _status_map()[
+        "Stream C – Execution, risk, compliance, ops readiness"
+    ]
+
+    expected_entries = {
+        "operations.event_bus_health.evaluate_event_bus_health",
+        "operations.failover_drill.execute_failover_drill",
+        "trading.order_management.lifecycle_processor.OrderLifecycleProcessor",
+        "trading.order_management.position_tracker.PositionTracker",
+        "trading.order_management.event_journal.OrderEventJournal",
+        "trading.order_management.reconciliation.replay_order_events",
+        "scripts/order_lifecycle_dry_run.py",
+        "scripts/reconcile_positions.py",
+        "docs/runbooks/execution_lifecycle.md",
+    }
+
+    for entry in expected_entries:
+        assert entry in status.evidence, f"missing {entry}"
+
+
 def test_markdown_formatter_outputs_table() -> None:
     statuses = high_impact.evaluate_streams()
     markdown = high_impact.format_markdown(statuses)

--- a/tools/roadmap/high_impact.py
+++ b/tools/roadmap/high_impact.py
@@ -13,6 +13,7 @@ from ._shared import (
     evaluate_requirements,
     repo_root,
     require_module_attr,
+    require_path,
 )
 
 
@@ -205,6 +206,28 @@ def _stream_definitions() -> Sequence[StreamDefinition]:
                     "operations.system_validation", "evaluate_system_validation"
                 ),
                 require_module_attr("operations.slo", "evaluate_ingest_slos"),
+                require_module_attr(
+                    "operations.event_bus_health", "evaluate_event_bus_health"
+                ),
+                require_module_attr(
+                    "operations.failover_drill", "execute_failover_drill"
+                ),
+                require_module_attr(
+                    "trading.order_management.lifecycle_processor",
+                    "OrderLifecycleProcessor",
+                ),
+                require_module_attr(
+                    "trading.order_management.position_tracker", "PositionTracker"
+                ),
+                require_module_attr(
+                    "trading.order_management.event_journal", "OrderEventJournal"
+                ),
+                require_module_attr(
+                    "trading.order_management.reconciliation", "replay_order_events"
+                ),
+                require_path("scripts/order_lifecycle_dry_run.py"),
+                require_path("scripts/reconcile_positions.py"),
+                require_path("docs/runbooks/execution_lifecycle.md"),
             ),
         ),
     )


### PR DESCRIPTION
## Summary
- extend the high-impact roadmap CLI to require execution lifecycle artefacts and operational evaluators
- update the roadmap detail doc so Stream C lists the new evidence points
- expand the roadmap tests to assert the execution stream reports the new evidence

## Testing
- `pytest tests/tools/test_high_impact_roadmap.py`


------
https://chatgpt.com/codex/tasks/task_e_68d960525c40832c9cefd4a53611181c