### PR TITLE
Add capital efficiency memo workflow

### DIFF
--- a/docs/High-Impact Development Roadmap.md
+++ b/docs/High-Impact Development Roadmap.md
@@ -115,7 +115,7 @@ To reflect the true scope of institutional-grade trading components, the roadmap
 - [x] Produce automated risk report artifact (Markdown/JSON) for CI artifacts (`scripts/generate_risk_report.py`).
 - [x] Backfill encyclopedia Tier-0/Tier-1 risk scenarios as pytest parametrized cases to validate guardrail behavior.
 - [x] Integrate VaR/ES outputs into canonical risk configuration defaults (`src/config/risk/risk_config.py`).
-- [ ] Publish weekly capital efficiency memo comparing realized vs target risk budgets.
+- [x] Publish weekly capital efficiency memo comparing realized vs target risk budgets.
 
 **Acceptance:** Pre-trade checks block orders breaching VaR/ES or exposure limits; regression suite validates guardrails.
 
@@ -141,7 +141,7 @@ To reflect the true scope of institutional-grade trading components, the roadmap
 - [x] Add data quality validators (missing candles, stale prices, split/dividend adjustments) with alerts feeding Workstream 1C dashboard.
 - [x] Cache normalized datasets in `data_foundation/cache/` with retention policies documented for Tier-0 bootstrap.
 - [x] Ship `scripts/data_bootstrap.py` to hydrate local env and CI with canonical fixtures used by sensors and strategies.
-- [ ] Cross-link encyclopedia tables for free-vs-premium data trade-offs within `/docs/runbooks/data_foundation.md`.
+- [x] Cross-link encyclopedia tables for free-vs-premium data trade-offs within `/docs/runbooks/data_foundation.md`.
 
 **Acceptance:** Canonical datasets load without manual intervention; validators surface anomalies; encyclopedia data lineage references stay in sync with implementation.
 

--- a/docs/runbooks/data_foundation.md
+++ b/docs/runbooks/data_foundation.md
@@ -65,3 +65,19 @@ data stores.
 All artefacts are Git-ignored and regenerated on demand; the runbook ensures a
 repeatable workflow for onboarding new venues or data vendors without drifting
 from the encyclopedia baseline.
+
+## Encyclopedia Cross-References
+
+The EMP Encyclopedia outlines which data vendors underpin the free Tier-0
+bootstrap versus premium professional feeds. Cross-linking these tables keeps
+runbook guidance aligned with the canonical operating model:
+
+- Tier-0 free sources (Yahoo, Alpha Vantage, FRED) and their rate limits guide
+  default bootstrap expectations.【F:docs/EMP_ENCYCLOPEDIA_v2.3_CANONICAL.md†L6864-L6881】
+- Tier-1/Tier-2 premium feeds (IC Markets FIX, Alpha Vantage Premium, Refinitiv,
+  Bloomberg) establish the upgrade path operators should plan for when moving
+  beyond bootstrap mode.【F:docs/EMP_ENCYCLOPEDIA_v2.3_CANONICAL.md†L6882-L6903】
+
+Operators updating vendor configurations should reference these tables when
+raising change requests so budgeting, latency targets, and entitlement checks
+match the encyclopedia narrative.

--- a/scripts/generate_capital_efficiency_memo.py
+++ b/scripts/generate_capital_efficiency_memo.py
@@ -1,0 +1,52 @@
+"""Generate a weekly capital efficiency memo from a risk report JSON artefact."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from src.risk import RiskReport, generate_capital_efficiency_memo
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "risk_report",
+        type=Path,
+        help="Path to a JSON file produced by scripts/generate_risk_report.py",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        help="Optional path to write the memo Markdown output",
+    )
+    return parser
+
+
+def main() -> None:
+    parser = build_parser()
+    args = parser.parse_args()
+
+    try:
+        payload = json.loads(args.risk_report.read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        parser.error(f"risk report file not found: {args.risk_report}")
+    except json.JSONDecodeError as exc:
+        parser.error(f"risk report file is not valid JSON: {exc}")
+
+    try:
+        report = RiskReport.from_mapping(payload)
+    except ValueError as exc:
+        parser.error(str(exc))
+
+    memo = generate_capital_efficiency_memo(report)
+
+    if args.output:
+        args.output.write_text(memo, encoding="utf-8")
+
+    print(memo)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/risk/__init__.py
+++ b/src/risk/__init__.py
@@ -13,9 +13,11 @@ from .analytics import (
     determine_target_allocation,
 )
 from .reporting import (
+    BudgetUtilisation,
     ExposureBreakdown,
     PortfolioRiskLimits,
     RiskReport,
+    generate_capital_efficiency_memo,
     generate_risk_report,
     load_portfolio_limits,
     render_risk_report_json,
@@ -34,9 +36,11 @@ from .telemetry import (
 __all__ = [
     "RealRiskManager",
     "RealRiskConfig",
+    "BudgetUtilisation",
     "ExposureBreakdown",
     "PortfolioRiskLimits",
     "RiskReport",
+    "generate_capital_efficiency_memo",
     "generate_risk_report",
     "load_portfolio_limits",
     "render_risk_report_json",

--- a/src/risk/reporting/__init__.py
+++ b/src/risk/reporting/__init__.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from .capital_efficiency import BudgetUtilisation, generate_capital_efficiency_memo
 from .report_generator import (
     ExposureBreakdown,
     PortfolioRiskLimits,
@@ -13,10 +14,12 @@ from .report_generator import (
 )
 
 __all__ = [
+    "BudgetUtilisation",
     "ExposureBreakdown",
     "PortfolioRiskLimits",
     "RiskReport",
     "generate_risk_report",
+    "generate_capital_efficiency_memo",
     "load_portfolio_limits",
     "render_risk_report_json",
     "render_risk_report_markdown",

--- a/src/risk/reporting/capital_efficiency.py
+++ b/src/risk/reporting/capital_efficiency.py
@@ -1,0 +1,120 @@
+"""Capital efficiency memo generator aligned with the high-impact roadmap."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from typing import Iterable
+
+from .report_generator import ExposureBreakdown, PortfolioRiskLimits, RiskReport
+
+__all__ = [
+    "BudgetUtilisation",
+    "generate_capital_efficiency_memo",
+]
+
+
+@dataclass(slots=True)
+class BudgetUtilisation:
+    """Snapshot of a risk budget utilisation metric."""
+
+    label: str
+    realised: float
+    target: float | None
+
+    @property
+    def utilisation_ratio(self) -> float | None:
+        if self.target in (None, 0.0):
+            return None
+        return self.realised / self.target
+
+
+def _format_ratio(utilisation: float | None) -> str:
+    if utilisation is None:
+        return "n/a"
+    return f"{utilisation * 100:.1f}%"
+
+
+def _iter_budget_lines(report: RiskReport) -> Iterable[BudgetUtilisation]:
+    limits = report.limits
+    yield BudgetUtilisation(
+        label="Aggregate exposure",
+        realised=report.total_exposure,
+        target=limits.aggregate_cap if limits else None,
+    )
+    yield BudgetUtilisation(
+        label=f"Historical VaR ({report.confidence:.0%})",
+        realised=report.historical_var,
+        target=limits.var95_cap if limits else None,
+    )
+
+
+def _format_notional(value: float) -> str:
+    return f"{value:.4f}"
+
+
+def _per_asset_flag(exposure: ExposureBreakdown, limits: PortfolioRiskLimits | None) -> str:
+    if not limits or limits.per_asset_cap is None:
+        return ""
+    return "⚠️" if abs(exposure.notional) > limits.per_asset_cap else ""
+
+
+def generate_capital_efficiency_memo(report: RiskReport) -> str:
+    """Render a weekly capital efficiency memo for operators."""
+
+    lines: list[str] = [
+        "# Weekly Capital Efficiency Memo",
+        "",
+        f"Generated: {report.generated_at.isoformat()}",
+        "",
+        "## Risk Budget Utilisation",
+        "",
+    ]
+
+    for budget in _iter_budget_lines(report):
+        target_display = (
+            _format_notional(budget.target) if budget.target is not None else "not set"
+        )
+        lines.append(
+            f"- {budget.label}: {_format_notional(budget.realised)} (limit: {target_display}, utilisation: {_format_ratio(budget.utilisation_ratio)})"
+        )
+
+    lines.extend(["", "## Exposure Concentration", ""])
+
+    if report.exposures:
+        lines.extend(
+            [
+                "| Symbol | Notional | Share | Limit Flag |",
+                "| --- | ---: | ---: | :---: |",
+            ]
+        )
+        for exposure in report.exposures:
+            lines.append(
+                "| {symbol} | {notional} | {share:.2f}% | {flag} |".format(
+                    symbol=exposure.symbol,
+                    notional=_format_notional(exposure.notional),
+                    share=exposure.percentage,
+                    flag=_per_asset_flag(exposure, report.limits),
+                )
+            )
+        if report.limits and report.limits.per_asset_cap is not None:
+            lines.append(
+                "\n_Per-asset limit: {limit}_".format(
+                    limit=_format_notional(report.limits.per_asset_cap)
+                )
+            )
+    else:
+        lines.append("_No exposures supplied._")
+
+    lines.extend(["", "## Breach Log", ""])
+
+    if report.breaches:
+        for name, payload in sorted(report.breaches.items()):
+            lines.append(
+                f"- **{name.replace('_', ' ').title()}**: {json.dumps(payload, sort_keys=True)}"
+            )
+    else:
+        lines.append("_No breaches recorded._")
+
+    memo = "\n".join(lines).strip()
+    return memo + "\n"

--- a/tests/risk/test_capital_efficiency_memo.py
+++ b/tests/risk/test_capital_efficiency_memo.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from src.risk import (
+    ExposureBreakdown,
+    PortfolioRiskLimits,
+    RiskReport,
+    generate_capital_efficiency_memo,
+)
+
+
+def build_sample_report() -> RiskReport:
+    exposures = (
+        ExposureBreakdown(symbol="EURUSD", notional=0.6, percentage=60.0),
+        ExposureBreakdown(symbol="GBPUSD", notional=0.4, percentage=40.0),
+    )
+    limits = PortfolioRiskLimits(
+        per_asset_cap=0.5,
+        aggregate_cap=1.0,
+        usd_beta_cap=None,
+        var95_cap=0.02,
+    )
+    return RiskReport(
+        generated_at=datetime(2025, 1, 1, tzinfo=timezone.utc),
+        confidence=0.95,
+        sample_size=128,
+        historical_var=0.015,
+        parametric_var=0.018,
+        monte_carlo_var=0.02,
+        monte_carlo_simulations=5000,
+        historical_expected_shortfall=0.02,
+        parametric_expected_shortfall=0.022,
+        total_exposure=1.0,
+        exposures=exposures,
+        breaches={"per_asset": {"symbols": ["EURUSD"], "limit": 0.5}},
+        limits=limits,
+    )
+
+
+def test_generate_capital_efficiency_memo_includes_utilisation() -> None:
+    report = build_sample_report()
+
+    memo = generate_capital_efficiency_memo(report)
+
+    assert "Aggregate exposure" in memo
+    assert "100.0%" in memo
+    assert "⚠️" in memo
+    assert memo.endswith("\n")
+
+
+def test_risk_report_from_mapping_round_trip() -> None:
+    report = build_sample_report()
+    payload = report.to_dict()
+
+    hydrated = RiskReport.from_mapping(payload)
+
+    assert hydrated.generated_at == report.generated_at
+    assert hydrated.sample_size == report.sample_size
+    assert hydrated.breaches == report.breaches
+    assert hydrated.limits and hydrated.limits.per_asset_cap == report.limits.per_asset_cap


### PR DESCRIPTION
## Summary
- add a capital efficiency memo generator plus CLI wiring to the risk reporting stack
- extend the risk report dataclass to support JSON rehydration and expose the new helper through package exports
- cross-link the data foundation runbook with encyclopedia vendor tables and mark the roadmap items complete

## Testing
- pytest tests/risk/test_capital_efficiency_memo.py tests/risk/test_risk_report_generator.py


------
https://chatgpt.com/codex/tasks/task_e_68d96650dda8832c9057ca4f27f644b0