### PR TITLE
Add summary formatter to high-impact roadmap CLI

### DIFF
--- a/docs/status/high_impact_roadmap.md
+++ b/docs/status/high_impact_roadmap.md
@@ -14,6 +14,12 @@ To focus on specific streams, provide one or more ``--stream`` flags:
 python -m tools.roadmap.high_impact --stream "Stream A – Institutional data backbone" --format detail
 ```
 
+For an at-a-glance rollup of the portfolio, render the summary view:
+
+```bash
+python -m tools.roadmap.high_impact --format summary
+```
+
 To update both this summary and the detailed evidence companion file in one
 shot, use the refresh flag:
 

--- a/tests/tools/test_high_impact_roadmap.py
+++ b/tests/tools/test_high_impact_roadmap.py
@@ -77,6 +77,16 @@ def test_markdown_formatter_outputs_table() -> None:
     assert "Stream A – Institutional data backbone" in markdown
 
 
+def test_portfolio_summary_formatter_lists_counts() -> None:
+    statuses = high_impact.evaluate_streams()
+    summary = high_impact.format_portfolio_summary(statuses)
+
+    assert summary.startswith("# High-impact roadmap summary")
+    assert "Total streams" in summary
+    assert "Ready" in summary
+    assert "Stream A – Institutional data backbone" in summary
+
+
 def test_summarise_portfolio_counts_ready_streams() -> None:
     statuses = high_impact.evaluate_streams()
 

--- a/tools/roadmap/high_impact.py
+++ b/tools/roadmap/high_impact.py
@@ -321,6 +321,35 @@ def format_markdown(statuses: Iterable[StreamStatus]) -> str:
     return "\n".join(lines)
 
 
+def format_portfolio_summary(statuses: Iterable[StreamStatus]) -> str:
+    """Return a narrative summary of the overall portfolio health."""
+
+    portfolio = summarise_portfolio(statuses)
+    lines = [
+        "# High-impact roadmap summary",
+        "",
+        f"- Total streams: {portfolio.total_streams}",
+        f"- Ready: {portfolio.ready}",
+        f"- Attention needed: {portfolio.attention_needed}",
+    ]
+
+    if portfolio.streams:
+        lines.extend(["", "## Streams", ""])
+        for status in portfolio.streams:
+            lines.extend(
+                [
+                    f"### {status.stream}",
+                    "",
+                    f"*Status:* {status.status}",
+                    f"*Summary:* {status.summary}",
+                    f"*Next checkpoint:* {status.next_checkpoint}",
+                    "",
+                ]
+            )
+
+    return "\n".join(lines).rstrip()
+
+
 def format_detail(statuses: Iterable[StreamStatus]) -> str:
     """Return a richer Markdown report for dashboards and docs."""
 
@@ -443,7 +472,7 @@ def main(argv: Sequence[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
         "--format",
-        choices=("markdown", "json", "detail"),
+        choices=("markdown", "json", "detail", "summary"),
         default="markdown",
         help="Output format (default: markdown table)",
     )
@@ -478,6 +507,8 @@ def main(argv: Sequence[str] | None = None) -> int:
         output = format_json(statuses)
     elif args.format == "detail":
         output = format_detail(statuses)
+    elif args.format == "summary":
+        output = format_portfolio_summary(statuses)
     else:
         output = format_markdown(statuses)
 


### PR DESCRIPTION
## Summary
- add a portfolio summary formatter to the high-impact roadmap CLI and expose it via `--format summary`
- cover the new formatter with unit tests that exercise the narrative output
- document how to render the summary view in the roadmap status guide

## Testing
- pytest tests/tools/test_high_impact_roadmap.py -q

------
https://chatgpt.com/codex/tasks/task_e_68d96bcbc898832ca624c4823292bcd1