### PR TITLE
Add sensory registry generator for roadmap documentation

### DIFF
--- a/docs/High-Impact Development Roadmap.md
+++ b/docs/High-Impact Development Roadmap.md
@@ -195,7 +195,7 @@ To reflect the true scope of institutional-grade trading components, the roadmap
 - [ ] Expand tests to validate sensor outputs over historical datasets.
 - [ ] Implement WHY-dimension narrative hooks (economic calendar sentiment, macro regime flags) using encyclopedia cues.
 - [ ] Stand up anomaly detection harness comparing sensor drifts vs baseline expectation windows.
-- [ ] Synchronize sensor metadata catalog in `/docs/sensory_registry.md` with encyclopedia Layer 2 tables.
+- [x] Synchronize sensor metadata catalog in `/docs/sensory_registry.md` with encyclopedia Layer 2 tables (auto-generated via `python -m tools.sensory.registry`).
 
 **Acceptance:** Strategies consume new sensory inputs; CI verifies data integrity; backlog explicitly records deferred advanced analytics.
 

--- a/docs/sensory_registry.md
+++ b/docs/sensory_registry.md
@@ -1,0 +1,66 @@
+# Sensory registry
+
+This registry summarises the high-impact sensory organs and their
+configuration surfaces. Regenerate via `python -m tools.sensory.registry`.
+
+## HOW – sensory.how.how_sensor.HowSensor
+
+Bridge the institutional HOW engine into the legacy sensory pipeline.
+
+### Configuration
+
+Configuration for the HOW sensor calibration thresholds.
+
+| Field | Type | Default |
+| --- | --- | --- |
+| `minimum_confidence` | float | 0.2 |
+| `warn_threshold` | float | 0.35 |
+| `alert_threshold` | float | 0.65 |
+
+## WHAT – sensory.what.what_sensor.WhatSensor
+
+Pattern sensor (WHAT dimension).
+
+*This sensor does not expose configuration parameters.*
+
+## WHEN – sensory.when.when_sensor.WhenSensor
+
+Temporal/context sensor (WHEN dimension).
+
+Combines session intensity, macro event proximity, and option gamma posture to
+reflect the temporal edge of acting right now versus waiting for better
+conditions.
+
+### Configuration
+
+Configuration for the WHEN sensor scoring function.
+
+| Field | Type | Default |
+| --- | --- | --- |
+| `minimum_confidence` | float | 0.2 |
+| `session_weight` | float | 0.4 |
+| `news_weight` | float | 0.3 |
+| `gamma_weight` | float | 0.3 |
+| `news_decay_minutes` | int | 120 |
+| `gamma_near_fraction` | float | 0.01 |
+| `gamma_pressure_normalizer` | float | 50000.0 |
+
+## WHY – sensory.why.why_sensor.WhySensor
+
+Macro proxy sensor (WHY dimension) with yield-curve awareness.
+
+*This sensor does not expose configuration parameters.*
+
+## ANOMALY – sensory.anomaly.anomaly_sensor.AnomalySensor
+
+Detect displacements in price/volume behaviour for the ANOMALY dimension.
+
+### Configuration
+
+Configuration for anomaly detection thresholds.
+
+| Field | Type | Default |
+| --- | --- | --- |
+| `window` | int | 32 |
+| `warn_threshold` | float | 0.4 |
+| `alert_threshold` | float | 0.7 |

--- a/tests/tools/test_sensory_registry.py
+++ b/tests/tools/test_sensory_registry.py
@@ -1,0 +1,41 @@
+"""Tests for the sensory registry CLI."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from tools.sensory import registry
+
+
+def test_build_registry_includes_all_dimensions() -> None:
+    entries = registry.build_registry()
+
+    dimensions = {entry.dimension for entry in entries}
+    assert dimensions == {"HOW", "WHAT", "WHEN", "WHY", "ANOMALY"}
+
+
+def test_format_markdown_lists_config_fields() -> None:
+    entries = registry.build_registry()
+    markdown = registry.format_markdown(entries)
+
+    assert "Sensory registry" in markdown
+    assert "sensory.how.how_sensor.HowSensor" in markdown
+    assert "`minimum_confidence`" in markdown
+    assert "does not expose configuration" in markdown
+
+
+def test_cli_supports_json_and_markdown(tmp_path: Path) -> None:
+    destination = tmp_path / "registry.md"
+    exit_code = registry.main(["--output", str(destination)])
+
+    assert exit_code == 0
+    assert destination.exists()
+    content = destination.read_text(encoding="utf-8")
+    assert "Sensory registry" in content
+
+    json_exit = registry.main(["--format", "json"])
+    assert json_exit == 0
+
+    payload = json.loads(registry.format_json(registry.build_registry()))
+    assert payload[0]["qualified_name"].startswith("sensory")

--- a/tools/sensory/__init__.py
+++ b/tools/sensory/__init__.py
@@ -1,0 +1,7 @@
+"""Utilities supporting sensory system documentation and tooling."""
+
+from __future__ import annotations
+
+__all__ = ["__version__"]
+
+__version__ = "0.1.0"

--- a/tools/sensory/registry.py
+++ b/tools/sensory/registry.py
@@ -1,0 +1,263 @@
+"""Generate a Markdown registry describing the sensory organs."""
+
+from __future__ import annotations
+
+import argparse
+import importlib
+import inspect
+from dataclasses import MISSING, dataclass, fields, is_dataclass
+from pathlib import Path
+from typing import Iterable, Sequence
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SRC_PATH = REPO_ROOT / "src"
+if str(SRC_PATH) not in __import__("sys").path:
+    __import__("sys").path.insert(0, str(SRC_PATH))
+
+__all__ = [
+    "SensorDefinition",
+    "ConfigField",
+    "SensorRegistryEntry",
+    "build_registry",
+    "format_markdown",
+    "format_json",
+    "main",
+]
+
+
+@dataclass(frozen=True)
+class SensorDefinition:
+    """Description of a sensory organ implementation."""
+
+    dimension: str
+    module: str
+    class_name: str
+    config_name: str | None = None
+
+
+@dataclass(frozen=True)
+class ConfigField:
+    """Configuration metadata extracted from a dataclass."""
+
+    name: str
+    type: str
+    default: str
+
+
+@dataclass(frozen=True)
+class SensorRegistryEntry:
+    """Materialised registry entry for a sensory organ."""
+
+    dimension: str
+    qualified_name: str
+    description: str
+    config_description: str | None
+    config_fields: tuple[ConfigField, ...]
+
+    def as_dict(self) -> dict[str, object]:
+        return {
+            "dimension": self.dimension,
+            "qualified_name": self.qualified_name,
+            "description": self.description,
+            "config_description": self.config_description,
+            "config_fields": [field.__dict__ for field in self.config_fields],
+        }
+
+
+_DEFAULT_DEFINITIONS: tuple[SensorDefinition, ...] = (
+    SensorDefinition(
+        dimension="HOW",
+        module="sensory.how.how_sensor",
+        class_name="HowSensor",
+        config_name="HowSensorConfig",
+    ),
+    SensorDefinition(
+        dimension="WHAT",
+        module="sensory.what.what_sensor",
+        class_name="WhatSensor",
+    ),
+    SensorDefinition(
+        dimension="WHEN",
+        module="sensory.when.when_sensor",
+        class_name="WhenSensor",
+        config_name="WhenSensorConfig",
+    ),
+    SensorDefinition(
+        dimension="WHY",
+        module="sensory.why.why_sensor",
+        class_name="WhySensor",
+    ),
+    SensorDefinition(
+        dimension="ANOMALY",
+        module="sensory.anomaly.anomaly_sensor",
+        class_name="AnomalySensor",
+        config_name="AnomalySensorConfig",
+    ),
+)
+
+
+def build_registry(
+    definitions: Sequence[SensorDefinition] | None = None,
+) -> list[SensorRegistryEntry]:
+    """Return registry entries for the configured sensory organs."""
+
+    definitions = list(definitions or _DEFAULT_DEFINITIONS)
+    entries: list[SensorRegistryEntry] = []
+
+    for definition in definitions:
+        module = importlib.import_module(definition.module)
+        sensor_cls = getattr(module, definition.class_name)
+        description = inspect.getdoc(sensor_cls) or ""
+        qualified_name = f"{definition.module}.{definition.class_name}"
+
+        config_fields: list[ConfigField] = []
+        config_description: str | None = None
+
+        if definition.config_name:
+            config_obj = getattr(module, definition.config_name)
+            config_description = inspect.getdoc(config_obj)
+            if is_dataclass(config_obj):
+                for field in fields(config_obj):
+                    config_fields.append(
+                        ConfigField(
+                            name=field.name,
+                            type=_format_annotation(field.type),
+                            default=_format_default(field),
+                        )
+                    )
+
+        entries.append(
+            SensorRegistryEntry(
+                dimension=definition.dimension,
+                qualified_name=qualified_name,
+                description=description,
+                config_description=config_description,
+                config_fields=tuple(config_fields),
+            )
+        )
+
+    return entries
+
+
+def _format_annotation(annotation: object) -> str:
+    if annotation is inspect._empty or annotation is None:
+        return "Any"
+    origin = getattr(annotation, "__origin__", None)
+    if origin is not None:
+        args = getattr(annotation, "__args__", ())
+        formatted_args = ", ".join(_format_annotation(arg) for arg in args)
+        name = getattr(origin, "__name__", str(origin))
+        return f"{name}[{formatted_args}]"
+    if hasattr(annotation, "__name__"):
+        return annotation.__name__
+    text = str(annotation)
+    if text.startswith("typing."):
+        text = text[len("typing.") :]
+    return text
+
+
+def _format_default(field) -> str:
+    default = field.default
+    if default is not MISSING:
+        return _repr_default(default)
+    factory = getattr(field, "default_factory", MISSING)
+    if factory is not MISSING:
+        if getattr(factory, "__name__", None):
+            return f"factory:{factory.__name__}()"
+        return "factory"  # pragma: no cover - best effort only
+    return "required"
+
+
+def _repr_default(value: object) -> str:
+    if isinstance(value, (int, float, bool)):
+        return str(value)
+    if isinstance(value, str):
+        return f"'{value}'"
+    if value is None:
+        return "None"
+    return repr(value)
+
+
+def format_markdown(entries: Iterable[SensorRegistryEntry]) -> str:
+    """Return a Markdown document describing the sensory registry."""
+
+    lines = [
+        "# Sensory registry",
+        "",
+        "This registry summarises the high-impact sensory organs and their",
+        "configuration surfaces. Regenerate via `python -m tools.sensory.registry`.",
+        "",
+    ]
+
+    for entry in entries:
+        lines.extend(
+            [
+                f"## {entry.dimension} – {entry.qualified_name}",
+                "",
+            ]
+        )
+        description = entry.description or "No class documentation available."
+        lines.append(description)
+        lines.append("")
+
+        if entry.config_fields:
+            lines.append("### Configuration")
+            lines.append("")
+            if entry.config_description:
+                lines.append(entry.config_description)
+                lines.append("")
+            lines.append("| Field | Type | Default |")
+            lines.append("| --- | --- | --- |")
+            for field in entry.config_fields:
+                lines.append(
+                    f"| `{field.name}` | {field.type} | {field.default} |"
+                )
+            lines.append("")
+        else:
+            lines.append("*This sensor does not expose configuration parameters.*")
+            lines.append("")
+
+    return "\n".join(lines).rstrip()
+
+
+def format_json(entries: Iterable[SensorRegistryEntry]) -> str:
+    """Serialise entries as a JSON payload."""
+
+    import json
+
+    return json.dumps([entry.as_dict() for entry in entries], indent=2)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Entry point for the sensory registry CLI."""
+
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--format",
+        choices=("markdown", "json"),
+        default="markdown",
+        help="Output format (default: markdown)",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        help="Optional path where the registry should be written",
+    )
+    args = parser.parse_args(argv)
+
+    entries = build_registry()
+    if args.format == "json":
+        content = format_json(entries)
+    else:
+        content = format_markdown(entries)
+
+    if args.output:
+        to_write = content if content.endswith("\n") else f"{content}\n"
+        args.output.write_text(to_write, encoding="utf-8")
+
+    print(content)
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI wrapper
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add a sensory registry CLI that introspects the HOW/WHAT/WHEN/WHY/ANOMALY sensors and can emit markdown or JSON
- generate docs/sensory_registry.md from the new helper and mark the roadmap checklist item as complete
- cover the CLI with dedicated pytest coverage to exercise markdown, JSON, and file output paths

## Testing
- pytest tests/tools/test_sensory_registry.py -q
- pytest tests/tools/test_high_impact_roadmap.py -q

------
https://chatgpt.com/codex/tasks/task_e_68d97a1eda38832cbec99b17d556ef5f