### PR TITLE
Add attention view for the high-impact roadmap CLI

### DIFF
--- a/docs/status/high_impact_roadmap.md
+++ b/docs/status/high_impact_roadmap.md
@@ -20,6 +20,13 @@ For an at-a-glance rollup of the portfolio, render the summary view:
 python -m tools.roadmap.high_impact --format summary
 ```
 
+When triaging gaps, render the attention report to list any missing
+requirements:
+
+```bash
+python -m tools.roadmap.high_impact --format attention
+```
+
 To update both this summary and the detailed evidence companion file in one
 shot, use the refresh flag:
 

--- a/tests/tools/test_high_impact_roadmap.py
+++ b/tests/tools/test_high_impact_roadmap.py
@@ -87,6 +87,24 @@ def test_portfolio_summary_formatter_lists_counts() -> None:
     assert "Stream A – Institutional data backbone" in summary
 
 
+def test_attention_formatter_notes_missing_items() -> None:
+    status = high_impact.StreamStatus(
+        stream="Stream Ω",
+        status="Attention needed",
+        summary="Incomplete",
+        next_checkpoint="Ship everything",
+        evidence=("module.present",),
+        missing=("module.missing", "docs.todo"),
+    )
+
+    report = high_impact.format_attention([status])
+
+    assert report.startswith("# High-impact roadmap attention")
+    assert "Stream Ω" in report
+    assert "module.missing" in report
+    assert "module.present" in report
+
+
 def test_summarise_portfolio_counts_ready_streams() -> None:
     statuses = high_impact.evaluate_streams()
 
@@ -117,6 +135,16 @@ def test_cli_supports_json_format(capsys: pytest.CaptureFixture[str]) -> None:
     assert not err
     decoded = json.loads(out)
     assert decoded[0]["status"] == "Ready"
+
+
+def test_cli_attention_format_handles_ready_streams(capsys: pytest.CaptureFixture[str]) -> None:
+    exit_code = high_impact.main(["--format", "attention"])
+
+    assert exit_code == 0
+
+    out, err = capsys.readouterr()
+    assert not err
+    assert "All streams are Ready" in out
 
 
 def test_evaluate_streams_can_filter() -> None:

--- a/tools/roadmap/high_impact.py
+++ b/tools/roadmap/high_impact.py
@@ -384,6 +384,43 @@ def format_detail(statuses: Iterable[StreamStatus]) -> str:
     return "\n".join(lines).rstrip()
 
 
+def format_attention(statuses: Iterable[StreamStatus]) -> str:
+    """Highlight streams that still have missing requirements."""
+
+    lines: list[str] = [
+        "# High-impact roadmap attention",
+        "",
+    ]
+
+    needing_attention = [
+        status for status in statuses if status.missing
+    ]
+
+    if not needing_attention:
+        lines.append("All streams are Ready; no missing requirements.")
+        return "\n".join(lines).rstrip()
+
+    for status in needing_attention:
+        lines.extend(
+            [
+                f"## {status.stream}",
+                "",
+                f"*Status:* {status.status}",
+                "",
+                "**Missing requirements:**",
+            ]
+        )
+        lines.extend(f"- {item}" for item in status.missing)
+
+        if status.evidence:
+            lines.extend(["", "**Evidence captured:**"])
+            lines.extend(f"- {item}" for item in status.evidence)
+
+        lines.append("")
+
+    return "\n".join(lines).rstrip()
+
+
 def format_json(statuses: Iterable[StreamStatus]) -> str:
     """Return a JSON payload describing the stream statuses.
 
@@ -472,7 +509,7 @@ def main(argv: Sequence[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
         "--format",
-        choices=("markdown", "json", "detail", "summary"),
+        choices=("markdown", "json", "detail", "summary", "attention"),
         default="markdown",
         help="Output format (default: markdown table)",
     )
@@ -509,6 +546,8 @@ def main(argv: Sequence[str] | None = None) -> int:
         output = format_detail(statuses)
     elif args.format == "summary":
         output = format_portfolio_summary(statuses)
+    elif args.format == "attention":
+        output = format_attention(statuses)
     else:
         output = format_markdown(statuses)
 


### PR DESCRIPTION
## Summary
- add an `attention` formatter that highlights streams with outstanding requirements
- expose the new format through the `tools.roadmap.high_impact` CLI and document its usage
- extend the roadmap CLI tests to cover the attention formatter and CLI output

## Testing
- pytest tests/tools/test_high_impact_roadmap.py -q

------
https://chatgpt.com/codex/tasks/task_e_68d97a1eda38832cbec99b17d556ef5f