### PR TITLE
Respect stream selection order in high-impact roadmap

### DIFF
--- a/tests/tools/test_high_impact_roadmap.py
+++ b/tests/tools/test_high_impact_roadmap.py
@@ -155,6 +155,20 @@ def test_evaluate_streams_can_filter() -> None:
     assert status.stream == "Stream A – Institutional data backbone"
 
 
+def test_evaluate_streams_preserves_requested_order() -> None:
+    statuses = high_impact.evaluate_streams(
+        [
+            "Stream C – Execution, risk, compliance, ops readiness",
+            "Stream A – Institutional data backbone",
+        ]
+    )
+
+    assert [status.stream for status in statuses] == [
+        "Stream C – Execution, risk, compliance, ops readiness",
+        "Stream A – Institutional data backbone",
+    ]
+
+
 def test_cli_rejects_unknown_stream(capsys: pytest.CaptureFixture[str]) -> None:
     with pytest.raises(SystemExit) as excinfo:
         high_impact.main(["--stream", "unknown stream"])


### PR DESCRIPTION
## Summary
- preserve the user-specified order when filtering high-impact roadmap streams
- add a regression test covering the ordering behaviour of evaluate_streams

## Testing
- pytest tests/tools/test_high_impact_roadmap.py

------
https://chatgpt.com/codex/tasks/task_e_68d97d7faa28832c80b50babd4abc5d2