### PR TITLE
Add sensory drift monitoring harness and CLI

### DIFF
--- a/docs/High-Impact Development Roadmap.md
+++ b/docs/High-Impact Development Roadmap.md
@@ -194,7 +194,7 @@ To reflect the true scope of institutional-grade trading components, the roadmap
 - [ ] Ensure new sensors emit structured data consumed by strategies and risk modules.
 - [ ] Expand tests to validate sensor outputs over historical datasets.
 - [ ] Implement WHY-dimension narrative hooks (economic calendar sentiment, macro regime flags) using encyclopedia cues.
-- [ ] Stand up anomaly detection harness comparing sensor drifts vs baseline expectation windows.
+- [x] Stand up anomaly detection harness comparing sensor drifts vs baseline expectation windows (see `src/sensory/monitoring/sensor_drift.py` and `scripts/check_sensor_drift.py`).
 - [x] Synchronize sensor metadata catalog in `/docs/sensory_registry.md` with encyclopedia Layer 2 tables (auto-generated via `python -m tools.sensory.registry`).
 
 **Acceptance:** Strategies consume new sensory inputs; CI verifies data integrity; backlog explicitly records deferred advanced analytics.

--- a/docs/runbooks/observability.md
+++ b/docs/runbooks/observability.md
@@ -49,3 +49,9 @@ tracing so spans and log events share correlation identifiers out of the box.
 
 Stop the collector (`Ctrl+C`) and unset the `OTEL_*` environment variables when
 finished to revert to local-only logging.
+
+## Related Runbooks
+
+* [Sensor Drift Monitoring](sensor_drift_monitoring.md) — evaluates sensory
+  windows for statistical drift and can be wired into CI using
+  `scripts/check_sensor_drift.py`.

--- a/docs/runbooks/sensor_drift_monitoring.md
+++ b/docs/runbooks/sensor_drift_monitoring.md
@@ -1,0 +1,57 @@
+# Sensor Drift Monitoring Harness
+
+The high-impact roadmap calls for proactive anomaly detection across the sensory
+stack so trading strategies receive trustworthy features.  This runbook explains
+how to run the new sensor drift harness, interpret its output, and fold the
+results into operational workflows.
+
+## Overview
+
+* **Module:** `src/sensory/monitoring/sensor_drift.py`
+* **CLI:** `scripts/check_sensor_drift.py`
+* **Goal:** Compare recent sensory windows against a historical baseline using a
+  pooled z-score heuristic. Any sensor whose absolute z-score exceeds the
+  configured threshold is flagged for investigation.
+
+## Running the CLI
+
+```bash
+python scripts/check_sensor_drift.py data/sensory_snapshot.csv \
+  --baseline 240 \
+  --evaluation 60 \
+  --z-threshold 3.0 \
+  --fail-on-drift \
+  --output artifacts/sensory/sensor_drift_summary.json
+```
+
+* `--baseline` controls how many historical observations form the expectation
+  window.
+* `--evaluation` defines the most recent window used for drift detection.
+* `--z-threshold` sets the absolute z-score above which sensors are marked as
+  drifting.
+* `--fail-on-drift` exits with a non-zero code when any sensor breaches the
+  threshold — useful for CI guards.
+* `--sensors` limits the analysis to a subset of columns. When omitted, all
+  numeric columns are analysed.
+
+The CLI prints a concise summary to stdout and can optionally persist the full
+JSON payload for dashboards or post-mortem analysis.
+
+## Automation Guidance
+
+1. Schedule the CLI after nightly sensory replays so baseline windows incorporate
+   the most recent clean data.
+2. Store JSON summaries under `artifacts/sensory/` and surface them in the
+   observability dashboard alongside latency metrics.
+3. Feed flagged sensors into strategy gating logic (e.g., disable strategies
+   that depend on a drifting indicator until it recovers).
+4. Combine with the existing structured logging pipeline so drift events inherit
+   correlation identifiers and show up in the OpenTelemetry stack.
+
+## Acceptance Criteria
+
+* Unit tests in `tests/sensory/test_sensor_drift.py` cover drift detection,
+  column selection, and guardrails for insufficient data.
+* The CLI supports CSV, JSON, and Parquet inputs with helpful error messages.
+* Documentation in this runbook plus the roadmap checklist is updated to reflect
+  the delivered capability.

--- a/scripts/check_sensor_drift.py
+++ b/scripts/check_sensor_drift.py
@@ -1,0 +1,102 @@
+"""CLI for evaluating sensory drift using the monitoring harness."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Sequence
+
+import pandas as pd
+
+from src.sensory.monitoring import evaluate_sensor_drift
+
+
+def _read_frame(path: Path) -> pd.DataFrame:
+    if not path.exists():
+        raise FileNotFoundError(f"Input file {path} does not exist")
+    suffix = path.suffix.lower()
+    if suffix in {".parquet", ".pq"}:
+        try:
+            return pd.read_parquet(path)
+        except Exception as exc:  # pragma: no cover - dependency optional
+            raise RuntimeError(f"Failed to read parquet file {path}: {exc}")
+    if suffix in {".csv", ".txt"}:
+        return pd.read_csv(path)
+    if suffix in {".json", ".jsonl"}:
+        return pd.read_json(path)
+    raise ValueError(f"Unsupported file extension: {suffix}")
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("input", type=Path, help="Input data file (csv, parquet, json)")
+    parser.add_argument(
+        "--sensors",
+        help="Comma-separated list of sensor columns to analyse (defaults to numeric columns)",
+    )
+    parser.add_argument("--baseline", type=int, default=240, help="Baseline window size")
+    parser.add_argument("--evaluation", type=int, default=60, help="Evaluation window size")
+    parser.add_argument(
+        "--min-observations",
+        type=int,
+        default=20,
+        help="Minimum observations required per window",
+    )
+    parser.add_argument(
+        "--z-threshold",
+        type=float,
+        default=3.0,
+        help="Absolute z-score threshold before flagging drift",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        help="Optional path to write JSON summary",
+    )
+    parser.add_argument(
+        "--fail-on-drift",
+        action="store_true",
+        help="Exit with non-zero status if any sensor breaches the threshold",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv)
+    frame = _read_frame(args.input)
+    sensor_columns = None
+    if args.sensors:
+        sensor_columns = [column.strip() for column in args.sensors.split(",") if column.strip()]
+
+    summary = evaluate_sensor_drift(
+        frame,
+        sensor_columns=sensor_columns,
+        baseline_window=args.baseline,
+        evaluation_window=args.evaluation,
+        min_observations=args.min_observations,
+        z_threshold=args.z_threshold,
+    )
+
+    print("Sensor drift summary:")
+    for result in summary.results:
+        z_repr = f"{result.z_score:.2f}" if result.z_score is not None else "n/a"
+        status = "DRIFT" if result.exceeded else "OK"
+        print(
+            f"  {result.sensor}: mean={result.evaluation_mean:.4f} "
+            f"baseline={result.baseline.mean:.4f} z={z_repr} status={status}"
+        )
+
+    if args.output:
+        payload = summary.as_dict()
+        args.output.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+        print(f"Wrote summary to {args.output}")
+
+    if summary.exceeded and args.fail_on_drift:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/src/sensory/monitoring/__init__.py
+++ b/src/sensory/monitoring/__init__.py
@@ -1,0 +1,17 @@
+"""Monitoring helpers for sensory output quality."""
+
+from .sensor_drift import (
+    SensorDriftBaseline,
+    SensorDriftParameters,
+    SensorDriftResult,
+    SensorDriftSummary,
+    evaluate_sensor_drift,
+)
+
+__all__ = [
+    "SensorDriftBaseline",
+    "SensorDriftParameters",
+    "SensorDriftResult",
+    "SensorDriftSummary",
+    "evaluate_sensor_drift",
+]

--- a/src/sensory/monitoring/sensor_drift.py
+++ b/src/sensory/monitoring/sensor_drift.py
@@ -1,0 +1,231 @@
+"""Sensor drift detection harness for roadmap Phase 2 monitoring.
+
+The high-impact roadmap calls for a lightweight anomaly detection harness that
+flags sensory drifts before they cascade into trading logic.  This module keeps
+the implementation dependency-light while exposing well-typed artefacts that
+strategies, risk modules, and operational tooling can consume.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from math import sqrt
+from typing import Mapping, Sequence
+
+import numpy as np
+import pandas as pd
+
+__all__ = [
+    "SensorDriftBaseline",
+    "SensorDriftParameters",
+    "SensorDriftResult",
+    "SensorDriftSummary",
+    "evaluate_sensor_drift",
+]
+
+
+@dataclass(slots=True)
+class SensorDriftBaseline:
+    """Summary statistics representing an expected sensory window."""
+
+    sensor: str
+    mean: float
+    std: float
+    count: int
+
+
+@dataclass(slots=True)
+class SensorDriftParameters:
+    """Configuration values applied during drift evaluation."""
+
+    baseline_window: int
+    evaluation_window: int
+    min_observations: int
+    z_threshold: float
+
+
+@dataclass(slots=True)
+class SensorDriftResult:
+    """Calculated drift characteristics for a single sensor."""
+
+    sensor: str
+    baseline: SensorDriftBaseline
+    evaluation_mean: float
+    evaluation_std: float
+    evaluation_count: int
+    z_score: float | None
+    drift_ratio: float
+    exceeded: bool
+
+    def as_dict(self) -> dict[str, float | int | str | None]:
+        """Return a JSON-friendly representation."""
+
+        return {
+            "sensor": self.sensor,
+            "baseline_mean": self.baseline.mean,
+            "baseline_std": self.baseline.std,
+            "baseline_count": self.baseline.count,
+            "evaluation_mean": self.evaluation_mean,
+            "evaluation_std": self.evaluation_std,
+            "evaluation_count": self.evaluation_count,
+            "z_score": self.z_score,
+            "drift_ratio": self.drift_ratio,
+            "exceeded": self.exceeded,
+        }
+
+
+@dataclass(slots=True)
+class SensorDriftSummary:
+    """Aggregate view of drift results for downstream tooling."""
+
+    parameters: SensorDriftParameters
+    results: tuple[SensorDriftResult, ...]
+
+    @property
+    def exceeded(self) -> tuple[SensorDriftResult, ...]:
+        """Return all sensors whose |z-score| breached the configured threshold."""
+
+        return tuple(result for result in self.results if result.exceeded)
+
+    def as_dict(self) -> Mapping[str, object]:
+        """Serialise the summary and underlying results."""
+
+        return {
+            "parameters": {
+                "baseline_window": self.parameters.baseline_window,
+                "evaluation_window": self.parameters.evaluation_window,
+                "min_observations": self.parameters.min_observations,
+                "z_threshold": self.parameters.z_threshold,
+            },
+            "results": [result.as_dict() for result in self.results],
+        }
+
+
+def _coerce_numeric(series: pd.Series) -> np.ndarray:
+    values = pd.to_numeric(series, errors="coerce").dropna()
+    return values.to_numpy(dtype=float, copy=False)
+
+
+def _compute_baseline(sensor: str, window: np.ndarray) -> SensorDriftBaseline | None:
+    if window.size == 0:
+        return None
+    mean = float(np.mean(window))
+    std = float(np.std(window, ddof=1 if window.size > 1 else 0))
+    return SensorDriftBaseline(sensor=sensor, mean=mean, std=std, count=int(window.size))
+
+
+def _standard_error(baseline: SensorDriftBaseline, eval_std: float, eval_count: int) -> float | None:
+    if baseline.count == 0 or eval_count == 0:
+        return None
+    baseline_var = baseline.std ** 2 if baseline.count > 1 else 0.0
+    eval_var = eval_std ** 2 if eval_count > 1 else 0.0
+    se = sqrt((baseline_var / max(baseline.count, 1)) + (eval_var / max(eval_count, 1)))
+    if se == 0.0:
+        return None
+    return se
+
+
+def _relative_drift(baseline: SensorDriftBaseline, evaluation_mean: float) -> float:
+    denominator = abs(baseline.mean) if abs(baseline.mean) > 1e-9 else 1.0
+    return abs(evaluation_mean - baseline.mean) / denominator
+
+
+def _build_result(
+    sensor: str,
+    baseline: SensorDriftBaseline,
+    evaluation_values: np.ndarray,
+    z_threshold: float,
+) -> SensorDriftResult | None:
+    if evaluation_values.size == 0:
+        return None
+
+    evaluation_mean = float(np.mean(evaluation_values))
+    evaluation_std = float(np.std(evaluation_values, ddof=1 if evaluation_values.size > 1 else 0))
+    evaluation_count = int(evaluation_values.size)
+
+    se = _standard_error(baseline, evaluation_std, evaluation_count)
+    z_score: float | None
+    exceeded = False
+    if se is None:
+        z_score = None
+    else:
+        z_score = (evaluation_mean - baseline.mean) / se
+        exceeded = abs(z_score) >= z_threshold
+
+    drift_ratio = _relative_drift(baseline, evaluation_mean)
+
+    return SensorDriftResult(
+        sensor=sensor,
+        baseline=baseline,
+        evaluation_mean=evaluation_mean,
+        evaluation_std=evaluation_std,
+        evaluation_count=evaluation_count,
+        z_score=None if z_score is None else float(z_score),
+        drift_ratio=drift_ratio,
+        exceeded=exceeded,
+    )
+
+
+def evaluate_sensor_drift(
+    frame: pd.DataFrame,
+    *,
+    sensor_columns: Sequence[str] | None = None,
+    baseline_window: int = 240,
+    evaluation_window: int = 60,
+    min_observations: int = 20,
+    z_threshold: float = 3.0,
+) -> SensorDriftSummary:
+    """Evaluate sensory drift over trailing windows.
+
+    Args:
+        frame: DataFrame containing sensory readings ordered chronologically.
+        sensor_columns: Optional subset of columns to analyse. Defaults to all
+            numeric columns in ``frame``.
+        baseline_window: Number of rows constituting the reference window.
+        evaluation_window: Number of most recent rows used for drift detection.
+        min_observations: Minimum observations required for both windows before
+            computing drift.
+        z_threshold: Absolute z-score threshold for flagging drift.
+    """
+
+    if baseline_window <= 0 or evaluation_window <= 0:
+        raise ValueError("baseline_window and evaluation_window must be positive")
+    if frame.empty:
+        raise ValueError("frame must contain observations")
+    if frame.shape[0] < baseline_window + evaluation_window:
+        raise ValueError("insufficient rows for the requested windows")
+
+    numeric_columns = frame.select_dtypes(include=["number"]).columns.tolist()
+    if sensor_columns is None:
+        candidate_columns = numeric_columns
+    else:
+        candidate_columns = [col for col in sensor_columns if col in frame.columns]
+
+    if not candidate_columns:
+        raise ValueError("no sensor columns available for drift evaluation")
+
+    baseline_slice = frame.iloc[-(baseline_window + evaluation_window) : -evaluation_window]
+    evaluation_slice = frame.iloc[-evaluation_window:]
+
+    parameters = SensorDriftParameters(
+        baseline_window=baseline_window,
+        evaluation_window=evaluation_window,
+        min_observations=min_observations,
+        z_threshold=z_threshold,
+    )
+
+    results: list[SensorDriftResult] = []
+    for column in candidate_columns:
+        baseline_values = _coerce_numeric(baseline_slice[column])
+        evaluation_values = _coerce_numeric(evaluation_slice[column])
+        if baseline_values.size < min_observations or evaluation_values.size < min_observations:
+            continue
+        baseline = _compute_baseline(column, baseline_values)
+        if baseline is None:
+            continue
+        result = _build_result(column, baseline, evaluation_values, z_threshold)
+        if result is not None:
+            results.append(result)
+
+    results.sort(key=lambda item: (abs(item.z_score) if item.z_score is not None else 0.0), reverse=True)
+    return SensorDriftSummary(parameters=parameters, results=tuple(results))

--- a/tests/sensory/test_sensor_drift.py
+++ b/tests/sensory/test_sensor_drift.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from src.sensory.monitoring import evaluate_sensor_drift
+
+
+def _build_frame() -> pd.DataFrame:
+    rng = np.random.default_rng(42)
+    baseline_a = rng.normal(loc=0.0, scale=1.0, size=60)
+    baseline_b = rng.normal(loc=5.0, scale=0.5, size=60)
+    # introduce drift in sensor_a during evaluation window
+    recent_a = rng.normal(loc=2.5, scale=1.0, size=20)
+    recent_b = rng.normal(loc=5.0, scale=0.5, size=20)
+    data = {
+        "sensor_a": np.concatenate([baseline_a, recent_a]),
+        "sensor_b": np.concatenate([baseline_b, recent_b]),
+    }
+    return pd.DataFrame(data)
+
+
+def test_evaluate_sensor_drift_flags_drift() -> None:
+    frame = _build_frame()
+    summary = evaluate_sensor_drift(
+        frame,
+        baseline_window=60,
+        evaluation_window=20,
+        min_observations=15,
+        z_threshold=3.0,
+    )
+
+    assert len(summary.results) == 2
+    flagged = {result.sensor: result for result in summary.results}
+    assert flagged["sensor_a"].exceeded is True
+    assert flagged["sensor_a"].z_score is not None
+    assert flagged["sensor_b"].exceeded is False
+
+
+def test_evaluate_sensor_drift_subset_columns() -> None:
+    frame = _build_frame()
+    summary = evaluate_sensor_drift(
+        frame,
+        sensor_columns=["sensor_a"],
+        baseline_window=60,
+        evaluation_window=20,
+        min_observations=15,
+        z_threshold=3.0,
+    )
+    assert [result.sensor for result in summary.results] == ["sensor_a"]
+
+
+def test_evaluate_sensor_drift_requires_enough_rows() -> None:
+    frame = pd.DataFrame({"sensor_a": [1, 2, 3, 4]})
+    with pytest.raises(ValueError):
+        evaluate_sensor_drift(frame, baseline_window=3, evaluation_window=2)


### PR DESCRIPTION
## Summary
- add a sensory drift monitoring harness under `src/sensory/monitoring` that exposes typed baselines, results, and evaluation helpers
- ship `scripts/check_sensor_drift.py` plus a runbook detailing how to run the drift check and integrate it into observability workflows
- mark the roadmap task for anomaly detection as complete and add unit tests covering drift detection behaviour

## Testing
- pytest tests/sensory/test_sensor_drift.py


------
https://chatgpt.com/codex/tasks/task_e_68d97d7faa28832c80b50babd4abc5d2