### PR TITLE
Allow high-impact roadmap CLI to refresh custom documentation paths

### DIFF
--- a/docs/status/high_impact_roadmap.md
+++ b/docs/status/high_impact_roadmap.md
@@ -34,6 +34,15 @@ shot, use the refresh flag:
 python -m tools.roadmap.high_impact --refresh-docs
 ```
 
+When writing to alternate locations (for example in CI workspaces), provide
+explicit paths for the summary and detail files:
+
+```bash
+python -m tools.roadmap.high_impact --refresh-docs \
+  --summary-path /tmp/high_impact_summary.md \
+  --detail-path /tmp/high_impact_detail.md
+```
+
 <!-- HIGH_IMPACT_SUMMARY:START -->
 | Stream | Status | Summary | Next checkpoint |
 | --- | --- | --- | --- |

--- a/tests/tools/test_high_impact_roadmap.py
+++ b/tests/tools/test_high_impact_roadmap.py
@@ -189,6 +189,44 @@ def test_cli_writes_output_file(tmp_path: Path) -> None:
     assert "High-impact roadmap status" in content
 
 
+def test_cli_refresh_docs_accepts_custom_paths(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    summary = tmp_path / "summary.md"
+    detail = tmp_path / "detail.md"
+    summary.write_text(
+        (
+            "Lead-in\n\n"
+            "<!-- HIGH_IMPACT_SUMMARY:START -->\n"
+            "outdated table\n"
+            "<!-- HIGH_IMPACT_SUMMARY:END -->\n"
+        ),
+        encoding="utf-8",
+    )
+    detail.write_text("outdated\n", encoding="utf-8")
+
+    exit_code = high_impact.main(
+        [
+            "--refresh-docs",
+            "--summary-path",
+            str(summary),
+            "--detail-path",
+            str(detail),
+        ]
+    )
+
+    assert exit_code == 0
+    out, err = capsys.readouterr()
+    assert not err
+    assert "Stream A – Institutional data backbone" in out
+
+    updated_summary = summary.read_text(encoding="utf-8")
+    assert "Stream A – Institutional data backbone" in updated_summary
+    assert updated_summary.startswith("Lead-in")
+
+    updated_detail = detail.read_text(encoding="utf-8")
+    assert updated_detail.startswith("# High-impact roadmap status")
+    assert updated_detail.endswith("\n")
+
+
 def test_refresh_docs_updates_summary_and_detail(tmp_path: Path) -> None:
     summary = tmp_path / "summary.md"
     detail = tmp_path / "detail.md"

--- a/tools/roadmap/high_impact.py
+++ b/tools/roadmap/high_impact.py
@@ -524,6 +524,22 @@ def main(argv: Sequence[str] | None = None) -> int:
         help="Update the status documentation files in docs/status/",
     )
     parser.add_argument(
+        "--summary-path",
+        type=Path,
+        help=(
+            "Optional path to the summary markdown file when refreshing docs. "
+            "Defaults to docs/status/high_impact_roadmap.md"
+        ),
+    )
+    parser.add_argument(
+        "--detail-path",
+        type=Path,
+        help=(
+            "Optional path to the detailed markdown file when refreshing docs. "
+            "Defaults to docs/status/high_impact_roadmap_detail.md"
+        ),
+    )
+    parser.add_argument(
         "--stream",
         action="append",
         dest="streams",
@@ -539,7 +555,11 @@ def main(argv: Sequence[str] | None = None) -> int:
     except ValueError as exc:
         parser.error(str(exc))
     if args.refresh_docs:
-        refresh_docs(statuses)
+        refresh_docs(
+            statuses,
+            summary_path=args.summary_path,
+            detail_path=args.detail_path,
+        )
     if args.format == "json":
         output = format_json(statuses)
     elif args.format == "detail":


### PR DESCRIPTION
## Summary
- add `--summary-path` and `--detail-path` options to the high-impact roadmap CLI so documentation refreshes can target custom files
- document the new CLI flags in the roadmap status instructions
- extend the roadmap CLI tests to cover refreshing user-specified paths

## Testing
- pytest tests/tools/test_high_impact_roadmap.py

------
https://chatgpt.com/codex/tasks/task_e_68d97d7faa28832c80b50babd4abc5d2