### PR TITLE
Add attention report output to high-impact roadmap docs

### DIFF
--- a/docs/status/high_impact_roadmap.md
+++ b/docs/status/high_impact_roadmap.md
@@ -60,3 +60,11 @@ python -m tools.roadmap.high_impact --format detail --output docs/status/high_im
 
 The command produces a stream-by-stream summary that includes the captured
 evidence list for each initiative.
+
+To persist the attention view alongside these reports, provide an explicit
+destination (or rely on the default location under `docs/status/`):
+
+```bash
+python -m tools.roadmap.high_impact --refresh-docs \
+  --attention-path docs/status/high_impact_roadmap_attention.md
+```

--- a/docs/status/high_impact_roadmap_attention.md
+++ b/docs/status/high_impact_roadmap_attention.md
@@ -1,0 +1,3 @@
+# High-impact roadmap attention
+
+All streams are Ready; no missing requirements.

--- a/tests/tools/test_high_impact_roadmap.py
+++ b/tests/tools/test_high_impact_roadmap.py
@@ -206,6 +206,7 @@ def test_cli_writes_output_file(tmp_path: Path) -> None:
 def test_cli_refresh_docs_accepts_custom_paths(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
     summary = tmp_path / "summary.md"
     detail = tmp_path / "detail.md"
+    attention = tmp_path / "attention.md"
     summary.write_text(
         (
             "Lead-in\n\n"
@@ -224,6 +225,8 @@ def test_cli_refresh_docs_accepts_custom_paths(tmp_path: Path, capsys: pytest.Ca
             str(summary),
             "--detail-path",
             str(detail),
+            "--attention-path",
+            str(attention),
         ]
     )
 
@@ -240,10 +243,15 @@ def test_cli_refresh_docs_accepts_custom_paths(tmp_path: Path, capsys: pytest.Ca
     assert updated_detail.startswith("# High-impact roadmap status")
     assert updated_detail.endswith("\n")
 
+    updated_attention = attention.read_text(encoding="utf-8")
+    assert updated_attention.startswith("# High-impact roadmap attention")
+    assert updated_attention.endswith("\n")
+
 
 def test_refresh_docs_updates_summary_and_detail(tmp_path: Path) -> None:
     summary = tmp_path / "summary.md"
     detail = tmp_path / "detail.md"
+    attention = tmp_path / "attention.md"
     summary.write_text(
         (
             "Header\n\n"
@@ -257,7 +265,12 @@ def test_refresh_docs_updates_summary_and_detail(tmp_path: Path) -> None:
     detail.write_text("outdated\n", encoding="utf-8")
 
     statuses = high_impact.evaluate_streams()
-    high_impact.refresh_docs(statuses, summary_path=summary, detail_path=detail)
+    high_impact.refresh_docs(
+        statuses,
+        summary_path=summary,
+        detail_path=detail,
+        attention_path=attention,
+    )
 
     updated_summary = summary.read_text(encoding="utf-8")
     assert "Header" in updated_summary
@@ -267,6 +280,10 @@ def test_refresh_docs_updates_summary_and_detail(tmp_path: Path) -> None:
     updated_detail = detail.read_text(encoding="utf-8")
     assert updated_detail.startswith("# High-impact roadmap status")
     assert updated_detail.endswith("\n")
+
+    updated_attention = attention.read_text(encoding="utf-8")
+    assert updated_attention.startswith("# High-impact roadmap attention")
+    assert updated_attention.endswith("\n")
 
 
 def test_refresh_docs_requires_markers(tmp_path: Path) -> None:

--- a/tools/roadmap/high_impact.py
+++ b/tools/roadmap/high_impact.py
@@ -485,6 +485,7 @@ def refresh_docs(
     *,
     summary_path: Path | None = None,
     detail_path: Path | None = None,
+    attention_path: Path | None = None,
 ) -> None:
     """Refresh the roadmap status documentation files.
 
@@ -502,6 +503,9 @@ def refresh_docs(
     root = repo_root()
     summary_path = summary_path or root / "docs/status/high_impact_roadmap.md"
     detail_path = detail_path or root / "docs/status/high_impact_roadmap_detail.md"
+    attention_path = (
+        attention_path or root / "docs/status/high_impact_roadmap_attention.md"
+    )
 
     summary_text = summary_path.read_text(encoding="utf-8")
     table = format_markdown(statuses)
@@ -514,6 +518,11 @@ def refresh_docs(
     if not detail_text.endswith("\n"):
         detail_text = f"{detail_text}\n"
     detail_path.write_text(detail_text, encoding="utf-8")
+
+    attention_text = format_attention(statuses)
+    if not attention_text.endswith("\n"):
+        attention_text = f"{attention_text}\n"
+    attention_path.write_text(attention_text, encoding="utf-8")
 
 
 def main(argv: Sequence[str] | None = None) -> int:
@@ -553,6 +562,14 @@ def main(argv: Sequence[str] | None = None) -> int:
         ),
     )
     parser.add_argument(
+        "--attention-path",
+        type=Path,
+        help=(
+            "Optional path to the attention markdown file when refreshing docs. "
+            "Defaults to docs/status/high_impact_roadmap_attention.md"
+        ),
+    )
+    parser.add_argument(
         "--stream",
         action="append",
         dest="streams",
@@ -572,6 +589,7 @@ def main(argv: Sequence[str] | None = None) -> int:
             statuses,
             summary_path=args.summary_path,
             detail_path=args.detail_path,
+            attention_path=args.attention_path,
         )
     if args.format == "json":
         output = format_json(statuses)


### PR DESCRIPTION
## Summary
- extend the high-impact roadmap CLI so `--refresh-docs` also writes an attention report
- document the new attention output and add the generated status file to docs/status

## Testing
- pytest tests/tools/test_high_impact_roadmap.py

------
https://chatgpt.com/codex/tasks/task_e_68d9803ee434832ca2a19c6c4bf48140