### PR TITLE
Enhance high-impact roadmap summary refresh

### DIFF
--- a/docs/status/high_impact_roadmap.md
+++ b/docs/status/high_impact_roadmap.md
@@ -49,6 +49,36 @@ python -m tools.roadmap.high_impact --refresh-docs \
   --detail-path /tmp/high_impact_detail.md
 ```
 
+<!-- HIGH_IMPACT_PORTFOLIO:START -->
+# High-impact roadmap summary
+
+- Total streams: 3
+- Ready: 3
+- Attention needed: 0
+
+All streams are Ready; no missing requirements.
+
+## Streams
+
+### Stream A – Institutional data backbone
+
+*Status:* Ready
+*Summary:* Timescale ingest, Redis caching, Kafka streaming, and Spark exports ship with readiness telemetry and failover tooling.
+*Next checkpoint:* Exercise cross-region failover and automated scheduler cutover using the readiness feeds.
+
+### Stream B – Sensory cortex & evolution uplift
+
+*Status:* Ready
+*Summary:* All five sensory organs operate with drift telemetry and catalogue-backed evolution lineage exports.
+*Next checkpoint:* Extend live-paper experiments and automated tuning loops using evolution telemetry.
+
+### Stream C – Execution, risk, compliance, ops readiness
+
+*Status:* Ready
+*Summary:* FIX pilots, risk/compliance workflows, ROI telemetry, and operational readiness publish evidence for operators.
+*Next checkpoint:* Expand broker connectivity with drop-copy reconciliation and extend regulatory telemetry coverage.
+<!-- HIGH_IMPACT_PORTFOLIO:END -->
+
 <!-- HIGH_IMPACT_SUMMARY:START -->
 | Stream | Status | Summary | Next checkpoint |
 | --- | --- | --- | --- |

--- a/tests/tools/test_high_impact_roadmap.py
+++ b/tests/tools/test_high_impact_roadmap.py
@@ -278,6 +278,9 @@ def test_cli_refresh_docs_accepts_custom_paths(tmp_path: Path, capsys: pytest.Ca
     summary.write_text(
         (
             "Lead-in\n\n"
+            "<!-- HIGH_IMPACT_PORTFOLIO:START -->\n"
+            "outdated summary\n"
+            "<!-- HIGH_IMPACT_PORTFOLIO:END -->\n\n"
             "<!-- HIGH_IMPACT_SUMMARY:START -->\n"
             "outdated table\n"
             "<!-- HIGH_IMPACT_SUMMARY:END -->\n"
@@ -304,6 +307,7 @@ def test_cli_refresh_docs_accepts_custom_paths(tmp_path: Path, capsys: pytest.Ca
     assert "Stream A – Institutional data backbone" in out
 
     updated_summary = summary.read_text(encoding="utf-8")
+    assert "# High-impact roadmap summary" in updated_summary
     assert "Stream A – Institutional data backbone" in updated_summary
     assert updated_summary.startswith("Lead-in")
 
@@ -323,6 +327,9 @@ def test_refresh_docs_updates_summary_and_detail(tmp_path: Path) -> None:
     summary.write_text(
         (
             "Header\n\n"
+            "<!-- HIGH_IMPACT_PORTFOLIO:START -->\n"
+            "outdated summary\n"
+            "<!-- HIGH_IMPACT_PORTFOLIO:END -->\n\n"
             "<!-- HIGH_IMPACT_SUMMARY:START -->\n"
             "old table\n"
             "<!-- HIGH_IMPACT_SUMMARY:END -->\n\n"
@@ -343,6 +350,7 @@ def test_refresh_docs_updates_summary_and_detail(tmp_path: Path) -> None:
     updated_summary = summary.read_text(encoding="utf-8")
     assert "Header" in updated_summary
     assert "Footer" in updated_summary
+    assert "# High-impact roadmap summary" in updated_summary
     assert "| Stream A – Institutional data backbone |" in updated_summary
 
     updated_detail = detail.read_text(encoding="utf-8")
@@ -361,6 +369,18 @@ def test_refresh_docs_requires_markers(tmp_path: Path) -> None:
     detail.write_text("outdated\n", encoding="utf-8")
 
     statuses = high_impact.evaluate_streams()
+
+    with pytest.raises(ValueError):
+        high_impact.refresh_docs(statuses, summary_path=summary, detail_path=detail)
+
+    summary.write_text(
+        (
+            "<!-- HIGH_IMPACT_SUMMARY:START -->\n"
+            "table\n"
+            "<!-- HIGH_IMPACT_SUMMARY:END -->\n"
+        ),
+        encoding="utf-8",
+    )
 
     with pytest.raises(ValueError):
         high_impact.refresh_docs(statuses, summary_path=summary, detail_path=detail)


### PR DESCRIPTION
## Summary
- inject a portfolio narrative block into the high-impact roadmap status page
- extend the roadmap refresh helper to update both the narrative block and summary table
- update roadmap tests to cover the new markers and validation paths

## Testing
- `pytest tests/tools/test_high_impact_roadmap.py`


------
https://chatgpt.com/codex/tasks/task_e_68d984687884832cbb7c004a75d7e9c5