### PR TITLE
Enable GA manifest promotion into strategy registry

### DIFF
--- a/docs/High-Impact Development Roadmap.md
+++ b/docs/High-Impact Development Roadmap.md
@@ -181,7 +181,7 @@ To reflect the true scope of institutional-grade trading components, the roadmap
 - [x] Document follow-on backlog (speciation, Pareto-front) for later phases.
 - [x] Integrate GA experiment runner with encyclopedia "Evolution Lab" conventions, including seed logging and reproducibility manifest.
 - [x] Publish experiment leaderboard (top genomes, metrics, configs) as Markdown table auto-generated in `/docs/research/evolution_lab.md`.
-- [ ] Cross-wire GA outputs into strategy registry via feature flags to enable supervised promotion into paper trading.
+- [x] Cross-wire GA outputs into strategy registry via feature flags to enable supervised promotion into paper trading.
 
 **Acceptance:** GA can evolve MA crossover parameters outperforming baseline in controlled backtest; results are reproducible from CI artifacts.
 

--- a/docs/research/evolution_lab.md
+++ b/docs/research/evolution_lab.md
@@ -20,4 +20,4 @@ _Auto-generated on 2025-09-28 19:01:38Z using `scripts/generate_evolution_lab.py
 - [ ] Evaluate Pareto-front selection for multi-objective fitness.
 - [ ] Swap synthetic datasets with live market snapshots for benchmarking.
 - [ ] Automate nightly leaderboard refresh with CI artifact publishing.
-- [ ] Integrate promoted genomes into the strategy registry feature flags.
+- [x] Integrate promoted genomes into the strategy registry feature flags (see `src/evolution/experiments/promotion.py`).

--- a/scripts/generate_evolution_lab.py
+++ b/scripts/generate_evolution_lab.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import subprocess
 from datetime import datetime, timezone
 from pathlib import Path
@@ -13,6 +14,7 @@ import numpy as np
 import pandas as pd
 
 from src.evolution.experiments.ma_crossover_ga import GARunConfig, run_ga_experiment
+from src.evolution.experiments.promotion import maybe_promote_best_genome
 from src.evolution.experiments.reporting import render_leaderboard_markdown
 
 DEFAULT_DATASET_NAME = "synthetic_trend_v1"
@@ -161,13 +163,20 @@ def main() -> None:
         "- [ ] Evaluate Pareto-front selection for multi-objective fitness.\n"
         "- [ ] Swap synthetic datasets with live market snapshots for benchmarking.\n"
         "- [ ] Automate nightly leaderboard refresh with CI artifact publishing.\n"
-        "- [ ] Integrate promoted genomes into the strategy registry feature flags.\n"
+        "- [x] Integrate promoted genomes into the strategy registry feature flags (auto-promotion behind feature flag).\n"
     )
 
     doc_path.write_text(doc_content)
 
+    promoted = maybe_promote_best_genome(
+        manifest,
+        registry_path=os.environ.get("EVOLUTION_STRATEGY_REGISTRY_PATH"),
+    )
+
     print(f"Wrote manifest to {manifest_path}")
     print(f"Updated leaderboard at {doc_path}")
+    if promoted:
+        print("Promoted GA champion to strategy registry (feature flag enabled).")
 
 
 if __name__ == "__main__":

--- a/src/evolution/experiments/promotion.py
+++ b/src/evolution/experiments/promotion.py
@@ -1,0 +1,226 @@
+"""Utilities to promote GA experiment champions into the strategy registry.
+
+This module fulfils the High-Impact Roadmap item that calls for wiring
+offline GA experiment outputs into the governance registry behind a
+feature flag. The helpers are intentionally conservative: they only act
+when the flag is enabled, degrade gracefully when manifests are
+incomplete, and default to *not* touching the registry to protect
+paper-trading runs from accidental churn.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import time
+from contextlib import suppress
+from dataclasses import asdict
+from pathlib import Path
+from typing import Any, Mapping
+
+from src.evolution.experiments.ma_crossover_ga import MovingAverageGenome
+from src.governance.strategy_registry import StrategyRegistry
+
+FEATURE_FLAG_ENV = "EVOLUTION_PROMOTE_FROM_LAB"
+REGISTRY_PATH_ENV = "EVOLUTION_STRATEGY_REGISTRY_PATH"
+
+logger = logging.getLogger(__name__)
+
+__all__ = ["maybe_promote_best_genome", "FEATURE_FLAG_ENV", "REGISTRY_PATH_ENV"]
+
+
+def _flag_enabled(flag_env: str = FEATURE_FLAG_ENV) -> bool:
+    raw = os.environ.get(flag_env)
+    if raw is None:
+        return False
+    normalised = raw.strip().lower()
+    return normalised in {"1", "true", "yes", "on", "enable", "enabled"}
+
+
+def _coerce_bool(value: Any, default: bool = True) -> bool:
+    if isinstance(value, bool):
+        return value
+    if value is None:
+        return default
+    if isinstance(value, (int, float)):
+        return bool(value)
+    if isinstance(value, str):
+        normalised = value.strip().lower()
+        if normalised in {"1", "true", "yes", "on"}:
+            return True
+        if normalised in {"0", "false", "no", "off"}:
+            return False
+    return default
+
+
+def _coerce_float(value: Any, default: float = 0.0) -> float:
+    try:
+        return float(value)
+    except Exception:
+        return default
+
+
+def _normalise_dataset(dataset: Any) -> dict[str, Any] | None:
+    if not isinstance(dataset, Mapping):
+        return None
+    name = dataset.get("name")
+    metadata = dataset.get("metadata")
+    payload: dict[str, Any] = {}
+    if isinstance(name, str) and name:
+        payload["name"] = name
+    if isinstance(metadata, Mapping):
+        payload["metadata"] = dict(metadata)
+    return payload or None
+
+
+def _resolve_registry_path(path: str | os.PathLike[str] | None) -> Path:
+    candidate = path or os.environ.get(REGISTRY_PATH_ENV)
+    resolved = Path(candidate) if candidate else Path.cwd() / "governance.db"
+    resolved.parent.mkdir(parents=True, exist_ok=True)
+    return resolved
+
+
+def _build_fitness_report(
+    metrics: Mapping[str, Any], manifest: Mapping[str, Any]
+) -> dict[str, Any]:
+    report = {
+        "fitness_score": _coerce_float(
+            metrics.get("fitness"),
+            default=_coerce_float(metrics.get("fitness_score"), 0.0),
+        ),
+        "sharpe_ratio": _coerce_float(
+            metrics.get("sharpe"),
+            default=_coerce_float(metrics.get("sharpe_ratio"), 0.0),
+        ),
+        "sortino_ratio": _coerce_float(
+            metrics.get("sortino"),
+            default=_coerce_float(metrics.get("sortino_ratio"), 0.0),
+        ),
+        "max_drawdown": _coerce_float(metrics.get("max_drawdown"), 0.0),
+        "total_return": _coerce_float(metrics.get("total_return"), 0.0),
+    }
+
+    dataset_payload = _normalise_dataset(manifest.get("dataset"))
+    lab_metadata: dict[str, Any] = {
+        "experiment": manifest.get("experiment"),
+        "generated_at": manifest.get("generated_at"),
+        "seed": manifest.get("seed"),
+    }
+    if dataset_payload:
+        lab_metadata["dataset"] = dataset_payload
+    config_section = manifest.get("config")
+    if isinstance(config_section, Mapping):
+        lab_metadata["config"] = asdict(config_section) if hasattr(config_section, "__dataclass_fields__") else dict(config_section)
+    elif config_section is not None:
+        lab_metadata["config"] = config_section
+    replay = manifest.get("replay")
+    if isinstance(replay, Mapping):
+        lab_metadata["replay"] = dict(replay)
+    code_version = manifest.get("code_version")
+    if code_version:
+        lab_metadata["code_version"] = code_version
+    notes = manifest.get("notes") or manifest.get("manifest_notes")
+    if notes:
+        lab_metadata["notes"] = notes
+
+    report["metadata"] = {"evolution_lab": lab_metadata}
+    return report
+
+
+def _build_provenance(
+    manifest: Mapping[str, Any], genome_id: str, fitness_report: Mapping[str, Any]
+) -> Mapping[str, Any]:
+    dataset_payload = _normalise_dataset(manifest.get("dataset"))
+    metrics = fitness_report.copy()
+    metrics.pop("metadata", None)
+
+    entry_metadata: dict[str, Any] = {
+        "best_metrics": metrics,
+    }
+    if dataset_payload:
+        entry_metadata["dataset"] = dataset_payload
+
+    return {
+        "seed_source": "evolution_lab",
+        "catalogue": {
+            "name": str(manifest.get("experiment", "evolution_lab")),
+            "version": str(manifest.get("code_version") or "unversioned"),
+            "seeded_at": time.time(),
+            "metadata": {
+                "seed": manifest.get("seed"),
+                "generated_at": manifest.get("generated_at"),
+            },
+        },
+        "entry": {
+            "id": genome_id,
+            "name": f"{manifest.get('experiment', 'experiment')} champion",
+            "metadata": entry_metadata,
+        },
+    }
+
+
+def maybe_promote_best_genome(
+    manifest: Mapping[str, Any],
+    *,
+    registry: StrategyRegistry | None = None,
+    flag_env: str = FEATURE_FLAG_ENV,
+    registry_path: str | os.PathLike[str] | None = None,
+) -> bool:
+    """Conditionally promote the manifest's best genome into the registry."""
+
+    if not _flag_enabled(flag_env):
+        return False
+
+    best_genome_payload = manifest.get("best_genome")
+    best_metrics_payload = manifest.get("best_metrics")
+
+    if not isinstance(best_genome_payload, Mapping) or not isinstance(
+        best_metrics_payload, Mapping
+    ):
+        logger.warning("Promotion flag enabled but manifest lacks best genome/metrics")
+        return False
+
+    try:
+        genome_model = MovingAverageGenome(
+            short_window=int(best_genome_payload["short_window"]),
+            long_window=int(best_genome_payload["long_window"]),
+            risk_fraction=float(best_genome_payload["risk_fraction"]),
+            use_var_guard=_coerce_bool(best_genome_payload.get("use_var_guard", True)),
+            use_drawdown_guard=_coerce_bool(
+                best_genome_payload.get("use_drawdown_guard", True)
+            ),
+        )
+    except Exception as exc:
+        logger.error("Failed to build MovingAverageGenome from manifest: %s", exc)
+        return False
+
+    identifier = best_genome_payload.get("id")
+    genome = genome_model.to_decision_genome(
+        identifier=str(identifier) if isinstance(identifier, str) and identifier else None
+    )
+
+    fitness_report = _build_fitness_report(best_metrics_payload, manifest)
+    provenance = _build_provenance(manifest, genome.id, fitness_report)
+
+    created_registry = False
+    registry_obj = registry
+    if registry_obj is None:
+        registry_path_resolved = _resolve_registry_path(registry_path)
+        registry_obj = StrategyRegistry(str(registry_path_resolved))
+        created_registry = True
+
+    try:
+        registered = registry_obj.register_champion(
+            genome,
+            dict(fitness_report),
+            provenance=provenance,
+        )
+    except Exception as exc:
+        logger.error("Failed to register champion genome: %s", exc)
+        registered = False
+    finally:
+        if created_registry:
+            with suppress(Exception):
+                registry_obj.conn.close()
+
+    return registered

--- a/tests/evolution/test_ga_promotion.py
+++ b/tests/evolution/test_ga_promotion.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from src.evolution.experiments.promotion import (
+    FEATURE_FLAG_ENV,
+    maybe_promote_best_genome,
+)
+from src.governance.strategy_registry import StrategyRegistry
+
+
+def _sample_manifest() -> dict[str, object]:
+    return {
+        "experiment": "ma_crossover_ga",
+        "generated_at": "2025-09-29T00:00:00Z",
+        "seed": 2025,
+        "code_version": "abcdef123456",
+        "notes": "Synthetic regression test dataset",
+        "dataset": {
+            "name": "synthetic_trend_v1",
+            "metadata": {"length": 512, "mean": 0.12},
+        },
+        "config": {
+            "population_size": 24,
+            "generations": 18,
+            "elite_count": 4,
+            "crossover_rate": 0.7,
+            "mutation_rate": 0.25,
+            "seed": 2025,
+        },
+        "replay": {"command": "python scripts/generate_evolution_lab.py --seed 2025"},
+        "best_genome": {
+            "short_window": 8,
+            "long_window": 169,
+            "risk_fraction": 0.36,
+            "use_var_guard": True,
+            "use_drawdown_guard": True,
+        },
+        "best_metrics": {
+            "fitness": 4.166,
+            "sharpe": 3.916,
+            "sortino": 5.98,
+            "max_drawdown": 0.01,
+            "total_return": 0.131,
+        },
+    }
+
+
+def test_promotion_respects_feature_flag(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.delenv(FEATURE_FLAG_ENV, raising=False)
+    manifest = _sample_manifest()
+    registry_path = tmp_path / "registry.db"
+
+    promoted = maybe_promote_best_genome(manifest, registry_path=registry_path)
+
+    assert promoted is False
+    assert not registry_path.exists()
+
+
+def test_promotion_registers_when_enabled(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.setenv(FEATURE_FLAG_ENV, "true")
+    manifest = _sample_manifest()
+    registry_path = tmp_path / "registry.db"
+
+    promoted = maybe_promote_best_genome(manifest, registry_path=registry_path)
+
+    assert promoted is True
+    registry = StrategyRegistry(str(registry_path))
+    try:
+        record = registry.get_strategy("ma::8-169-0.360")
+        assert record is not None
+        report = record["fitness_report"]
+        assert pytest.approx(report["fitness_score"], rel=1e-6) == 4.166
+        metadata = report["metadata"]["evolution_lab"]
+        assert metadata["experiment"] == "ma_crossover_ga"
+        assert metadata["dataset"]["name"] == "synthetic_trend_v1"
+        assert metadata["config"]["population_size"] == 24
+    finally:
+        registry.conn.close()


### PR DESCRIPTION
## Summary
- add a promotion utility that converts GA leaderboard manifests into strategy registry entries behind a feature flag
- update the evolution lab generator to invoke the promotion helper and reflect the completed roadmap task
- mark the roadmap and leaderboard documentation to show the feature-flagged promotion workflow is live

## Testing
- pytest tests/evolution/test_ga_promotion.py

------
https://chatgpt.com/codex/tasks/task_e_68da1f1b2d00832ca26839a48517f9ce