### PR TITLE
Add feature-flagged GA promotion workflow

### DIFF
--- a/docs/High-Impact Development Roadmap.md
+++ b/docs/High-Impact Development Roadmap.md
@@ -181,7 +181,7 @@ To reflect the true scope of institutional-grade trading components, the roadmap
 - [x] Document follow-on backlog (speciation, Pareto-front) for later phases.
 - [x] Integrate GA experiment runner with encyclopedia "Evolution Lab" conventions, including seed logging and reproducibility manifest.
 - [x] Publish experiment leaderboard (top genomes, metrics, configs) as Markdown table auto-generated in `/docs/research/evolution_lab.md`.
-- [ ] Cross-wire GA outputs into strategy registry via feature flags to enable supervised promotion into paper trading.
+- [x] Cross-wire GA outputs into strategy registry via feature flags to enable supervised promotion into paper trading.
 
 **Acceptance:** GA can evolve MA crossover parameters outperforming baseline in controlled backtest; results are reproducible from CI artifacts.
 

--- a/docs/research/evolution_lab.md
+++ b/docs/research/evolution_lab.md
@@ -20,4 +20,4 @@ _Auto-generated on 2025-09-28 19:01:38Z using `scripts/generate_evolution_lab.py
 - [ ] Evaluate Pareto-front selection for multi-objective fitness.
 - [ ] Swap synthetic datasets with live market snapshots for benchmarking.
 - [ ] Automate nightly leaderboard refresh with CI artifact publishing.
-- [ ] Integrate promoted genomes into the strategy registry feature flags.
+- [x] Integrate promoted genomes into the strategy registry feature flags.

--- a/scripts/generate_evolution_lab.py
+++ b/scripts/generate_evolution_lab.py
@@ -161,7 +161,7 @@ def main() -> None:
         "- [ ] Evaluate Pareto-front selection for multi-objective fitness.\n"
         "- [ ] Swap synthetic datasets with live market snapshots for benchmarking.\n"
         "- [ ] Automate nightly leaderboard refresh with CI artifact publishing.\n"
-        "- [ ] Integrate promoted genomes into the strategy registry feature flags.\n"
+        "- [x] Integrate promoted genomes into the strategy registry feature flags.\n"
     )
 
     doc_path.write_text(doc_content)

--- a/scripts/promote_evolved_strategy.py
+++ b/scripts/promote_evolved_strategy.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+"""Promote GA champions into the strategy registry when feature flags allow."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+from src.governance.promotion import (
+    PromotionFeatureFlags,
+    PromotionResult,
+    promote_manifest_to_registry,
+)
+from src.governance.strategy_registry import StrategyRegistry, StrategyStatus
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "manifest",
+        type=Path,
+        help="Path to the GA manifest JSON file produced by Evolution Lab runs.",
+    )
+    parser.add_argument(
+        "--registry-db",
+        type=Path,
+        default=Path("artifacts/governance/strategy_registry.db"),
+        help="Location of the SQLite registry database.",
+    )
+    parser.add_argument(
+        "--enable",
+        action="store_true",
+        help="Force-enable promotion regardless of environment feature flags.",
+    )
+    parser.add_argument(
+        "--approve",
+        action="store_true",
+        help="Automatically approve the promoted strategy (overrides feature flag).",
+    )
+    parser.add_argument(
+        "--target-status",
+        type=str,
+        default=None,
+        help="Target status when approving (evolved, approved, active, inactive).",
+    )
+    parser.add_argument(
+        "--min-fitness",
+        type=float,
+        default=None,
+        help="Override the minimum fitness threshold for promotion.",
+    )
+    return parser.parse_args()
+
+
+def _resolve_flags(args: argparse.Namespace) -> PromotionFeatureFlags:
+    flags = PromotionFeatureFlags.from_env()
+    overrides: dict[str, object] = {}
+    if args.enable:
+        overrides["register_enabled"] = True
+    if args.approve:
+        overrides["auto_approve"] = True
+        overrides.setdefault("target_status", StrategyStatus.APPROVED)
+    if args.target_status:
+        overrides["target_status"] = _parse_status(args.target_status, flags.target_status)
+    if args.min_fitness is not None:
+        overrides["min_fitness"] = float(args.min_fitness)
+    return flags.with_overrides(**overrides) if overrides else flags
+
+
+def _parse_status(raw: str, fallback: StrategyStatus) -> StrategyStatus:
+    normalised = raw.strip().lower()
+    for status in StrategyStatus:
+        if status.value == normalised or status.name.lower() == normalised:
+            return status
+    return fallback
+
+
+def _ensure_registry(path: Path) -> StrategyRegistry:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    return StrategyRegistry(str(path))
+
+
+def _print_result(result: PromotionResult) -> None:
+    if result.skipped and result.reason == "feature_flag_disabled":
+        print("⚠️ Promotion skipped: feature flag disabled.")
+        return
+    if result.skipped:
+        reason = result.reason or "unknown"
+        print(f"⚠️ Promotion skipped for {result.genome_id or 'n/a'} ({reason}).")
+        return
+    status = "updated" if result.status_updated else "recorded"
+    print(
+        f"✅ Registered {result.genome_id} with fitness {result.fitness:.3f} and {status} status."
+    )
+
+
+def main() -> int:
+    args = _parse_args()
+    flags = _resolve_flags(args)
+    registry = _ensure_registry(args.registry_db)
+    result = promote_manifest_to_registry(args.manifest, registry, flags=flags)
+    _print_result(result)
+    return 0 if result.registered or result.skipped else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/governance/__init__.py
+++ b/src/governance/__init__.py
@@ -1,3 +1,11 @@
 """Governance module for system configuration and management."""
 
 from __future__ import annotations
+
+from .promotion import PromotionFeatureFlags, PromotionResult, promote_manifest_to_registry
+
+__all__ = [
+    "PromotionFeatureFlags",
+    "PromotionResult",
+    "promote_manifest_to_registry",
+]

--- a/src/governance/promotion.py
+++ b/src/governance/promotion.py
@@ -1,0 +1,348 @@
+"""Feature-flagged promotion utilities for evolution experiment champions."""
+
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import dataclass, replace
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Mapping, MutableMapping
+
+from src.governance.strategy_registry import StrategyRegistry, StrategyStatus
+
+try:  # Lazy import so the module remains light for callers that do not need GA
+    from src.evolution.experiments.ma_crossover_ga import MovingAverageGenome
+except Exception:  # pragma: no cover - imported lazily for optional dependency
+    MovingAverageGenome = None  # type: ignore[assignment]
+
+__all__ = [
+    "PromotionFeatureFlags",
+    "PromotionResult",
+    "promote_manifest_to_registry",
+]
+
+
+def _parse_bool(value: str | None) -> bool:
+    if value is None:
+        return False
+    return value.strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _parse_float(value: str | None, *, default: float = 0.0) -> float:
+    if value is None:
+        return default
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _normalise_status(raw: str | None, fallback: StrategyStatus) -> StrategyStatus:
+    if raw is None:
+        return fallback
+    normalised = raw.strip().lower()
+    for status in StrategyStatus:
+        if status.value == normalised or status.name.lower() == normalised:
+            return status
+    return fallback
+
+
+def _to_timestamp(value: str | None) -> float | None:
+    if not value:
+        return None
+    try:
+        return datetime.fromisoformat(value.replace("Z", "+00:00")).timestamp()
+    except Exception:
+        return None
+
+
+@dataclass(slots=True, frozen=True)
+class PromotionFeatureFlags:
+    """Feature switches controlling how GA champions are promoted."""
+
+    register_enabled: bool = False
+    auto_approve: bool = False
+    target_status: StrategyStatus = StrategyStatus.EVOLVED
+    min_fitness: float = 0.0
+
+    @classmethod
+    def from_env(cls, env: Mapping[str, str] | None = None) -> "PromotionFeatureFlags":
+        env = env or os.environ
+        register_enabled = _parse_bool(env.get("EVOLUTION_PROMOTE_STRATEGIES"))
+        auto_approve = _parse_bool(env.get("EVOLUTION_PROMOTE_AUTO_APPROVE"))
+        default_status = StrategyStatus.APPROVED if auto_approve else StrategyStatus.EVOLVED
+        target_status = _normalise_status(env.get("EVOLUTION_PROMOTE_TARGET_STATUS"), default_status)
+        min_fitness = _parse_float(env.get("EVOLUTION_PROMOTE_MIN_FITNESS"), default=0.0)
+        return cls(
+            register_enabled=register_enabled,
+            auto_approve=auto_approve,
+            target_status=target_status,
+            min_fitness=min_fitness,
+        )
+
+    def with_overrides(
+        self,
+        *,
+        register_enabled: bool | None = None,
+        auto_approve: bool | None = None,
+        target_status: StrategyStatus | None = None,
+        min_fitness: float | None = None,
+    ) -> "PromotionFeatureFlags":
+        """Return a copy with selective overrides for CLI tooling."""
+
+        return replace(
+            self,
+            register_enabled=self.register_enabled if register_enabled is None else register_enabled,
+            auto_approve=self.auto_approve if auto_approve is None else auto_approve,
+            target_status=self.target_status if target_status is None else target_status,
+            min_fitness=self.min_fitness if min_fitness is None else min_fitness,
+        )
+
+
+@dataclass(slots=True)
+class PromotionResult:
+    """Outcome of a promotion attempt."""
+
+    genome_id: str | None
+    registered: bool
+    status_updated: bool
+    skipped: bool
+    reason: str | None = None
+    fitness: float | None = None
+
+    def as_dict(self) -> dict[str, Any]:
+        payload = {
+            "genome_id": self.genome_id,
+            "registered": self.registered,
+            "status_updated": self.status_updated,
+            "skipped": self.skipped,
+        }
+        if self.reason:
+            payload["reason"] = self.reason
+        if self.fitness is not None:
+            payload["fitness"] = self.fitness
+        return payload
+
+
+def _load_manifest(path: Path) -> Mapping[str, Any]:
+    try:
+        data = json.loads(path.read_text())
+    except FileNotFoundError as exc:
+        raise FileNotFoundError(f"Manifest not found at {path}") from exc
+    except json.JSONDecodeError as exc:  # pragma: no cover - defensive guard
+        raise ValueError(f"Manifest at {path} is not valid JSON") from exc
+    if not isinstance(data, Mapping):
+        raise ValueError("Manifest payload must be a mapping")
+    return data
+
+
+def _build_ma_genome(manifest: Mapping[str, Any]) -> tuple[Any, dict[str, Any], Mapping[str, Any]]:
+    if MovingAverageGenome is None:  # pragma: no cover - import guard
+        raise RuntimeError("MovingAverageGenome unavailable; install optional dependencies")
+
+    genome_payload = manifest.get("best_genome")
+    if not isinstance(genome_payload, Mapping):
+        raise ValueError("Manifest missing 'best_genome' mapping")
+
+    metrics = manifest.get("best_metrics") or {}
+    if not isinstance(metrics, Mapping):
+        raise ValueError("Manifest 'best_metrics' must be a mapping")
+
+    try:
+        genome = MovingAverageGenome(
+            short_window=int(genome_payload.get("short_window", 0)),
+            long_window=int(genome_payload.get("long_window", 0)),
+            risk_fraction=float(genome_payload.get("risk_fraction", 0.0)),
+            use_var_guard=bool(genome_payload.get("use_var_guard", True)),
+            use_drawdown_guard=bool(genome_payload.get("use_drawdown_guard", True)),
+        )
+    except Exception as exc:
+        raise ValueError(f"Invalid best_genome payload: {exc}") from exc
+
+    identifier_parts = [
+        str(manifest.get("experiment", "ma_crossover_ga")),
+        str(manifest.get("seed", "seed")),
+        f"s{genome.short_window}",
+        f"l{genome.long_window}",
+        f"r{int(round(genome.risk_fraction * 1000))}",
+    ]
+    identifier = "::".join(part for part in identifier_parts if part)
+    decision_genome = genome.to_decision_genome(identifier=identifier)
+
+    generation = manifest.get("generations")
+    if generation is None:
+        config = manifest.get("config")
+        if isinstance(config, Mapping):
+            generation = config.get("generations")
+    try:
+        decision_genome.generation = int(generation or 0)
+    except Exception:  # pragma: no cover - guard for unexpected payloads
+        decision_genome.generation = 0
+
+    performance_metrics = {
+        "fitness": float(metrics.get("fitness", 0.0)),
+        "sharpe_ratio": float(metrics.get("sharpe", 0.0)),
+        "sortino_ratio": float(metrics.get("sortino", 0.0)),
+        "max_drawdown": float(metrics.get("max_drawdown", 0.0)),
+        "total_return": float(metrics.get("total_return", 0.0)),
+    }
+    try:
+        decision_genome.performance_metrics.update(performance_metrics)
+    except Exception:  # pragma: no cover - defensive guard
+        decision_genome.performance_metrics = performance_metrics  # type: ignore[assignment]
+
+    metadata: MutableMapping[str, Any] = {
+        "source": "evolution_lab",
+        "experiment": manifest.get("experiment"),
+        "seed": manifest.get("seed"),
+        "dataset": manifest.get("dataset"),
+    }
+    try:
+        setattr(decision_genome, "metadata", metadata)
+    except Exception:  # pragma: no cover - optional attribute in dataclass
+        pass
+
+    return decision_genome, performance_metrics, genome_payload
+
+
+def _build_fitness_report(
+    metrics: Mapping[str, Any],
+    manifest: Mapping[str, Any],
+    manifest_path: Path,
+) -> tuple[dict[str, Any], float]:
+    fitness = float(metrics.get("fitness", 0.0))
+    report = {
+        "fitness_score": fitness,
+        "max_drawdown": float(metrics.get("max_drawdown", 0.0)),
+        "sharpe_ratio": float(metrics.get("sharpe", 0.0)),
+        "total_return": float(metrics.get("total_return", 0.0)),
+        "volatility": float(metrics.get("volatility", 0.0)),
+    }
+    metadata: dict[str, Any] = {
+        "experiment": manifest.get("experiment"),
+        "generated_at": manifest.get("generated_at"),
+        "seed": manifest.get("seed"),
+        "manifest_path": str(manifest_path),
+    }
+    dataset = manifest.get("dataset")
+    if dataset:
+        metadata["dataset"] = dataset
+    config = manifest.get("config")
+    if config:
+        metadata["config"] = config
+    report["metadata"] = metadata
+    return report, fitness
+
+
+def _build_provenance(
+    manifest: Mapping[str, Any],
+    genome_id: str,
+    genome_payload: Mapping[str, Any],
+) -> Mapping[str, Any]:
+    seeded_at = _to_timestamp(str(manifest.get("generated_at")))
+    catalogue_metadata = {
+        "experiment": manifest.get("experiment"),
+        "seed": manifest.get("seed"),
+        "config": manifest.get("config"),
+    }
+    provenance: dict[str, Any] = {
+        "seed_source": "evolution_lab",
+        "catalogue": {
+            "name": str(manifest.get("experiment", "evolution_lab")),
+            "version": str((manifest.get("config") or {}).get("generations", "")),
+            "seeded_at": seeded_at,
+            "metadata": catalogue_metadata,
+        },
+        "entry": {
+            "id": genome_id,
+            "name": f"{manifest.get('experiment', 'experiment')} champion",
+            "metadata": {
+                "best_genome": dict(genome_payload),
+                "best_metrics": dict(manifest.get("best_metrics") or {}),
+            },
+        },
+    }
+    return provenance
+
+
+def promote_manifest_to_registry(
+    manifest_path: str | Path,
+    registry: StrategyRegistry,
+    *,
+    flags: PromotionFeatureFlags | None = None,
+) -> PromotionResult:
+    """Promote a GA champion described by ``manifest_path`` into the registry."""
+
+    resolved_flags = flags or PromotionFeatureFlags.from_env()
+    if not resolved_flags.register_enabled:
+        return PromotionResult(
+            genome_id=None,
+            registered=False,
+            status_updated=False,
+            skipped=True,
+            reason="feature_flag_disabled",
+        )
+
+    path = Path(manifest_path)
+    try:
+        manifest = _load_manifest(path)
+    except Exception as exc:
+        return PromotionResult(
+            genome_id=None,
+            registered=False,
+            status_updated=False,
+            skipped=True,
+            reason=str(exc),
+        )
+
+    experiment = str(manifest.get("experiment", "")).strip()
+    if experiment and experiment != "ma_crossover_ga":
+        return PromotionResult(
+            genome_id=None,
+            registered=False,
+            status_updated=False,
+            skipped=True,
+            reason=f"unsupported_experiment:{experiment}",
+        )
+
+    try:
+        decision_genome, metrics, genome_payload = _build_ma_genome(manifest)
+    except Exception as exc:
+        return PromotionResult(
+            genome_id=None,
+            registered=False,
+            status_updated=False,
+            skipped=True,
+            reason=str(exc),
+        )
+
+    report, fitness = _build_fitness_report(metrics, manifest, path)
+    if fitness < resolved_flags.min_fitness:
+        return PromotionResult(
+            genome_id=decision_genome.id,
+            registered=False,
+            status_updated=False,
+            skipped=True,
+            reason="fitness_below_threshold",
+            fitness=fitness,
+        )
+
+    provenance = _build_provenance(manifest, decision_genome.id, genome_payload)
+
+    registered = registry.register_champion(decision_genome, dict(report), provenance=provenance)
+    status_updated = False
+
+    if registered and resolved_flags.auto_approve:
+        target = resolved_flags.target_status.value
+        if registry.update_strategy_status(decision_genome.id, target):
+            status_updated = True
+
+    return PromotionResult(
+        genome_id=decision_genome.id,
+        registered=registered,
+        status_updated=status_updated,
+        skipped=not registered,
+        fitness=fitness,
+        reason=None if registered else "registration_failed",
+    )

--- a/tests/governance/test_evolution_promotion.py
+++ b/tests/governance/test_evolution_promotion.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from src.governance.promotion import (
+    PromotionFeatureFlags,
+    promote_manifest_to_registry,
+)
+from src.governance.strategy_registry import StrategyRegistry, StrategyStatus
+
+
+def _write_manifest(path: Path, fitness: float = 4.2) -> Path:
+    payload = {
+        "experiment": "ma_crossover_ga",
+        "generated_at": "2025-09-28T19:01:38Z",
+        "seed": 2025,
+        "config": {"generations": 18, "population_size": 24},
+        "dataset": {"name": "synthetic", "metadata": {"length": 64}},
+        "best_genome": {
+            "short_window": 8,
+            "long_window": 64,
+            "risk_fraction": 0.35,
+            "use_var_guard": True,
+            "use_drawdown_guard": True,
+        },
+        "best_metrics": {
+            "fitness": fitness,
+            "sharpe": 3.9,
+            "sortino": 5.7,
+            "max_drawdown": 0.01,
+            "total_return": 0.12,
+        },
+    }
+    manifest_path = path / "manifest.json"
+    manifest_path.write_text(json.dumps(payload))
+    return manifest_path
+
+
+def _registry(tmp_path: Path) -> StrategyRegistry:
+    return StrategyRegistry(db_path=str(tmp_path / "registry.db"))
+
+
+def test_promotion_skipped_when_flag_disabled(tmp_path: Path) -> None:
+    manifest = _write_manifest(tmp_path)
+    registry = _registry(tmp_path)
+    flags = PromotionFeatureFlags(register_enabled=False)
+
+    result = promote_manifest_to_registry(manifest, registry, flags=flags)
+
+    assert result.skipped is True
+    assert result.registered is False
+    summary = registry.get_registry_summary()
+    assert summary["total_strategies"] == 0
+
+
+def test_promotion_registers_genome(tmp_path: Path) -> None:
+    manifest = _write_manifest(tmp_path)
+    registry = _registry(tmp_path)
+    flags = PromotionFeatureFlags(register_enabled=True, min_fitness=0.0)
+
+    result = promote_manifest_to_registry(manifest, registry, flags=flags)
+
+    assert result.registered is True
+    assert result.skipped is False
+    assert result.genome_id is not None
+
+    stored = registry.get_strategy(result.genome_id)
+    assert stored is not None
+    assert stored["status"] == StrategyStatus.EVOLVED.value
+    metadata = stored["fitness_report"].get("metadata", {})
+    assert metadata.get("experiment") == "ma_crossover_ga"
+
+
+def test_promotion_auto_approve(tmp_path: Path) -> None:
+    manifest = _write_manifest(tmp_path)
+    registry = _registry(tmp_path)
+    flags = PromotionFeatureFlags(
+        register_enabled=True,
+        auto_approve=True,
+        target_status=StrategyStatus.APPROVED,
+    )
+
+    result = promote_manifest_to_registry(manifest, registry, flags=flags)
+
+    assert result.status_updated is True
+    stored = registry.get_strategy(result.genome_id or "")
+    assert stored is not None
+    assert stored["status"] == StrategyStatus.APPROVED.value
+
+
+def test_promotion_respects_min_fitness(tmp_path: Path) -> None:
+    manifest = _write_manifest(tmp_path, fitness=0.1)
+    registry = _registry(tmp_path)
+    flags = PromotionFeatureFlags(register_enabled=True, min_fitness=1.0)
+
+    result = promote_manifest_to_registry(manifest, registry, flags=flags)
+
+    assert result.skipped is True
+    assert result.reason == "fitness_below_threshold"
+    summary = registry.get_registry_summary()
+    assert summary["total_strategies"] == 0


### PR DESCRIPTION
## Summary
- add a governance promotion module that registers GA champions behind environment-driven feature flags
- provide a CLI helper to promote manifests and mark the roadmap/docs item as complete
- cover the new workflow with governance tests and update evolution lab backlog text

## Testing
- pytest tests/governance/test_evolution_promotion.py

------
https://chatgpt.com/codex/tasks/task_e_68da1f1b2d00832ca26839a48517f9ce