### PR TITLE
Add JSON detail export for high-impact roadmap

### DIFF
--- a/docs/status/high_impact_roadmap.md
+++ b/docs/status/high_impact_roadmap.md
@@ -14,6 +14,13 @@ To focus on specific streams, provide one or more ``--stream`` flags:
 python -m tools.roadmap.high_impact --stream "Stream A – Institutional data backbone" --format detail
 ```
 
+When dashboards require the same evidence payloads in JSON form, use the
+``detail-json`` format:
+
+```bash
+python -m tools.roadmap.high_impact --format detail-json
+```
+
 For an at-a-glance rollup of the portfolio, render the summary view:
 
 ```bash

--- a/tests/tools/test_high_impact_roadmap.py
+++ b/tests/tools/test_high_impact_roadmap.py
@@ -139,6 +139,15 @@ def test_json_format_includes_evidence() -> None:
     assert payload["streams"][0]["evidence"], "expected evidence list in JSON output"
 
 
+def test_detail_json_format_includes_streams() -> None:
+    statuses = high_impact.evaluate_streams()
+    payload = json.loads(high_impact.format_detail_json(statuses))
+
+    assert payload["portfolio"]["total_streams"] == len(statuses)
+    assert payload["streams"], "expected streams list in detail JSON output"
+    assert payload["streams"][0]["evidence"], "expected evidence list in detail JSON output"
+
+
 def test_attention_json_format_includes_missing_requirements() -> None:
     statuses = [
         high_impact.StreamStatus(
@@ -220,6 +229,17 @@ def test_cli_supports_attention_json(capsys: pytest.CaptureFixture[str]) -> None
     payload = json.loads(out)
     assert "portfolio" in payload
     assert "streams" in payload
+
+
+def test_cli_supports_detail_json(capsys: pytest.CaptureFixture[str]) -> None:
+    exit_code = high_impact.main(["--format", "detail-json"])
+
+    assert exit_code == 0
+
+    out, err = capsys.readouterr()
+    assert not err
+    payload = json.loads(out)
+    assert payload["streams"], "expected streams list in CLI detail JSON output"
 
 
 def test_evaluate_streams_can_filter() -> None:

--- a/tools/roadmap/high_impact.py
+++ b/tools/roadmap/high_impact.py
@@ -451,6 +451,30 @@ def format_detail(statuses: Iterable[StreamStatus]) -> str:
     return "\n".join(lines).rstrip()
 
 
+def format_detail_json(statuses: Iterable[StreamStatus]) -> str:
+    """Return a JSON payload with evidence for every stream."""
+
+    stream_statuses = tuple(statuses)
+    portfolio = summarise_portfolio(stream_statuses)
+
+    payload = {
+        "portfolio": portfolio.as_dict(),
+        "streams": [
+            {
+                "stream": status.stream,
+                "status": status.status,
+                "summary": status.summary,
+                "next_checkpoint": status.next_checkpoint,
+                "evidence": list(status.evidence),
+                "missing": list(status.missing),
+            }
+            for status in stream_statuses
+        ],
+    }
+
+    return json.dumps(payload, indent=2)
+
+
 def format_attention(statuses: Iterable[StreamStatus]) -> str:
     """Highlight streams that still have missing requirements."""
 
@@ -661,6 +685,7 @@ def main(argv: Sequence[str] | None = None) -> int:
             "markdown",
             "json",
             "detail",
+            "detail-json",
             "summary",
             "attention",
             "attention-json",
@@ -729,6 +754,8 @@ def main(argv: Sequence[str] | None = None) -> int:
         output = format_json(statuses)
     elif args.format == "detail":
         output = format_detail(statuses)
+    elif args.format == "detail-json":
+        output = format_detail_json(statuses)
     elif args.format == "summary":
         output = format_portfolio_summary(statuses)
     elif args.format == "attention":


### PR DESCRIPTION
## Summary
- add a JSON detail formatter for the high-impact roadmap CLI alongside a `--format detail-json` flag
- extend the roadmap status documentation to describe the new dashboard-friendly format
- cover the new formatter and CLI pathway with unit tests

## Testing
- pytest tests/tools/test_high_impact_roadmap.py -q

------
https://chatgpt.com/codex/tasks/task_e_68da227ccef8832cb82e513315b62811