### PR TITLE
Enforce exit code for high-impact roadmap CLI when attention needed

### DIFF
--- a/docs/status/high_impact_roadmap.md
+++ b/docs/status/high_impact_roadmap.md
@@ -8,6 +8,9 @@ before demos or reviews:
 python -m tools.roadmap.high_impact --format markdown
 ```
 
+The command exits with a non-zero status when any stream needs attention, so CI
+pipelines can gate on roadmap readiness without additional scripting.
+
 To focus on specific streams, provide one or more ``--stream`` flags:
 
 ```bash

--- a/tests/tools/test_high_impact_roadmap.py
+++ b/tests/tools/test_high_impact_roadmap.py
@@ -199,6 +199,32 @@ def test_cli_attention_format_handles_ready_streams(capsys: pytest.CaptureFixtur
     assert "All streams are Ready" in out
 
 
+def test_cli_exit_code_reflects_attention(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    def _fake_streams(_: list[str] | None = None) -> list[high_impact.StreamStatus]:
+        return [
+            high_impact.StreamStatus(
+                stream="Stream Ω – Test",
+                status="Attention needed",
+                summary="Incomplete",
+                next_checkpoint="Ship everything",
+                evidence=("module.present",),
+                missing=("module.missing",),
+            )
+        ]
+
+    monkeypatch.setattr(high_impact, "evaluate_streams", _fake_streams)
+
+    exit_code = high_impact.main([])
+
+    assert exit_code == 1
+
+    out, err = capsys.readouterr()
+    assert not err
+    assert "Stream Ω – Test" in out
+
+
 def test_cli_supports_portfolio_json(capsys: pytest.CaptureFixture[str]) -> None:
     exit_code = high_impact.main(["--format", "portfolio-json"])
 

--- a/tools/roadmap/high_impact.py
+++ b/tools/roadmap/high_impact.py
@@ -715,9 +715,11 @@ def main(argv: Sequence[str] | None = None) -> int:
     args = parser.parse_args(argv)
 
     try:
-        statuses = evaluate_streams(args.streams)
+        statuses = tuple(evaluate_streams(args.streams))
     except ValueError as exc:
         parser.error(str(exc))
+
+    portfolio = summarise_portfolio(statuses)
     if args.refresh_docs:
         refresh_docs(
             statuses,
@@ -744,7 +746,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         args.output.write_text(output, encoding="utf-8")
 
     print(output)
-    return 0
+    return 0 if portfolio.all_ready else 1
 
 
 if __name__ == "__main__":  # pragma: no cover - CLI wrapper


### PR DESCRIPTION
## Summary
- update the high-impact roadmap CLI to reuse evaluated statuses and return a non-zero exit code whenever any stream still needs attention
- document the CLI behaviour so CI pipelines can rely on the exit status for gating
- add a regression test that stubs attention-needed streams and asserts the CLI exits with a failure status

## Testing
- pytest tests/tools/test_high_impact_roadmap.py

------
https://chatgpt.com/codex/tasks/task_e_68da227ccef8832cb82e513315b62811