### PR TITLE
Add JSON artifacts to high-impact roadmap refresh

### DIFF
--- a/docs/status/high_impact_roadmap.md
+++ b/docs/status/high_impact_roadmap.md
@@ -33,6 +33,18 @@ requirements:
 python -m tools.roadmap.high_impact --format attention
 ```
 
+When refreshing documentation, JSON payloads for dashboards are emitted
+alongside the Markdown files (by default they land in
+`docs/status/high_impact_roadmap_portfolio.json` and
+`docs/status/high_impact_roadmap_attention.json`). Override the default
+destinations when needed:
+
+```bash
+python -m tools.roadmap.high_impact --refresh-docs \
+  --portfolio-json-path /tmp/high_impact_portfolio.json \
+  --attention-json-path /tmp/high_impact_attention.json
+```
+
 To feed dashboards that only need the missing requirements, emit the JSON
 attention view:
 

--- a/docs/status/high_impact_roadmap_attention.json
+++ b/docs/status/high_impact_roadmap_attention.json
@@ -1,0 +1,10 @@
+{
+  "portfolio": {
+    "total_streams": 3,
+    "ready": 3,
+    "attention_needed": 0,
+    "all_ready": true
+  },
+  "streams": [],
+  "missing_requirements": {}
+}

--- a/docs/status/high_impact_roadmap_portfolio.json
+++ b/docs/status/high_impact_roadmap_portfolio.json
@@ -1,0 +1,88 @@
+{
+  "total_streams": 3,
+  "ready": 3,
+  "attention_needed": 0,
+  "streams": [
+    {
+      "stream": "Stream A \u2013 Institutional data backbone",
+      "status": "Ready",
+      "summary": "Timescale ingest, Redis caching, Kafka streaming, and Spark exports ship with readiness telemetry and failover tooling.",
+      "next_checkpoint": "Exercise cross-region failover and automated scheduler cutover using the readiness feeds.",
+      "evidence": [
+        "data_foundation.ingest.timescale_pipeline.TimescaleBackboneOrchestrator",
+        "data_foundation.ingest.configuration.build_institutional_ingest_config",
+        "data_foundation.ingest.quality.evaluate_ingest_quality",
+        "data_foundation.cache.redis_cache.ManagedRedisCache",
+        "data_foundation.streaming.kafka_stream.KafkaIngestEventPublisher",
+        "data_foundation.streaming.kafka_stream.KafkaIngestQualityPublisher",
+        "data_foundation.batch.spark_export.execute_spark_export_plan",
+        "operations.data_backbone.evaluate_data_backbone_readiness",
+        "operations.ingest_trends.evaluate_ingest_trends",
+        "data_foundation.ingest.failover.decide_ingest_failover",
+        "operations.cross_region_failover.evaluate_cross_region_failover",
+        "operations.backup.evaluate_backup_readiness",
+        "operations.spark_stress.execute_spark_stress_drill"
+      ],
+      "missing": []
+    },
+    {
+      "stream": "Stream B \u2013 Sensory cortex & evolution uplift",
+      "status": "Ready",
+      "summary": "All five sensory organs operate with drift telemetry and catalogue-backed evolution lineage exports.",
+      "next_checkpoint": "Extend live-paper experiments and automated tuning loops using evolution telemetry.",
+      "evidence": [
+        "sensory.how.how_sensor.HowSensor",
+        "sensory.anomaly.anomaly_sensor.AnomalySensor",
+        "sensory.when.gamma_exposure.GammaExposureAnalyzer",
+        "sensory.why.why_sensor.WhySensor",
+        "sensory.what.what_sensor.WhatSensor",
+        "operations.sensory_drift.evaluate_sensory_drift",
+        "genome.catalogue.load_default_catalogue",
+        "evolution.lineage_telemetry.EvolutionLineageSnapshot",
+        "orchestration.evolution_cycle.EvolutionCycleOrchestrator",
+        "operations.evolution_experiments.evaluate_evolution_experiments",
+        "operations.evolution_tuning.evaluate_evolution_tuning"
+      ],
+      "missing": []
+    },
+    {
+      "stream": "Stream C \u2013 Execution, risk, compliance, ops readiness",
+      "status": "Ready",
+      "summary": "FIX pilots, risk/compliance workflows, ROI telemetry, and operational readiness publish evidence for operators.",
+      "next_checkpoint": "Expand broker connectivity with drop-copy reconciliation and extend regulatory telemetry coverage.",
+      "evidence": [
+        "runtime.fix_pilot.FixIntegrationPilot",
+        "operations.fix_pilot.evaluate_fix_pilot",
+        "runtime.fix_dropcopy.FixDropcopyReconciler",
+        "operations.execution.evaluate_execution_readiness",
+        "operations.professional_readiness.evaluate_professional_readiness",
+        "operations.roi.evaluate_roi_posture",
+        "operations.strategy_performance.evaluate_strategy_performance",
+        "compliance.workflow.evaluate_compliance_workflows",
+        "operations.compliance_readiness.evaluate_compliance_readiness",
+        "compliance.trade_compliance.TradeComplianceMonitor",
+        "compliance.kyc.KycAmlMonitor",
+        "operations.configuration_audit.evaluate_configuration_audit",
+        "operations.system_validation.evaluate_system_validation",
+        "operations.slo.evaluate_ingest_slos",
+        "operations.event_bus_health.evaluate_event_bus_health",
+        "operations.failover_drill.execute_failover_drill",
+        "trading.order_management.lifecycle_processor.OrderLifecycleProcessor",
+        "trading.order_management.position_tracker.PositionTracker",
+        "trading.order_management.event_journal.OrderEventJournal",
+        "trading.order_management.reconciliation.replay_order_events",
+        "scripts/order_lifecycle_dry_run.py",
+        "scripts/reconcile_positions.py",
+        "docs/runbooks/execution_lifecycle.md"
+      ],
+      "missing": []
+    }
+  ],
+  "ready_streams": [
+    "Stream A \u2013 Institutional data backbone",
+    "Stream B \u2013 Sensory cortex & evolution uplift",
+    "Stream C \u2013 Execution, risk, compliance, ops readiness"
+  ],
+  "attention_streams": [],
+  "missing_requirements": {}
+}

--- a/tests/tools/test_high_impact_roadmap.py
+++ b/tests/tools/test_high_impact_roadmap.py
@@ -314,10 +314,14 @@ def test_cli_writes_output_file(tmp_path: Path) -> None:
     assert "High-impact roadmap status" in content
 
 
-def test_cli_refresh_docs_accepts_custom_paths(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+def test_cli_refresh_docs_accepts_custom_paths(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
     summary = tmp_path / "summary.md"
     detail = tmp_path / "detail.md"
     attention = tmp_path / "attention.md"
+    portfolio_json = tmp_path / "portfolio.json"
+    attention_json = tmp_path / "attention.json"
     summary.write_text(
         (
             "Lead-in\n\n"
@@ -341,6 +345,10 @@ def test_cli_refresh_docs_accepts_custom_paths(tmp_path: Path, capsys: pytest.Ca
             str(detail),
             "--attention-path",
             str(attention),
+            "--portfolio-json-path",
+            str(portfolio_json),
+            "--attention-json-path",
+            str(attention_json),
         ]
     )
 
@@ -362,11 +370,19 @@ def test_cli_refresh_docs_accepts_custom_paths(tmp_path: Path, capsys: pytest.Ca
     assert updated_attention.startswith("# High-impact roadmap attention")
     assert updated_attention.endswith("\n")
 
+    portfolio_payload = json.loads(portfolio_json.read_text(encoding="utf-8"))
+    assert portfolio_payload["ready"] == portfolio_payload["total_streams"]
+
+    attention_payload = json.loads(attention_json.read_text(encoding="utf-8"))
+    assert attention_payload["portfolio"]["attention_needed"] == 0
+
 
 def test_refresh_docs_updates_summary_and_detail(tmp_path: Path) -> None:
     summary = tmp_path / "summary.md"
     detail = tmp_path / "detail.md"
     attention = tmp_path / "attention.md"
+    portfolio_json = tmp_path / "portfolio.json"
+    attention_json = tmp_path / "attention.json"
     summary.write_text(
         (
             "Header\n\n"
@@ -388,6 +404,8 @@ def test_refresh_docs_updates_summary_and_detail(tmp_path: Path) -> None:
         summary_path=summary,
         detail_path=detail,
         attention_path=attention,
+        portfolio_json_path=portfolio_json,
+        attention_json_path=attention_json,
     )
 
     updated_summary = summary.read_text(encoding="utf-8")
@@ -403,6 +421,12 @@ def test_refresh_docs_updates_summary_and_detail(tmp_path: Path) -> None:
     updated_attention = attention.read_text(encoding="utf-8")
     assert updated_attention.startswith("# High-impact roadmap attention")
     assert updated_attention.endswith("\n")
+
+    portfolio_payload = json.loads(portfolio_json.read_text(encoding="utf-8"))
+    assert portfolio_payload["ready_streams"]
+
+    attention_payload = json.loads(attention_json.read_text(encoding="utf-8"))
+    assert attention_payload["streams"] == []
 
 
 def test_refresh_docs_requires_markers(tmp_path: Path) -> None:

--- a/tools/roadmap/high_impact.py
+++ b/tools/roadmap/high_impact.py
@@ -610,13 +610,17 @@ def refresh_docs(
     summary_path: Path | None = None,
     detail_path: Path | None = None,
     attention_path: Path | None = None,
+    portfolio_json_path: Path | None = None,
+    attention_json_path: Path | None = None,
 ) -> None:
     """Refresh the roadmap status documentation files.
 
     The summary document retains its narrative wrapper and only replaces the
     table that sits between the ``HIGH_IMPACT_SUMMARY`` markers.  The detail
     document is overwritten with the richer report used by dashboards and
-    narrative status updates.
+    narrative status updates.  When JSON destinations are provided (or the
+    defaults are used), the helper also emits the portfolio roll-up and the
+    attention-focused payload used by dashboards.
     """
 
     if statuses is None:
@@ -629,6 +633,14 @@ def refresh_docs(
     detail_path = detail_path or root / "docs/status/high_impact_roadmap_detail.md"
     attention_path = (
         attention_path or root / "docs/status/high_impact_roadmap_attention.md"
+    )
+    portfolio_json_path = (
+        portfolio_json_path
+        or root / "docs/status/high_impact_roadmap_portfolio.json"
+    )
+    attention_json_path = (
+        attention_json_path
+        or root / "docs/status/high_impact_roadmap_attention.json"
     )
 
     summary_text = summary_path.read_text(encoding="utf-8")
@@ -649,6 +661,18 @@ def refresh_docs(
     if not attention_text.endswith("\n"):
         attention_text = f"{attention_text}\n"
     attention_path.write_text(attention_text, encoding="utf-8")
+
+    if portfolio_json_path:
+        portfolio_payload = format_portfolio_json(statuses)
+        if not portfolio_payload.endswith("\n"):
+            portfolio_payload = f"{portfolio_payload}\n"
+        portfolio_json_path.write_text(portfolio_payload, encoding="utf-8")
+
+    if attention_json_path:
+        attention_payload = format_attention_json(statuses)
+        if not attention_payload.endswith("\n"):
+            attention_payload = f"{attention_payload}\n"
+        attention_json_path.write_text(attention_payload, encoding="utf-8")
 
 
 def main(argv: Sequence[str] | None = None) -> int:
@@ -704,6 +728,22 @@ def main(argv: Sequence[str] | None = None) -> int:
         ),
     )
     parser.add_argument(
+        "--portfolio-json-path",
+        type=Path,
+        help=(
+            "Optional path to the portfolio JSON file when refreshing docs. "
+            "Defaults to docs/status/high_impact_roadmap_portfolio.json"
+        ),
+    )
+    parser.add_argument(
+        "--attention-json-path",
+        type=Path,
+        help=(
+            "Optional path to the attention JSON file when refreshing docs. "
+            "Defaults to docs/status/high_impact_roadmap_attention.json"
+        ),
+    )
+    parser.add_argument(
         "--stream",
         action="append",
         dest="streams",
@@ -724,6 +764,8 @@ def main(argv: Sequence[str] | None = None) -> int:
             summary_path=args.summary_path,
             detail_path=args.detail_path,
             attention_path=args.attention_path,
+            portfolio_json_path=args.portfolio_json_path,
+            attention_json_path=args.attention_json_path,
         )
     if args.format == "json":
         output = format_json(statuses)


### PR DESCRIPTION
## Summary
- extend the high-impact roadmap refresh helper to emit portfolio and attention JSON artifacts alongside the markdown outputs
- document the new JSON defaults and override flags in the roadmap status guide and version the generated files
- cover the JSON flows with unit tests to ensure the CLI and helper write the expected payloads

## Testing
- pytest tests/tools/test_high_impact_roadmap.py

------
https://chatgpt.com/codex/tasks/task_e_68da227ccef8832cb82e513315b62811