### PR TITLE
Add order book imbalance analytics for HOW sensor

### DIFF
--- a/src/sensory/how/__init__.py
+++ b/src/sensory/how/__init__.py
@@ -1,5 +1,13 @@
 from __future__ import annotations
 
 from .how_sensor import HowSensor
+from .order_book_imbalance import (
+    OrderBookImbalanceMetrics,
+    compute_order_book_imbalance,
+)
 
-__all__ = ["HowSensor"]
+__all__ = [
+    "HowSensor",
+    "OrderBookImbalanceMetrics",
+    "compute_order_book_imbalance",
+]

--- a/src/sensory/how/order_book_imbalance.py
+++ b/src/sensory/how/order_book_imbalance.py
@@ -1,0 +1,126 @@
+"""Order book imbalance analytics for the HOW sensory dimension."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, Mapping, Sequence
+
+from src.trading.order_management.order_book.snapshot import (
+    OrderBookLevel,
+    OrderBookSnapshot,
+)
+
+__all__ = ["OrderBookImbalanceMetrics", "compute_order_book_imbalance"]
+
+
+@dataclass(frozen=True)
+class OrderBookImbalanceMetrics:
+    """Summary statistics describing order book imbalance."""
+
+    buy_volume: float
+    sell_volume: float
+    total_volume: float
+    imbalance: float
+    levels_evaluated: int
+
+    @property
+    def has_volume(self) -> bool:
+        return self.total_volume > 0.0
+
+
+def compute_order_book_imbalance(
+    order_book: OrderBookSnapshot | Mapping[str, object] | None,
+    *,
+    depth: int | None = None,
+) -> OrderBookImbalanceMetrics:
+    """Calculate an order flow imbalance score for a snapshot.
+
+    The function accepts either the canonical :class:`OrderBookSnapshot` model
+    or any mapping containing ``"bids"``/``"asks"`` sequences.  Each level can be
+    represented as an :class:`OrderBookLevel`, mapping (``{"price": ..., "volume": ...}``)
+    or a tuple ``(price, volume)``.  Levels are assumed to be ordered from best
+    to worst, matching FIX book updates.
+
+    Args:
+        order_book: Snapshot or mapping describing the order book levels.
+        depth: Optional number of levels per side to include in the calculation.
+
+    Returns:
+        ``OrderBookImbalanceMetrics`` describing aggregated buy/sell volume and
+        a normalised imbalance in ``[-1, 1]`` where positive numbers indicate bid
+        pressure.
+    """
+
+    bids, asks = _extract_levels(order_book)
+
+    if depth is not None and depth > 0:
+        bids = bids[:depth]
+        asks = asks[:depth]
+
+    buy_volume = sum(volume for _, volume in bids)
+    sell_volume = sum(volume for _, volume in asks)
+    total_volume = buy_volume + sell_volume
+
+    if total_volume <= 0.0:
+        return OrderBookImbalanceMetrics(
+            buy_volume=0.0,
+            sell_volume=0.0,
+            total_volume=0.0,
+            imbalance=0.0,
+            levels_evaluated=len(bids) + len(asks),
+        )
+
+    imbalance = (buy_volume - sell_volume) / total_volume
+    imbalance = max(min(imbalance, 1.0), -1.0)
+
+    return OrderBookImbalanceMetrics(
+        buy_volume=float(buy_volume),
+        sell_volume=float(sell_volume),
+        total_volume=float(total_volume),
+        imbalance=float(imbalance),
+        levels_evaluated=len(bids) + len(asks),
+    )
+
+
+def _extract_levels(
+    order_book: OrderBookSnapshot | Mapping[str, object] | None,
+) -> tuple[list[tuple[float, float]], list[tuple[float, float]]]:
+    if isinstance(order_book, OrderBookSnapshot):
+        return (
+            _normalise_levels(order_book.bids),
+            _normalise_levels(order_book.asks),
+        )
+
+    if isinstance(order_book, Mapping):
+        bids = order_book.get("bids")
+        asks = order_book.get("asks")
+        return (
+            _normalise_levels(bids if isinstance(bids, Iterable) else ()),
+            _normalise_levels(asks if isinstance(asks, Iterable) else ()),
+        )
+
+    return ([], [])
+
+
+def _normalise_levels(levels: Iterable[object]) -> list[tuple[float, float]]:
+    normalised: list[tuple[float, float]] = []
+    for level in levels:
+        if isinstance(level, OrderBookLevel):
+            price = float(level.price)
+            volume = float(level.volume)
+        elif isinstance(level, Mapping):
+            price = float(level.get("price", 0.0) or 0.0)
+            volume = float(level.get("volume", 0.0) or 0.0)
+        elif isinstance(level, Sequence) and len(level) >= 2:
+            price = float(level[0])
+            volume = float(level[1])
+        else:
+            continue
+
+        if volume <= 0.0:
+            continue
+
+        normalised.append((price, volume))
+
+    return normalised
+

--- a/tests/sensory/test_order_book_imbalance.py
+++ b/tests/sensory/test_order_book_imbalance.py
@@ -1,0 +1,68 @@
+from datetime import datetime, timezone
+
+import pandas as pd
+
+from src.sensory.how.how_sensor import HowSensor
+from src.sensory.how.order_book_imbalance import compute_order_book_imbalance
+from src.trading.order_management.order_book.snapshot import (
+    OrderBookLevel,
+    OrderBookSnapshot,
+)
+
+
+def _build_snapshot() -> OrderBookSnapshot:
+    timestamp = datetime(2024, 1, 1, 12, tzinfo=timezone.utc)
+    bids = [
+        OrderBookLevel(price=1.1000, volume=2_000),
+        OrderBookLevel(price=1.0995, volume=1_200),
+        OrderBookLevel(price=1.0990, volume=800),
+    ]
+    asks = [
+        OrderBookLevel(price=1.1005, volume=1_100),
+        OrderBookLevel(price=1.1010, volume=900),
+        OrderBookLevel(price=1.1015, volume=700),
+    ]
+    return OrderBookSnapshot(symbol="EURUSD", timestamp=timestamp, bids=bids, asks=asks)
+
+
+def test_compute_order_book_imbalance_returns_expected_ratio() -> None:
+    snapshot = _build_snapshot()
+
+    metrics = compute_order_book_imbalance(snapshot)
+
+    assert metrics.has_volume
+    assert metrics.total_volume == snapshot.total_bid_volume + snapshot.total_ask_volume
+    expected_imbalance = (snapshot.total_bid_volume - snapshot.total_ask_volume) / metrics.total_volume
+    assert abs(metrics.imbalance - expected_imbalance) < 1e-9
+
+
+def test_how_sensor_derives_order_imbalance_from_snapshot() -> None:
+    snapshot = _build_snapshot()
+
+    rows = [
+        {
+            "timestamp": snapshot.timestamp,
+            "symbol": snapshot.symbol,
+            "open": snapshot.mid_price,
+            "high": snapshot.mid_price + 0.0006,
+            "low": snapshot.mid_price - 0.0005,
+            "close": snapshot.mid_price,
+            "volume": snapshot.total_bid_volume + snapshot.total_ask_volume,
+            "volatility": 0.0005,
+            "spread": snapshot.spread,
+            "depth": snapshot.total_bid_volume + snapshot.total_ask_volume,
+            "data_quality": 0.9,
+            "order_book_snapshot": snapshot,
+        }
+    ]
+    frame = pd.DataFrame(rows)
+
+    sensor = HowSensor()
+    signals = sensor.process(frame)
+
+    assert len(signals) == 1
+    value = signals[0].value
+    assert "book_buy_volume" in value
+    assert "book_sell_volume" in value
+    assert value["book_total_volume"] == snapshot.total_bid_volume + snapshot.total_ask_volume
+    assert value["imbalance"] == value["imbalance"]  # sanity check for NaN


### PR DESCRIPTION
## Summary
- add a reusable order book imbalance calculator backed by canonical snapshot models
- enrich HowSensor telemetry with book volume metrics and automatically derive imbalance when only raw book data is supplied
- cover the new behaviour with focused unit tests exercising both the calculator and the HOW sensor integration

## Testing
- pytest tests/sensory/test_how_anomaly_sensors.py tests/sensory/test_order_book_imbalance.py


------
https://chatgpt.com/codex/tasks/task_e_68da27eabc74832c9ca6b6857f0ce5d9