### PR TITLE
Add feed anomaly detection and telemetry

### DIFF
--- a/docs/High-Impact Development Roadmap.md
+++ b/docs/High-Impact Development Roadmap.md
@@ -208,7 +208,7 @@ To reflect the true scope of institutional-grade trading components, the roadmap
 - [x] Multi-source aggregation (Yahoo, Alpha Vantage, FRED) with data-quality validators via `src/data_foundation/ingest/multi_source.py`.
 - [ ] Introduce streaming ingestion adapters with latency benchmarks.
 - [ ] Incorporate selected ICT-style sensors (fair value gaps, liquidity sweeps) once validated by strategies.
-- [ ] Build anomaly detection for data feed breaks and false ticks.
+- [x] Build anomaly detection for data feed breaks and false ticks.
 - [ ] Update documentation on data lineage and quality SLA.
 - [ ] Implement encyclopedia-aligned "Market Microstructure Observatory" notebooks showcasing liquidity/volume profiling studies.
 - [ ] Add market regime classifier blending volatility, liquidity, and sentiment signals for execution model selection.

--- a/docs/status/high_impact_roadmap_detail.md
+++ b/docs/status/high_impact_roadmap_detail.md
@@ -71,6 +71,8 @@ streaming and production telemetry land.
 - operations.system_validation.evaluate_system_validation
 - operations.slo.evaluate_ingest_slos
 - operations.event_bus_health.evaluate_event_bus_health
+- data_foundation.monitoring.feed_anomaly.analyse_feed
+- operations.feed_health.evaluate_feed_health
 - operations.failover_drill.execute_failover_drill
 - operations.alerts.build_default_alert_manager
 - risk.analytics.var.compute_parametric_var

--- a/src/data_foundation/monitoring/feed_anomaly.py
+++ b/src/data_foundation/monitoring/feed_anomaly.py
@@ -1,0 +1,384 @@
+"""Data feed anomaly detection aligned with the high-impact roadmap.
+
+The Phase 3 roadmap requires anomaly detection for data-feed breaks and
+erroneous ticks.  This module keeps the implementation light-weight while
+providing deterministic helpers that other layers (operations dashboards,
+CI checks, CLI tooling) can reuse without needing external services.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from enum import StrEnum
+from statistics import median
+from typing import Iterable, Mapping, Sequence
+
+__all__ = [
+    "Tick",
+    "FeedGap",
+    "FalseTick",
+    "FeedHealthStatus",
+    "FeedAnomalyConfig",
+    "FeedAnomalyReport",
+    "analyse_feed",
+]
+
+
+@dataclass(frozen=True, slots=True)
+class Tick:
+    """Minimal tick structure used by the detector."""
+
+    timestamp: datetime
+    price: float
+    volume: float | None = None
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.timestamp, datetime):  # pragma: no cover - defensive
+            raise TypeError("timestamp must be a datetime instance")
+
+
+@dataclass(frozen=True, slots=True)
+class FeedGap:
+    """Represents a gap in the incoming market data feed."""
+
+    start: datetime
+    end: datetime
+    duration_seconds: float
+    estimated_missing_ticks: int
+
+    def as_dict(self) -> Mapping[str, object]:
+        return {
+            "start": self.start.astimezone(UTC).isoformat(),
+            "end": self.end.astimezone(UTC).isoformat(),
+            "duration_seconds": self.duration_seconds,
+            "estimated_missing_ticks": self.estimated_missing_ticks,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class FalseTick:
+    """Represents a potential erroneous tick."""
+
+    timestamp: datetime
+    price: float
+    previous_price: float
+    deviation_pct: float
+    volume: float | None
+
+    def as_dict(self) -> Mapping[str, object]:
+        return {
+            "timestamp": self.timestamp.astimezone(UTC).isoformat(),
+            "price": self.price,
+            "previous_price": self.previous_price,
+            "deviation_pct": self.deviation_pct,
+            "volume": self.volume,
+        }
+
+
+class FeedHealthStatus(StrEnum):
+    """Severity levels surfaced to operators."""
+
+    ok = "ok"
+    warn = "warn"
+    fail = "fail"
+
+
+@dataclass(frozen=True, slots=True)
+class FeedAnomalyConfig:
+    """Configuration controlling anomaly detection thresholds."""
+
+    max_gap_seconds: float = 90.0
+    fail_gap_multiplier: float = 3.0
+    price_jump_pct: float = 5.0
+    false_tick_limit: int = 2
+    min_samples_for_ok: int = 5
+    lookback_limit: int = 5000
+    stale_grace_seconds: float = 120.0
+    min_false_tick_reversion_pct: float = 2.5
+
+    def __post_init__(self) -> None:  # pragma: no cover - defensive
+        if self.max_gap_seconds <= 0:
+            raise ValueError("max_gap_seconds must be positive")
+        if self.fail_gap_multiplier < 1:
+            raise ValueError("fail_gap_multiplier must be >= 1")
+        if self.price_jump_pct <= 0:
+            raise ValueError("price_jump_pct must be positive")
+        if self.false_tick_limit < 0:
+            raise ValueError("false_tick_limit must be >= 0")
+        if self.min_samples_for_ok < 1:
+            raise ValueError("min_samples_for_ok must be >= 1")
+        if self.lookback_limit < 1:
+            raise ValueError("lookback_limit must be >= 1")
+        if self.stale_grace_seconds <= 0:
+            raise ValueError("stale_grace_seconds must be positive")
+        if self.min_false_tick_reversion_pct < 0:
+            raise ValueError("min_false_tick_reversion_pct must be >= 0")
+
+
+@dataclass(slots=True)
+class FeedAnomalyReport:
+    """Summary of detected anomalies for a symbol."""
+
+    symbol: str
+    generated_at: datetime
+    status: FeedHealthStatus
+    sample_count: int
+    lookback_seconds: float | None
+    median_interval_seconds: float | None
+    max_gap_seconds: float | None
+    stale: bool
+    gaps: tuple[FeedGap, ...] = ()
+    false_ticks: tuple[FalseTick, ...] = ()
+    issues: tuple[str, ...] = ()
+    metadata: Mapping[str, object] = field(default_factory=dict)
+
+    def as_dict(self) -> dict[str, object]:
+        return {
+            "symbol": self.symbol,
+            "generated_at": self.generated_at.astimezone(UTC).isoformat(),
+            "status": self.status.value,
+            "sample_count": self.sample_count,
+            "lookback_seconds": self.lookback_seconds,
+            "median_interval_seconds": self.median_interval_seconds,
+            "max_gap_seconds": self.max_gap_seconds,
+            "stale": self.stale,
+            "gaps": [gap.as_dict() for gap in self.gaps],
+            "false_ticks": [tick.as_dict() for tick in self.false_ticks],
+            "issues": list(self.issues),
+            "metadata": dict(self.metadata),
+        }
+
+    def to_markdown(self) -> str:
+        lines = [
+            f"**Feed health** — {self.symbol}",
+            f"- Status: {self.status.value}",
+            f"- Generated: {self.generated_at.astimezone(UTC).isoformat()}",
+            f"- Samples: {self.sample_count}",
+        ]
+        if self.median_interval_seconds is not None:
+            lines.append(f"- Median interval: {self.median_interval_seconds:.2f}s")
+        if self.max_gap_seconds is not None:
+            lines.append(f"- Largest gap: {self.max_gap_seconds:.2f}s")
+        if self.stale:
+            lines.append("- ⚠️ Feed is stale")
+        if self.issues:
+            lines.append("\n**Issues:**")
+            for issue in self.issues:
+                lines.append(f"- {issue}")
+        if self.gaps:
+            lines.append("\n**Detected gaps:**")
+            for gap in self.gaps:
+                lines.append(
+                    "- {start} → {end} ({duration:.1f}s, ~{missing} ticks)".format(
+                        start=gap.start.astimezone(UTC).isoformat(),
+                        end=gap.end.astimezone(UTC).isoformat(),
+                        duration=gap.duration_seconds,
+                        missing=gap.estimated_missing_ticks,
+                    )
+                )
+        if self.false_ticks:
+            lines.append("\n**Suspect ticks:**")
+            for tick in self.false_ticks:
+                lines.append(
+                    "- {timestamp} price {price:.4f} dev {dev:.2f}% (prev {prev:.4f})".format(
+                        timestamp=tick.timestamp.astimezone(UTC).isoformat(),
+                        price=tick.price,
+                        dev=tick.deviation_pct,
+                        prev=tick.previous_price,
+                    )
+                )
+        return "\n".join(lines)
+
+
+def _normalise_ticks(ticks: Sequence[Tick] | Iterable[Tick], limit: int) -> list[Tick]:
+    if isinstance(ticks, Sequence):
+        selected = list(ticks)[-limit:]
+    else:
+        selected = list(ticks)
+        if len(selected) > limit:
+            selected = selected[-limit:]
+    return sorted(selected, key=lambda tick: tick.timestamp)
+
+
+def _estimate_median_interval(ticks: Sequence[Tick]) -> float | None:
+    if len(ticks) < 2:
+        return None
+    deltas = [
+        (current.timestamp - previous.timestamp).total_seconds()
+        for previous, current in zip(ticks, ticks[1:])
+    ]
+    deltas = [delta for delta in deltas if delta > 0]
+    if not deltas:
+        return None
+    return float(median(deltas))
+
+
+def _estimate_missing_ticks(delta: float, median_interval: float | None) -> int:
+    if median_interval and median_interval > 0:
+        missing = max(int(round(delta / median_interval)) - 1, 0)
+        return missing
+    return 0
+
+
+def _detect_gaps(
+    ticks: Sequence[Tick],
+    *,
+    config: FeedAnomalyConfig,
+    median_interval: float | None,
+) -> tuple[list[FeedGap], float | None]:
+    largest_gap: float | None = None
+    gaps: list[FeedGap] = []
+    for previous, current in zip(ticks, ticks[1:]):
+        delta = (current.timestamp - previous.timestamp).total_seconds()
+        if delta > config.max_gap_seconds:
+            largest_gap = max(largest_gap or 0.0, delta)
+            gaps.append(
+                FeedGap(
+                    start=previous.timestamp,
+                    end=current.timestamp,
+                    duration_seconds=delta,
+                    estimated_missing_ticks=_estimate_missing_ticks(delta, median_interval),
+                )
+            )
+    return gaps, largest_gap
+
+
+def _detect_false_ticks(
+    ticks: Sequence[Tick],
+    *,
+    config: FeedAnomalyConfig,
+) -> list[FalseTick]:
+    suspects: list[FalseTick] = []
+    for index in range(1, len(ticks)):
+        previous = ticks[index - 1]
+        current = ticks[index]
+        if previous.price <= 0 or current.price <= 0:
+            continue
+        change = abs(current.price - previous.price)
+        deviation_pct = (change / previous.price) * 100
+        if deviation_pct < config.price_jump_pct:
+            continue
+        reverted = False
+        if index + 1 < len(ticks):
+            next_tick = ticks[index + 1]
+            if previous.price > 0:
+                reversion_pct = abs(next_tick.price - previous.price) / previous.price * 100
+                if reversion_pct <= config.min_false_tick_reversion_pct:
+                    reverted = True
+        if reverted:
+            suspects.append(
+                FalseTick(
+                    timestamp=current.timestamp,
+                    price=current.price,
+                    previous_price=previous.price,
+                    deviation_pct=round(deviation_pct, 4),
+                    volume=current.volume,
+                )
+            )
+    return suspects
+
+
+def analyse_feed(
+    symbol: str,
+    ticks: Sequence[Tick] | Iterable[Tick],
+    *,
+    config: FeedAnomalyConfig | None = None,
+    now: datetime | None = None,
+) -> FeedAnomalyReport:
+    """Analyse tick history and surface feed anomalies."""
+
+    resolved_config = config or FeedAnomalyConfig()
+    sample_ticks = _normalise_ticks(ticks, resolved_config.lookback_limit)
+    generated_at = now or datetime.now(tz=UTC)
+    status = FeedHealthStatus.ok
+    issues: list[str] = []
+
+    if not sample_ticks:
+        issues.append("No ticks available for analysis")
+        return FeedAnomalyReport(
+            symbol=symbol,
+            generated_at=generated_at,
+            status=FeedHealthStatus.fail,
+            sample_count=0,
+            lookback_seconds=None,
+            median_interval_seconds=None,
+            max_gap_seconds=None,
+            stale=True,
+            issues=tuple(issues),
+        )
+
+    median_interval = _estimate_median_interval(sample_ticks)
+    lookback_seconds = (
+        sample_ticks[-1].timestamp - sample_ticks[0].timestamp
+    ).total_seconds() if len(sample_ticks) > 1 else None
+
+    gaps, largest_gap = _detect_gaps(
+        sample_ticks,
+        config=resolved_config,
+        median_interval=median_interval,
+    )
+
+    false_ticks = _detect_false_ticks(sample_ticks, config=resolved_config)
+
+    def _escalate(candidate: FeedHealthStatus) -> None:
+        nonlocal status
+        if status is FeedHealthStatus.fail:
+            return
+        if candidate is FeedHealthStatus.fail:
+            status = FeedHealthStatus.fail
+        elif status is FeedHealthStatus.ok and candidate is FeedHealthStatus.warn:
+            status = FeedHealthStatus.warn
+
+    if len(sample_ticks) < resolved_config.min_samples_for_ok:
+        issues.append(
+            f"Only {len(sample_ticks)} ticks available (< {resolved_config.min_samples_for_ok})"
+        )
+        _escalate(FeedHealthStatus.warn)
+
+    if gaps:
+        gap_issue = f"Detected {len(gaps)} feed gaps"
+        if largest_gap:
+            gap_issue += f"; largest {largest_gap:.1f}s"
+        issues.append(gap_issue)
+        if largest_gap and largest_gap > resolved_config.max_gap_seconds * resolved_config.fail_gap_multiplier:
+            _escalate(FeedHealthStatus.fail)
+        else:
+            _escalate(FeedHealthStatus.warn)
+
+    if false_ticks:
+        issues.append(f"Detected {len(false_ticks)} suspect ticks")
+        if len(false_ticks) > resolved_config.false_tick_limit:
+            _escalate(FeedHealthStatus.fail)
+        else:
+            _escalate(FeedHealthStatus.warn)
+
+    last_tick = sample_ticks[-1]
+    stale_delta = (generated_at - last_tick.timestamp).total_seconds()
+    stale = stale_delta > resolved_config.stale_grace_seconds
+    if stale:
+        issues.append(
+            f"Feed stale by {stale_delta:.1f}s (grace {resolved_config.stale_grace_seconds:.1f}s)"
+        )
+        _escalate(FeedHealthStatus.fail)
+
+    metadata: dict[str, object] = {}
+    if median_interval is not None:
+        metadata["median_interval_seconds"] = median_interval
+    metadata["stale_delta_seconds"] = stale_delta
+
+    return FeedAnomalyReport(
+        symbol=symbol,
+        generated_at=generated_at,
+        status=status,
+        sample_count=len(sample_ticks),
+        lookback_seconds=lookback_seconds,
+        median_interval_seconds=median_interval,
+        max_gap_seconds=largest_gap,
+        stale=stale,
+        gaps=tuple(gaps),
+        false_ticks=tuple(false_ticks),
+        issues=tuple(issues),
+        metadata=metadata,
+    )
+

--- a/src/operations/__init__.py
+++ b/src/operations/__init__.py
@@ -88,6 +88,13 @@ from .event_bus_health import (
     format_event_bus_markdown,
     publish_event_bus_health,
 )
+from .feed_health import (
+    FeedAnomalyConfig,
+    FeedAnomalyReport,
+    FeedHealthStatus,
+    evaluate_feed_health,
+    publish_feed_health,
+)
 from .kafka_readiness import (
     KafkaReadinessComponent,
     KafkaReadinessSnapshot,
@@ -245,6 +252,11 @@ __all__ = [
     "evaluate_event_bus_health",
     "format_event_bus_markdown",
     "publish_event_bus_health",
+    "FeedAnomalyConfig",
+    "FeedAnomalyReport",
+    "FeedHealthStatus",
+    "evaluate_feed_health",
+    "publish_feed_health",
     "KafkaReadinessComponent",
     "KafkaReadinessSnapshot",
     "KafkaReadinessStatus",

--- a/src/operations/feed_health.py
+++ b/src/operations/feed_health.py
@@ -1,0 +1,50 @@
+"""Operational helpers for data feed anomaly detection."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Iterable, Sequence
+
+from src.core.event_bus import Event, EventBus, get_global_bus
+from src.data_foundation.monitoring.feed_anomaly import (
+    FeedAnomalyConfig,
+    FeedAnomalyReport,
+    FeedHealthStatus,
+    Tick,
+    analyse_feed,
+)
+
+__all__ = [
+    "FeedAnomalyConfig",
+    "FeedAnomalyReport",
+    "FeedHealthStatus",
+    "Tick",
+    "evaluate_feed_health",
+    "publish_feed_health",
+]
+
+
+def evaluate_feed_health(
+    symbol: str,
+    ticks: Sequence[Tick] | Iterable[Tick],
+    *,
+    config: FeedAnomalyConfig | None = None,
+    now: datetime | None = None,
+) -> FeedAnomalyReport:
+    """Run the feed anomaly detector for operational reporting."""
+
+    return analyse_feed(symbol, ticks, config=config, now=now)
+
+
+def publish_feed_health(
+    report: FeedAnomalyReport,
+    bus: EventBus | None = None,
+) -> int | None:
+    """Publish feed health telemetry to the event bus."""
+
+    resolved_bus = bus or get_global_bus()
+    event = Event("telemetry.data_feed.health", report.as_dict())
+    if hasattr(resolved_bus, "publish_from_sync"):
+        return resolved_bus.publish_from_sync(event)
+    return resolved_bus.publish(event)
+

--- a/tests/data_foundation/test_feed_anomaly.py
+++ b/tests/data_foundation/test_feed_anomaly.py
@@ -1,0 +1,75 @@
+from datetime import UTC, datetime, timedelta
+
+from src.data_foundation.monitoring.feed_anomaly import (
+    FeedAnomalyConfig,
+    FeedHealthStatus,
+    Tick,
+    analyse_feed,
+)
+
+
+def _ticks(
+    start: datetime,
+    count: int,
+    *,
+    interval_seconds: int = 60,
+    price: float = 100.0,
+) -> list[Tick]:
+    return [
+        Tick(timestamp=start + timedelta(seconds=interval_seconds * index), price=price + index)
+        for index in range(count)
+    ]
+
+
+def test_analyse_feed_returns_ok_when_no_anomalies() -> None:
+    start = datetime(2024, 1, 1, tzinfo=UTC)
+    ticks = _ticks(start, 10)
+
+    report = analyse_feed("EURUSD", ticks, now=start + timedelta(minutes=9))
+
+    assert report.status is FeedHealthStatus.ok
+    assert report.gaps == ()
+    assert report.false_ticks == ()
+    assert report.sample_count == 10
+    assert not report.stale
+
+
+def test_analyse_feed_flags_large_gap() -> None:
+    start = datetime(2024, 1, 1, tzinfo=UTC)
+    ticks = _ticks(start, 5)
+    ticks.append(Tick(timestamp=start + timedelta(minutes=20), price=150.0))
+
+    config = FeedAnomalyConfig(max_gap_seconds=120, fail_gap_multiplier=20)
+    report = analyse_feed("EURUSD", ticks, config=config, now=start + timedelta(minutes=21))
+
+    assert report.gaps
+    assert report.status is FeedHealthStatus.warn
+    assert report.max_gap_seconds and report.max_gap_seconds > 600
+    assert any("feed gaps" in issue for issue in report.issues)
+
+
+def test_analyse_feed_flags_false_tick_reversion() -> None:
+    start = datetime(2024, 1, 1, tzinfo=UTC)
+    ticks = _ticks(start, 5)
+    # Insert false spike that reverts on the next tick.
+    ticks.insert(3, Tick(timestamp=start + timedelta(minutes=3, seconds=30), price=200.0, volume=0.0))
+    config = FeedAnomalyConfig(price_jump_pct=20.0, min_samples_for_ok=3)
+
+    report = analyse_feed("EURUSD", ticks, config=config, now=start + timedelta(minutes=5))
+
+    assert report.false_ticks
+    assert report.status is FeedHealthStatus.warn
+    assert any("suspect ticks" in issue for issue in report.issues)
+
+
+def test_analyse_feed_marks_stale_as_failure() -> None:
+    start = datetime(2024, 1, 1, tzinfo=UTC)
+    ticks = _ticks(start, 6)
+
+    config = FeedAnomalyConfig(stale_grace_seconds=60)
+    report = analyse_feed("EURUSD", ticks, config=config, now=start + timedelta(minutes=15))
+
+    assert report.stale
+    assert report.status is FeedHealthStatus.fail
+    assert any("stale" in issue for issue in report.issues)
+

--- a/tests/operations/test_feed_health.py
+++ b/tests/operations/test_feed_health.py
@@ -1,0 +1,41 @@
+from datetime import UTC, datetime, timedelta
+
+from src.core.event_bus import Event
+from src.data_foundation.monitoring.feed_anomaly import Tick
+from src.operations.feed_health import evaluate_feed_health, publish_feed_health
+
+
+def _ticks() -> list[Tick]:
+    start = datetime(2024, 1, 1, tzinfo=UTC)
+    return [
+        Tick(timestamp=start + timedelta(minutes=index), price=100.0 + index)
+        for index in range(6)
+    ]
+
+
+def test_evaluate_feed_health_passes_through_report() -> None:
+    report = evaluate_feed_health("EURUSD", _ticks(), now=datetime(2024, 1, 1, 0, 10, tzinfo=UTC))
+
+    assert report.symbol == "EURUSD"
+    assert report.sample_count == 6
+
+
+def test_publish_feed_health_uses_event_bus() -> None:
+    report = evaluate_feed_health("EURUSD", _ticks(), now=datetime(2024, 1, 1, 0, 10, tzinfo=UTC))
+
+    class _StubBus:
+        def __init__(self) -> None:
+            self.events: list[Event] = []
+
+        def publish_from_sync(self, event: Event) -> int:  # pragma: no cover - trivial
+            self.events.append(event)
+            return 1
+
+    bus = _StubBus()
+    publish_feed_health(report, bus)
+
+    assert bus.events
+    event = bus.events[0]
+    assert event.type == "telemetry.data_feed.health"
+    assert event.payload["symbol"] == "EURUSD"
+


### PR DESCRIPTION
## Summary
- add a reusable data feed anomaly detector to flag gaps and false ticks for roadmap phase 3 workstream 3A
- expose operational helpers that publish feed health telemetry on the event bus
- document roadmap completion status and cover the new functionality with targeted unit tests

## Testing
- pytest tests/data_foundation/test_feed_anomaly.py tests/operations/test_feed_health.py

------
https://chatgpt.com/codex/tasks/task_e_68da2b3f1400832c8059d64a1e70d3f6