### PR TITLE
Add roadmap document task extraction utility

### DIFF
--- a/tests/tools/test_roadmap_doc_tasks.py
+++ b/tests/tools/test_roadmap_doc_tasks.py
@@ -1,0 +1,97 @@
+"""Tests for the roadmap document task extraction helpers."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+import tools.roadmap.doc_tasks as doc_tasks
+
+
+@pytest.fixture()
+def sample_doc(tmp_path: Path) -> Path:
+    content = """# High-impact roadmap
+
+Intro text that should be ignored.
+
+```bash
+- [ ] not-a-real-task
+```
+
+## Phase 1 — Trading Core
+
+- [x] Finish execution lifecycle polish
+- [ ] Harden nightly reconciliation pipeline
+
+### Workstream 1B
+
+    - [ ] Add remaining VaR guardrails
+
+## Phase 2 — Strategy Expansion
+
+- [ ] Extend adaptive intelligence backlog
+"""
+    path = tmp_path / "sample.md"
+    path.write_text(content, encoding="utf-8")
+    return path
+
+
+def test_extract_document_tasks_parses_sections(sample_doc: Path) -> None:
+    tasks = doc_tasks.extract_document_tasks(sample_doc)
+
+    assert len(tasks) == 4
+
+    assert tasks[0].description == "Finish execution lifecycle polish"
+    assert tasks[0].checked is True
+    assert tasks[0].section == ("High-impact roadmap", "Phase 1 — Trading Core")
+
+    assert tasks[1].description == "Harden nightly reconciliation pipeline"
+    assert tasks[1].checked is False
+    assert tasks[1].section == ("High-impact roadmap", "Phase 1 — Trading Core")
+
+    assert tasks[2].description == "Add remaining VaR guardrails"
+    assert tasks[2].indent > tasks[1].indent
+    assert tasks[2].section == (
+        "High-impact roadmap",
+        "Phase 1 — Trading Core",
+        "Workstream 1B",
+    )
+
+    assert tasks[3].section == (
+        "High-impact roadmap",
+        "Phase 2 — Strategy Expansion",
+    )
+
+
+def test_summarise_document_counts_completed_and_remaining(sample_doc: Path) -> None:
+    summary = doc_tasks.summarise_document(sample_doc)
+
+    assert summary.total == 4
+    assert summary.completed == 1
+    assert summary.remaining == 3
+    assert len(summary.remaining_tasks()) == 3
+    assert len(summary.completed_tasks()) == 1
+
+
+def test_format_markdown_includes_remaining_and_completed(sample_doc: Path) -> None:
+    summary = doc_tasks.summarise_document(sample_doc)
+    report = doc_tasks.format_markdown(summary, include_completed=True)
+
+    assert report.startswith("# Roadmap tasks for sample.md")
+    assert "- Total tasks: 4" in report
+    assert "- [ ] High-impact roadmap › Phase 2 — Strategy Expansion — Extend adaptive intelligence backlog" in report
+    assert "## Completed tasks" in report
+    assert "- [x] High-impact roadmap › Phase 1 — Trading Core — Finish execution lifecycle polish" in report
+
+
+def test_format_json_includes_remaining_tasks(sample_doc: Path) -> None:
+    summary = doc_tasks.summarise_document(sample_doc)
+    payload = doc_tasks.format_json(summary, include_completed=True)
+
+    data = json.loads(payload)
+    assert data["total"] == 4
+    assert len(data["remaining_tasks"]) == 3
+    assert len(data["completed_tasks"]) == 1
+

--- a/tools/roadmap/__init__.py
+++ b/tools/roadmap/__init__.py
@@ -11,6 +11,7 @@ if TYPE_CHECKING:  # pragma: no cover - import-time conveniences for type checke
         evaluate_portfolio_snapshot,
         main as snapshot_main,
     )
+    from . import doc_tasks as doc_tasks
 
 __all__ = [
     "InitiativeStatus",
@@ -19,6 +20,7 @@ __all__ = [
     "evaluate_streams",
     "snapshot_main",
     "high_impact_main",
+    "doc_tasks",
     "main",
 ]
 
@@ -38,6 +40,7 @@ def __getattr__(name: str) -> Any:
         "StreamStatus": ("tools.roadmap.high_impact", "StreamStatus"),
         "evaluate_streams": ("tools.roadmap.high_impact", "evaluate_streams"),
         "high_impact_main": ("tools.roadmap.high_impact", "main"),
+        "doc_tasks": ("tools.roadmap.doc_tasks", None),
         "main": ("tools.roadmap.snapshot", "main"),
     }
 
@@ -45,13 +48,17 @@ def __getattr__(name: str) -> Any:
     if target is None:
         raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
-    module = import_module(target[0])
-    attribute = getattr(module, target[1])
+    module_name, attribute_name = target
+    module = import_module(module_name)
+    attribute = module if attribute_name is None else getattr(module, attribute_name)
 
     # Cache the resolved attribute to avoid repeated imports.
     globals()[name] = attribute
 
     # Keep the alias between ``main`` and ``snapshot_main`` in sync.
+    if attribute_name is None:
+        return attribute
+
     if name == "main" and "snapshot_main" not in globals():
         globals()["snapshot_main"] = attribute
     elif name == "snapshot_main" and "main" not in globals():

--- a/tools/roadmap/doc_tasks.py
+++ b/tools/roadmap/doc_tasks.py
@@ -1,0 +1,253 @@
+"""Extract checklist tasks from the High-impact roadmap documents."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Sequence
+
+from ._shared import repo_root
+
+
+_CHECKBOX_PATTERN = re.compile(
+    r"^(?P<indent>\s*)[-*]\s*\[(?P<mark>[ xX])\]\s+(?P<body>.+?)\s*$"
+)
+
+
+@dataclass(frozen=True)
+class RoadmapTask:
+    """Representation of a single checklist entry in the roadmap document."""
+
+    description: str
+    checked: bool
+    line_number: int
+    indent: int
+    section: tuple[str, ...]
+
+    def as_dict(self) -> dict[str, object]:
+        """Return a JSON-serialisable payload for the task."""
+
+        return {
+            "description": self.description,
+            "checked": self.checked,
+            "line": self.line_number,
+            "indent": self.indent,
+            "section": list(self.section),
+        }
+
+
+@dataclass(frozen=True)
+class RoadmapSummary:
+    """Aggregated view across all roadmap tasks in a document."""
+
+    document: Path
+    tasks: tuple[RoadmapTask, ...]
+    total: int
+    completed: int
+    remaining: int
+
+    @classmethod
+    def from_tasks(cls, document: Path, tasks: Sequence[RoadmapTask]) -> "RoadmapSummary":
+        """Create a summary from the parsed tasks."""
+
+        task_tuple = tuple(tasks)
+        completed = sum(1 for task in task_tuple if task.checked)
+        total = len(task_tuple)
+        remaining = total - completed
+        return cls(
+            document=document,
+            tasks=task_tuple,
+            total=total,
+            completed=completed,
+            remaining=remaining,
+        )
+
+    def remaining_tasks(self) -> tuple[RoadmapTask, ...]:
+        """Return the outstanding roadmap tasks."""
+
+        return tuple(task for task in self.tasks if not task.checked)
+
+    def completed_tasks(self) -> tuple[RoadmapTask, ...]:
+        """Return the completed roadmap tasks."""
+
+        return tuple(task for task in self.tasks if task.checked)
+
+
+def _read_document(path: Path) -> list[str]:
+    if not path.exists():
+        raise FileNotFoundError(path)
+    return path.read_text(encoding="utf-8").splitlines()
+
+
+def extract_document_tasks(path: Path) -> tuple[RoadmapTask, ...]:
+    """Parse the roadmap document and return all checklist entries."""
+
+    headings: list[str] = []
+    tasks: list[RoadmapTask] = []
+    in_code_block = False
+
+    for line_number, line in enumerate(_read_document(path), start=1):
+        stripped = line.strip()
+
+        if stripped.startswith("```"):
+            in_code_block = not in_code_block
+            continue
+
+        if in_code_block:
+            continue
+
+        if stripped.startswith("#"):
+            level = len(stripped) - len(stripped.lstrip("#"))
+            heading_text = stripped[level:].strip()
+            if heading_text:
+                while len(headings) >= level:
+                    headings.pop()
+                headings.append(heading_text)
+            continue
+
+        match = _CHECKBOX_PATTERN.match(line)
+        if not match:
+            continue
+
+        mark = match.group("mark").lower()
+        description = match.group("body").strip()
+        indent = len(match.group("indent"))
+
+        tasks.append(
+            RoadmapTask(
+                description=description,
+                checked=mark == "x",
+                line_number=line_number,
+                indent=indent,
+                section=tuple(headings),
+            )
+        )
+
+    return tuple(tasks)
+
+
+def summarise_document(path: Path) -> RoadmapSummary:
+    """Return a :class:`RoadmapSummary` for the given roadmap document."""
+
+    tasks = extract_document_tasks(path)
+    return RoadmapSummary.from_tasks(path, tasks)
+
+
+def _format_task_entry(task: RoadmapTask) -> str:
+    context = " › ".join(task.section) if task.section else "Document"
+    status = "[x]" if task.checked else "[ ]"
+    return f"- {status} {context} — {task.description} (line {task.line_number})"
+
+
+def format_markdown(summary: RoadmapSummary, *, include_completed: bool = False) -> str:
+    """Render the roadmap task summary as Markdown."""
+
+    lines = [
+        f"# Roadmap tasks for {summary.document.name}",
+        "",
+        f"- Total tasks: {summary.total}",
+        f"- Completed: {summary.completed}",
+        f"- Remaining: {summary.remaining}",
+        "",
+        "## Remaining tasks",
+    ]
+
+    remaining_tasks = summary.remaining_tasks()
+    if remaining_tasks:
+        lines.extend(_format_task_entry(task) for task in remaining_tasks)
+    else:
+        lines.append("- [x] None (all tasks complete)")
+
+    if include_completed:
+        lines.append("")
+        lines.append("## Completed tasks")
+        completed_tasks = summary.completed_tasks()
+        if completed_tasks:
+            lines.extend(_format_task_entry(task) for task in completed_tasks)
+        else:
+            lines.append("- [ ] None yet")
+
+    return "\n".join(lines)
+
+
+def format_json(summary: RoadmapSummary, *, include_completed: bool = False) -> str:
+    """Render the roadmap task summary as JSON."""
+
+    payload: dict[str, object] = {
+        "document": str(summary.document),
+        "total": summary.total,
+        "completed": summary.completed,
+        "remaining": summary.remaining,
+        "remaining_tasks": [task.as_dict() for task in summary.remaining_tasks()],
+    }
+
+    if include_completed:
+        payload["completed_tasks"] = [
+            task.as_dict() for task in summary.completed_tasks()
+        ]
+
+    return json.dumps(payload, indent=2)
+
+
+def _default_document() -> Path:
+    return repo_root() / "docs/High-Impact Development Roadmap.md"
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """CLI entry point for roadmap document task extraction."""
+
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--document",
+        type=Path,
+        default=_default_document(),
+        help="Path to the roadmap markdown document",
+    )
+    parser.add_argument(
+        "--format",
+        choices=("markdown", "json"),
+        default="markdown",
+        help="Output format (default: markdown)",
+    )
+    parser.add_argument(
+        "--include-completed",
+        action="store_true",
+        help="Include completed tasks in the report",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        help="Optional file path to write the report to",
+    )
+    args = parser.parse_args(argv)
+
+    summary = summarise_document(args.document)
+
+    if args.format == "json":
+        output = format_json(summary, include_completed=args.include_completed)
+    else:
+        output = format_markdown(summary, include_completed=args.include_completed)
+
+    if args.output:
+        if not output.endswith("\n"):
+            output = f"{output}\n"
+        args.output.write_text(output, encoding="utf-8")
+    else:
+        print(output)
+
+    return 0
+
+
+__all__ = [
+    "RoadmapTask",
+    "RoadmapSummary",
+    "extract_document_tasks",
+    "summarise_document",
+    "format_markdown",
+    "format_json",
+    "main",
+]
+


### PR DESCRIPTION
## Summary
- add a `tools.roadmap.doc_tasks` helper to parse the High-Impact Development Roadmap checklists and build Markdown/JSON reports
- expose the helper through the roadmap package for CLI usage
- cover the parser and formatters with targeted unit tests

## Testing
- `pytest tests/tools/test_roadmap_doc_tasks.py`
- `pytest tests/tools/test_high_impact_roadmap.py`


------
https://chatgpt.com/codex/tasks/task_e_68da2b3f1400832c8059d64a1e70d3f6