### PR TITLE
Prevent partial high-impact doc refresh

### DIFF
--- a/docs/status/high_impact_roadmap.md
+++ b/docs/status/high_impact_roadmap.md
@@ -69,6 +69,10 @@ shot, use the refresh flag:
 python -m tools.roadmap.high_impact --refresh-docs
 ```
 
+> **Note:** Refreshing documentation always evaluates the full portfolio. The
+> CLI rejects attempts to combine `--refresh-docs` with stream filters so the
+> published status pages cannot accidentally omit streams.
+
 When writing to alternate locations (for example in CI workspaces), provide
 explicit paths for the summary and detail files:
 

--- a/tests/tools/test_high_impact_roadmap.py
+++ b/tests/tools/test_high_impact_roadmap.py
@@ -442,6 +442,24 @@ def test_cli_refresh_docs_accepts_custom_paths(
     assert attention_payload["portfolio"]["attention_needed"] == 0
 
 
+def test_cli_rejects_stream_filter_when_refreshing_docs(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    with pytest.raises(SystemExit) as excinfo:
+        high_impact.main(
+            [
+                "--refresh-docs",
+                "--stream",
+                "Stream A – Institutional data backbone",
+            ]
+        )
+
+    assert excinfo.value.code == 2
+    out, err = capsys.readouterr()
+    assert not out
+    assert "cannot be combined" in err
+
+
 def test_refresh_docs_updates_summary_and_detail(tmp_path: Path) -> None:
     summary = tmp_path / "summary.md"
     detail = tmp_path / "detail.md"

--- a/tools/roadmap/high_impact.py
+++ b/tools/roadmap/high_impact.py
@@ -809,6 +809,12 @@ def main(argv: Sequence[str] | None = None) -> int:
     )
     args = parser.parse_args(argv)
 
+    if args.refresh_docs and args.streams:
+        parser.error(
+            "--refresh-docs cannot be combined with --stream; refresh the full "
+            "portfolio instead"
+        )
+
     try:
         statuses = tuple(evaluate_streams(args.streams))
     except ValueError as exc:


### PR DESCRIPTION
## Summary
- prevent mixing `--refresh-docs` and `--stream` in the high-impact roadmap CLI to keep docs comprehensive
- document the restriction so operators know the CLI enforces full portfolio refreshes
- add regression coverage ensuring the CLI exits with an error when the guard is violated

## Testing
- pytest tests/tools/test_high_impact_roadmap.py


------
https://chatgpt.com/codex/tasks/task_e_68da306755a0832c9431b0e8fea6147e