### PR TITLE
Add JSON progress export to high-impact roadmap CLI

### DIFF
--- a/docs/status/high_impact_roadmap.md
+++ b/docs/status/high_impact_roadmap.md
@@ -37,6 +37,13 @@ upcoming checkpoints, emit the progress report:
 python -m tools.roadmap.high_impact --format progress
 ```
 
+When dashboards require the same roll-up as structured data, emit the JSON
+variant:
+
+```bash
+python -m tools.roadmap.high_impact --format progress-json
+```
+
 For dashboards that only need aggregate counts, export the portfolio JSON view:
 
 ```bash


### PR DESCRIPTION
## Summary
- add a JSON export that mirrors the progress narrative in the high-impact roadmap helper
- extend the CLI to accept the new format and document it in the status guide
- cover the format with new unit tests alongside existing CLI checks

## Testing
- pytest tests/tools/test_high_impact_roadmap.py

------
https://chatgpt.com/codex/tasks/task_e_68da7e52de90832c9f01d1279176cb08