### PR TITLE
Add ICT-style microstructure analysis for order flow

### DIFF
--- a/docs/High-Impact Development Roadmap.md
+++ b/docs/High-Impact Development Roadmap.md
@@ -207,7 +207,7 @@ To reflect the true scope of institutional-grade trading components, the roadmap
 
 - [x] Multi-source aggregation (Yahoo, Alpha Vantage, FRED) with data-quality validators via `src/data_foundation/ingest/multi_source.py`.
 - [x] Introduce streaming ingestion adapters with latency benchmarks.
-- [ ] Incorporate selected ICT-style sensors (fair value gaps, liquidity sweeps) once validated by strategies.
+- [x] Incorporate selected ICT-style sensors (fair value gaps, liquidity sweeps) once validated by strategies (`MarketMicrostructureAnalyzer`).
 - [x] Build anomaly detection for data feed breaks and false ticks.
 - [x] Update documentation on data lineage and quality SLA (`docs/deployment/data_lineage.md`).
 - [ ] Implement encyclopedia-aligned "Market Microstructure Observatory" notebooks showcasing liquidity/volume profiling studies.

--- a/src/sensory/organs/dimensions/order_flow.py
+++ b/src/sensory/organs/dimensions/order_flow.py
@@ -1,18 +1,165 @@
 from __future__ import annotations
 
+from dataclasses import dataclass
+from typing import Any, Iterable
+
+import pandas as pd
+
+
+_REQUIRED_COLUMNS = ("high", "low", "close")
+
+
+def _coerce_dataframe(data: object) -> pd.DataFrame:
+    """Return a sanitized DataFrame with the expected OHLC columns."""
+
+    if isinstance(data, pd.DataFrame):
+        frame = data.copy()
+    elif isinstance(data, Iterable):
+        frame = pd.DataFrame(data)
+    else:  # pragma: no cover - defensive guardrail
+        raise TypeError("Order flow analysis expects a DataFrame or iterable input")
+
+    missing = [column for column in _REQUIRED_COLUMNS if column not in frame.columns]
+    if missing:
+        raise ValueError(f"Missing required columns for order flow analysis: {missing}")
+
+    if "timestamp" in frame.columns:
+        frame = frame.sort_values("timestamp")
+    frame = frame.reset_index(drop=True)
+
+    numeric_columns = [column for column in ["open", "high", "low", "close", "volume"] if column in frame.columns]
+    for column in numeric_columns:
+        frame[column] = pd.to_numeric(frame[column], errors="coerce")
+
+    return frame
+
+
+@dataclass(frozen=True)
+class _MicrostructureResult:
+    microstructure_score: float
+    bullish_fvg: int
+    bearish_fvg: int
+    average_gap_size: float
+    buy_sweeps: int
+    sell_sweeps: int
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "microstructure_score": float(self.microstructure_score),
+            "fair_value_gaps": {
+                "bullish_count": int(self.bullish_fvg),
+                "bearish_count": int(self.bearish_fvg),
+                "average_gap_size": float(self.average_gap_size),
+            },
+            "liquidity_sweeps": {
+                "buy_side": int(self.buy_sweeps),
+                "sell_side": int(self.sell_sweeps),
+            },
+        }
+
 
 class MarketMicrostructureAnalyzer:
-    def analyze_microstructure(self, df: object) -> dict[str, float]:
-        """Analyze market microstructure signals (typed no-op)."""
-        return {"microstructure_score": 0.0}
+    """Detect ICT-style market microstructure patterns from OHLC data."""
+
+    def __init__(self, *, minimum_candles: int = 3) -> None:
+        self._minimum_candles = max(minimum_candles, 3)
+
+    # ------------------------------------------------------------------
+    def analyze_microstructure(self, df: object) -> dict[str, Any]:
+        """Surface fair value gaps and liquidity sweeps from price history."""
+
+        frame = _coerce_dataframe(df)
+        if len(frame) < self._minimum_candles:
+            return _MicrostructureResult(0.0, 0, 0, 0.0, 0, 0).as_dict()
+
+        bullish_gaps: list[float] = []
+        bearish_gaps: list[float] = []
+        buy_sweeps = 0
+        sell_sweeps = 0
+
+        highs = frame["high"].tolist()
+        lows = frame["low"].tolist()
+        closes = frame["close"].tolist()
+
+        for idx in range(2, len(frame)):
+            current_low = lows[idx]
+            current_high = highs[idx]
+            prior_high = highs[idx - 2]
+            prior_low = lows[idx - 2]
+
+            if pd.notna(current_low) and pd.notna(prior_high) and float(current_low) > float(prior_high):
+                bullish_gaps.append(float(current_low) - float(prior_high))
+
+            if pd.notna(current_high) and pd.notna(prior_low) and float(current_high) < float(prior_low):
+                bearish_gaps.append(float(prior_low) - float(current_high))
+
+        for idx in range(1, len(frame)):
+            if pd.notna(highs[idx]) and pd.notna(highs[idx - 1]) and pd.notna(closes[idx]) and pd.notna(closes[idx - 1]):
+                if float(highs[idx]) > float(highs[idx - 1]) and float(closes[idx]) < float(closes[idx - 1]):
+                    buy_sweeps += 1
+
+            if pd.notna(lows[idx]) and pd.notna(lows[idx - 1]) and pd.notna(closes[idx]) and pd.notna(closes[idx - 1]):
+                if float(lows[idx]) < float(lows[idx - 1]) and float(closes[idx]) > float(closes[idx - 1]):
+                    sell_sweeps += 1
+
+        total_events = len(bullish_gaps) + len(bearish_gaps) + buy_sweeps + sell_sweeps
+        if total_events == 0:
+            score = 0.0
+        else:
+            directional = (len(bullish_gaps) + buy_sweeps) - (len(bearish_gaps) + sell_sweeps)
+            score = directional / float(total_events)
+
+        all_gaps = bullish_gaps + bearish_gaps
+        average_gap = sum(all_gaps) / len(all_gaps) if all_gaps else 0.0
+
+        return _MicrostructureResult(score, len(bullish_gaps), len(bearish_gaps), average_gap, buy_sweeps, sell_sweeps).as_dict()
 
 
 class OrderFlowAnalyzer:
-    def analyze_institutional_flow(self, df: object) -> dict[str, object]:
-        """Analyze institutional order flow (typed no-op)."""
+    """Aggregate institutional order flow bias from microstructure signals."""
+
+    def __init__(self, *, microstructure: MarketMicrostructureAnalyzer | None = None) -> None:
+        self._microstructure = microstructure or MarketMicrostructureAnalyzer()
+
+    # ------------------------------------------------------------------
+    def analyze_institutional_flow(self, df: object) -> dict[str, Any]:
+        """Summarise directional liquidity sweeps and fair value gap bias."""
+
+        frame = _coerce_dataframe(df)
+        if len(frame) < 2:
+            return {
+                "flow_strength": 0.0,
+                "institutional_pressure": {"buying_pressure": 0.0, "selling_pressure": 0.0},
+                "microstructure": _MicrostructureResult(0.0, 0, 0, 0.0, 0, 0).as_dict(),
+            }
+
+        microstructure = self._microstructure.analyze_microstructure(frame)
+        sweeps = microstructure.get("liquidity_sweeps", {})
+        fvg = microstructure.get("fair_value_gaps", {})
+
+        buy_sweeps = int(sweeps.get("buy_side", 0))
+        sell_sweeps = int(sweeps.get("sell_side", 0))
+        total_sweeps = buy_sweeps + sell_sweeps
+
+        bullish_fvg = int(fvg.get("bullish_count", 0))
+        bearish_fvg = int(fvg.get("bearish_count", 0))
+        total_gaps = bullish_fvg + bearish_fvg
+
+        sweep_bias = (buy_sweeps - sell_sweeps) / float(total_sweeps) if total_sweeps else 0.0
+        gap_bias = (bullish_fvg - bearish_fvg) / float(total_gaps) if total_gaps else 0.0
+
+        flow_bias = 0.5 * sweep_bias + 0.5 * gap_bias
+        flow_strength = abs(flow_bias)
+
+        institutional_pressure = {
+            "buying_pressure": float(max(flow_bias, 0.0)),
+            "selling_pressure": float(max(-flow_bias, 0.0)),
+        }
+
         return {
-            "flow_strength": 0.0,
-            "institutional_pressure": {"buying_pressure": 0.0, "selling_pressure": 0.0},
+            "flow_strength": float(flow_strength),
+            "institutional_pressure": institutional_pressure,
+            "microstructure": microstructure,
         }
 
 

--- a/tests/sensory/test_order_flow_microstructure.py
+++ b/tests/sensory/test_order_flow_microstructure.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+
+from src.sensory.organs.dimensions.order_flow import (
+    MarketMicrostructureAnalyzer,
+    OrderFlowAnalyzer,
+)
+
+
+def _balanced_fixture() -> pd.DataFrame:
+    timestamps = pd.date_range("2024-01-01", periods=6, freq="h")
+    return pd.DataFrame(
+        {
+            "timestamp": timestamps,
+            "open": [100, 101, 102, 103, 100, 100],
+            "high": [101, 103, 105, 107, 105, 99],
+            "low": [99, 100, 102, 100, 98, 95],
+            "close": [100, 102, 103, 101, 104, 96],
+            "volume": [10_000, 11_000, 12_000, 11_500, 12_500, 12_200],
+        }
+    )
+
+
+def _bullish_bias_fixture() -> pd.DataFrame:
+    timestamps = pd.date_range("2024-02-01", periods=6, freq="h")
+    return pd.DataFrame(
+        {
+            "timestamp": timestamps,
+            "open": [100, 101, 105, 108, 113, 117],
+            "high": [101, 105, 109, 113, 118, 122],
+            "low": [99, 99, 102, 101, 111, 107],
+            "close": [100, 101, 108, 104, 112, 108],
+            "volume": [9000, 9400, 9800, 9700, 9600, 9500],
+        }
+    )
+
+
+def test_microstructure_detects_fvg_and_liquidity_sweeps() -> None:
+    frame = _balanced_fixture()
+    analyzer = MarketMicrostructureAnalyzer()
+
+    result = analyzer.analyze_microstructure(frame)
+
+    fvg = result["fair_value_gaps"]
+    sweeps = result["liquidity_sweeps"]
+
+    assert fvg["bullish_count"] == 1
+    assert fvg["bearish_count"] == 1
+    assert sweeps["buy_side"] == 1
+    assert sweeps["sell_side"] == 1
+    assert fvg["average_gap_size"] == pytest.approx(1.0)
+    assert result["microstructure_score"] == pytest.approx(0.0, abs=1e-9)
+
+
+def test_order_flow_bias_highlights_buy_pressure() -> None:
+    frame = _bullish_bias_fixture()
+    analyzer = OrderFlowAnalyzer()
+
+    result = analyzer.analyze_institutional_flow(frame)
+
+    pressure = result["institutional_pressure"]
+    assert result["flow_strength"] == pytest.approx(1.0)
+    assert pressure["buying_pressure"] == pytest.approx(1.0)
+    assert pressure["selling_pressure"] == pytest.approx(0.0)
+
+    microstructure = result["microstructure"]
+    assert microstructure["fair_value_gaps"]["bullish_count"] == 2
+    assert microstructure["liquidity_sweeps"]["buy_side"] == 2


### PR DESCRIPTION
## Summary
- enhance the order flow microstructure analyzer to detect ICT fair value gaps and liquidity sweeps
- expose aggregate institutional flow bias metrics and document completion in the roadmap
- add regression coverage for the new microstructure calculations

## Testing
- pytest tests/sensory/test_order_flow_microstructure.py

------
https://chatgpt.com/codex/tasks/task_e_68da92bae748832ca747267b184a44e9