### PR TITLE
Add microstructure tiered storage archive support

### DIFF
--- a/docs/High-Impact Development Roadmap.md
+++ b/docs/High-Impact Development Roadmap.md
@@ -212,7 +212,7 @@ To reflect the true scope of institutional-grade trading components, the roadmap
 - [x] Update documentation on data lineage and quality SLA (`docs/deployment/data_lineage.md`).
 - [ ] Implement encyclopedia-aligned "Market Microstructure Observatory" notebooks showcasing liquidity/volume profiling studies.
 - [x] Add market regime classifier blending volatility, liquidity, and sentiment signals for execution model selection.
-- [ ] Archive microstructure datasets in tiered storage (hot/cold) with retention guidance per encyclopedia cost matrix.
+- [x] Archive microstructure datasets in tiered storage (hot/cold) with retention guidance per encyclopedia cost matrix. (`src/data_foundation/storage/tiered_storage.py`, `scripts/archive_microstructure_data.py`, `docs/runbooks/microstructure_storage.md`)
 
 #### Workstream 3B: Monitoring, Alerting & Deployment (~1.5 weeks)
 **Impact:** 🔥🔥 **HIGH** — Moves toward production readiness earlier than previously planned

--- a/docs/runbooks/microstructure_storage.md
+++ b/docs/runbooks/microstructure_storage.md
@@ -1,0 +1,55 @@
+# Microstructure dataset storage runbook
+
+The high-impact roadmap calls for archiving microstructure research datasets in
+tiered storage with clear retention guidance. This runbook documents the EMP
+reference implementation so operators and researchers can keep datasets aligned
+with the encyclopedia’s cost matrix.
+
+## Storage layout
+
+Microstructure datasets are persisted in two tiers beneath the repository root:
+
+| Tier | Path | Purpose | Retention |
+| --- | --- | --- | --- |
+| Hot | `artifacts/microstructure/hot/` | Recent datasets used by day-to-day research and paper-trading calibration. | 7 days by default. |
+| Cold | `artifacts/microstructure/cold/` | Long-term archive that feeds historical validation and compliance audits. | 90 days by default. |
+
+Each archived file sits inside a dataset- and date-partitioned hierarchy,
+`<tier>/<dataset>/<YYYY>/<MM>/<DD>/<filename>`. Metadata is written alongside
+the file as `<filename>.meta.json` so retention and lineage details survive
+transfers between tiers.
+
+## Tooling
+
+The `scripts/archive_microstructure_data.py` CLI automates ingesting new files
+and enforcing retention windows. Example usage:
+
+```bash
+python scripts/archive_microstructure_data.py ict_microstructure data/microstructure --pattern "*.parquet" --enforce-retention
+```
+
+This command:
+
+1. Copies all matching files into the hot tier.
+2. Writes metadata that records the source path, archive timestamp, and
+   retention windows.
+3. Moves expired files from hot to cold storage and deletes cold files that
+   exceed the retention window when `--enforce-retention` is supplied.
+
+`RetentionPolicy.from_days` inside `src/data_foundation/storage/tiered_storage.py`
+exposes stricter or looser retention windows. Update the CLI flags or call the
+library directly from orchestration jobs when professional deployments require
+custom horizons.
+
+## Operational checks
+
+- **Nightly enforcement** – Schedule the CLI with `--enforce-retention` to ensure
+  the hot tier only contains the most recent datasets.
+- **Audit trail** – The metadata JSON includes the original source path and size
+  so compliance can trace lineage during investigations.
+- **Cost management** – Adjust hot/cold retention days to mirror the
+  encyclopedia’s storage cost matrix for different market tiers.
+
+Document updates should accompany any retention changes or path overrides so
+operators always have a current reference.
+

--- a/docs/status/high_impact_roadmap_detail.md
+++ b/docs/status/high_impact_roadmap_detail.md
@@ -24,6 +24,9 @@
 - operations.cross_region_failover.evaluate_cross_region_failover
 - operations.backup.evaluate_backup_readiness
 - operations.spark_stress.execute_spark_stress_drill
+- data_foundation.storage.tiered_storage.MicrostructureTieredArchive
+- scripts/archive_microstructure_data.py
+- docs/runbooks/microstructure_storage.md
 
 ## Stream B – Sensory cortex & evolution uplift
 

--- a/scripts/archive_microstructure_data.py
+++ b/scripts/archive_microstructure_data.py
@@ -1,0 +1,86 @@
+"""CLI for archiving microstructure datasets into tiered storage."""
+
+from __future__ import annotations
+
+import argparse
+from datetime import datetime
+from pathlib import Path
+from typing import Iterable
+
+from src.data_foundation.storage import MicrostructureTieredArchive, RetentionPolicy
+
+
+def _iter_source_files(source: Path, pattern: str) -> Iterable[Path]:
+    if source.is_file():
+        yield source
+        return
+    if not source.exists():
+        raise FileNotFoundError(source)
+    yield from sorted(source.rglob(pattern))
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("dataset", help="Dataset name used to partition the archive")
+    parser.add_argument("source", type=Path, help="Path to a microstructure file or directory")
+    parser.add_argument("--pattern", default="*.parquet", help="Glob pattern when archiving directories")
+    parser.add_argument(
+        "--hot-dir",
+        type=Path,
+        default=Path("artifacts/microstructure/hot"),
+        help="Destination directory for the hot tier",
+    )
+    parser.add_argument(
+        "--cold-dir",
+        type=Path,
+        default=Path("artifacts/microstructure/cold"),
+        help="Destination directory for the cold tier",
+    )
+    parser.add_argument("--hot-days", type=int, default=7, help="Retention window (days) for the hot tier")
+    parser.add_argument("--cold-days", type=int, default=90, help="Retention window (days) for the cold tier")
+    parser.add_argument(
+        "--as-of",
+        default=None,
+        help="Timestamp (ISO 8601) applied to all files; defaults to current UTC time",
+    )
+    parser.add_argument(
+        "--enforce-retention",
+        action="store_true",
+        help="Run retention enforcement after archiving",
+    )
+    return parser
+
+
+def main() -> None:
+    parser = build_parser()
+    args = parser.parse_args()
+
+    try:
+        retention = RetentionPolicy.from_days(hot_days=args.hot_days, cold_days=args.cold_days)
+    except ValueError as exc:  # pragma: no cover - argparse handles messaging
+        parser.error(str(exc))
+
+    if args.as_of is not None:
+        try:
+            as_of = datetime.fromisoformat(args.as_of)
+        except ValueError as exc:  # pragma: no cover - argparse handles messaging
+            parser.error(f"invalid --as-of timestamp: {exc}")
+    else:
+        as_of = None
+
+    archive = MicrostructureTieredArchive(args.hot_dir, args.cold_dir, retention_policy=retention)
+
+    sources = list(_iter_source_files(args.source, args.pattern))
+    if not sources:
+        parser.error("no files found to archive")
+
+    for file_path in sources:
+        archive.archive_file(file_path, args.dataset, as_of=as_of)
+
+    if args.enforce_retention:
+        archive.enforce_retention()
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    main()
+

--- a/src/data_foundation/storage/__init__.py
+++ b/src/data_foundation/storage/__init__.py
@@ -1,0 +1,20 @@
+"""Storage helpers supporting the roadmap's tiered microstructure archive."""
+
+from __future__ import annotations
+
+from .tiered_storage import (
+    ArchiveMetadata,
+    ArchiveResult,
+    MicrostructureTieredArchive,
+    RetentionEnforcementReport,
+    RetentionPolicy,
+)
+
+__all__ = [
+    "ArchiveMetadata",
+    "ArchiveResult",
+    "MicrostructureTieredArchive",
+    "RetentionEnforcementReport",
+    "RetentionPolicy",
+]
+

--- a/src/data_foundation/storage/tiered_storage.py
+++ b/src/data_foundation/storage/tiered_storage.py
@@ -1,0 +1,241 @@
+"""Tiered storage helpers for microstructure datasets."""
+
+from __future__ import annotations
+
+import json
+import logging
+import shutil
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Iterable
+
+logger = logging.getLogger(__name__)
+
+
+def _as_utc(value: datetime | None) -> datetime:
+    """Normalise a datetime to UTC without timezone information."""
+
+    if value is None:
+        value = datetime.utcnow().replace(tzinfo=timezone.utc)
+    elif value.tzinfo is None:
+        value = value.replace(tzinfo=timezone.utc)
+    else:
+        value = value.astimezone(timezone.utc)
+    return value
+
+
+@dataclass(slots=True, frozen=True)
+class RetentionPolicy:
+    """Retention windows for tiered storage."""
+
+    hot_retention: timedelta
+    cold_retention: timedelta
+
+    @classmethod
+    def from_days(cls, *, hot_days: int, cold_days: int) -> "RetentionPolicy":
+        if hot_days <= 0:
+            raise ValueError("hot_days must be positive")
+        if cold_days <= 0:
+            raise ValueError("cold_days must be positive")
+        return cls(timedelta(days=hot_days), timedelta(days=cold_days))
+
+
+@dataclass(slots=True)
+class ArchiveMetadata:
+    """Metadata written alongside archived datasets."""
+
+    dataset: str
+    tier: str
+    as_of: datetime
+    relative_path: str
+    original_source: str
+    size_bytes: int
+
+    def to_dict(self, policy: RetentionPolicy) -> dict[str, object]:
+        return {
+            "dataset": self.dataset,
+            "tier": self.tier,
+            "as_of": self.as_of.isoformat(),
+            "relative_path": self.relative_path,
+            "original_source": self.original_source,
+            "size_bytes": self.size_bytes,
+            "hot_retention_days": policy.hot_retention.days,
+            "cold_retention_days": policy.cold_retention.days,
+        }
+
+    @classmethod
+    def from_dict(cls, payload: dict[str, object]) -> "ArchiveMetadata":
+        as_of_raw = payload.get("as_of")
+        if not isinstance(as_of_raw, str):
+            raise ValueError("metadata missing as_of timestamp")
+        return cls(
+            dataset=str(payload.get("dataset")),
+            tier=str(payload.get("tier", "hot")),
+            as_of=datetime.fromisoformat(as_of_raw),
+            relative_path=str(payload.get("relative_path")),
+            original_source=str(payload.get("original_source", "")),
+            size_bytes=int(payload.get("size_bytes", 0)),
+        )
+
+
+@dataclass(slots=True)
+class ArchiveResult:
+    """Result of archiving a dataset."""
+
+    dataset: str
+    destination: Path
+    metadata_path: Path
+    metadata: ArchiveMetadata
+
+
+@dataclass(slots=True)
+class RetentionEnforcementReport:
+    """Summary of retention enforcement operations."""
+
+    moved_to_cold: int
+    deleted_from_cold: int
+    missing_files: int
+
+
+class MicrostructureTieredArchive:
+    """Manage tiered storage for microstructure datasets."""
+
+    def __init__(
+        self,
+        hot_directory: Path,
+        cold_directory: Path,
+        *,
+        retention_policy: RetentionPolicy,
+    ) -> None:
+        self._hot_directory = Path(hot_directory).expanduser().resolve()
+        self._cold_directory = Path(cold_directory).expanduser().resolve()
+        self._retention_policy = retention_policy
+        self._metadata_suffix = ".meta.json"
+        self._hot_directory.mkdir(parents=True, exist_ok=True)
+        self._cold_directory.mkdir(parents=True, exist_ok=True)
+
+    @property
+    def retention_policy(self) -> RetentionPolicy:
+        return self._retention_policy
+
+    def archive_file(
+        self,
+        source_path: Path,
+        dataset: str,
+        *,
+        as_of: datetime | None = None,
+    ) -> ArchiveResult:
+        if not dataset or "/" in dataset or ".." in dataset:
+            raise ValueError("dataset must be a simple name without path separators")
+
+        source_path = Path(source_path)
+        if not source_path.exists():
+            raise FileNotFoundError(source_path)
+
+        as_of = _as_utc(as_of)
+        relative_dir = Path(dataset) / as_of.strftime("%Y/%m/%d")
+        destination_directory = self._hot_directory / relative_dir
+        destination_directory.mkdir(parents=True, exist_ok=True)
+
+        destination = destination_directory / source_path.name
+        shutil.copy2(source_path, destination)
+        size_bytes = destination.stat().st_size
+
+        metadata = ArchiveMetadata(
+            dataset=dataset,
+            tier="hot",
+            as_of=as_of.replace(tzinfo=None),
+            relative_path=str(relative_dir / source_path.name),
+            original_source=str(source_path),
+            size_bytes=size_bytes,
+        )
+        metadata_path = destination.with_suffix(destination.suffix + self._metadata_suffix)
+        metadata_path.write_text(
+            json.dumps(metadata.to_dict(self._retention_policy), indent=2, sort_keys=True),
+            encoding="utf-8",
+        )
+        return ArchiveResult(dataset, destination, metadata_path, metadata)
+
+    def enforce_retention(self, *, now: datetime | None = None) -> RetentionEnforcementReport:
+        now = _as_utc(now).replace(tzinfo=None)
+        hot_cutoff = now - self._retention_policy.hot_retention
+        cold_cutoff = now - self._retention_policy.cold_retention
+
+        moved = 0
+        deleted = 0
+        missing = 0
+
+        for metadata_path in self._metadata_files(self._hot_directory):
+            metadata = self._load_metadata(metadata_path)
+            if metadata is None:
+                continue
+            if metadata.as_of <= hot_cutoff:
+                if self._move_to_cold(metadata, metadata_path):
+                    moved += 1
+                else:
+                    missing += 1
+
+        for metadata_path in self._metadata_files(self._cold_directory):
+            metadata = self._load_metadata(metadata_path)
+            if metadata is None:
+                continue
+            if metadata.as_of <= cold_cutoff:
+                if self._delete_from_cold(metadata, metadata_path):
+                    deleted += 1
+                else:
+                    missing += 1
+
+        return RetentionEnforcementReport(moved_to_cold=moved, deleted_from_cold=deleted, missing_files=missing)
+
+    def _metadata_files(self, root: Path) -> Iterable[Path]:
+        suffix = self._metadata_suffix
+        for path in root.rglob(f"*{suffix}"):
+            if path.is_file():
+                yield path
+
+    def _load_metadata(self, path: Path) -> ArchiveMetadata | None:
+        try:
+            payload = json.loads(path.read_text(encoding="utf-8"))
+            metadata = ArchiveMetadata.from_dict(payload)
+            # Maintain awareness of storage tier transitions.
+            if path.is_relative_to(self._cold_directory):
+                metadata.tier = "cold"
+            else:
+                metadata.tier = "hot"
+            return metadata
+        except Exception:  # pragma: no cover - defensive logging
+            logger.exception("microstructure_archive_metadata_invalid", path=str(path))
+            return None
+
+    def _resolve_target(self, metadata: ArchiveMetadata, *, hot: bool) -> Path:
+        base = self._hot_directory if hot else self._cold_directory
+        return base / Path(metadata.relative_path)
+
+    def _move_to_cold(self, metadata: ArchiveMetadata, metadata_path: Path) -> bool:
+        source_file = self._resolve_target(metadata, hot=True)
+        if not source_file.exists():
+            logger.warning("microstructure_archive_missing_hot_file", path=str(source_file))
+            metadata_path.unlink(missing_ok=True)
+            return False
+
+        destination = self._resolve_target(metadata, hot=False)
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        shutil.move(str(source_file), str(destination))
+
+        updated_metadata = metadata_path.read_text(encoding="utf-8")
+        payload = json.loads(updated_metadata)
+        payload["tier"] = "cold"
+        payload["relative_path"] = metadata.relative_path
+        payload["cold_storage_path"] = str(destination)
+        metadata_path_cold = destination.with_suffix(destination.suffix + self._metadata_suffix)
+        metadata_path_cold.write_text(json.dumps(payload, indent=2, sort_keys=True), encoding="utf-8")
+        metadata_path.unlink(missing_ok=True)
+        return True
+
+    def _delete_from_cold(self, metadata: ArchiveMetadata, metadata_path: Path) -> bool:
+        target = self._resolve_target(metadata, hot=False)
+        target.unlink(missing_ok=True)
+        metadata_path.unlink(missing_ok=True)
+        return True
+

--- a/tests/data_foundation/test_microstructure_tiered_storage.py
+++ b/tests/data_foundation/test_microstructure_tiered_storage.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+from pathlib import Path
+
+import pytest
+
+from src.data_foundation.storage import MicrostructureTieredArchive, RetentionPolicy
+
+
+@pytest.fixture()
+def sample_file(tmp_path: Path) -> Path:
+    path = tmp_path / "microstructure.parquet"
+    path.write_bytes(b"test payload")
+    return path
+
+
+def test_archive_file_writes_metadata_and_copies(sample_file: Path, tmp_path: Path) -> None:
+    hot_dir = tmp_path / "hot"
+    cold_dir = tmp_path / "cold"
+    archive = MicrostructureTieredArchive(
+        hot_dir,
+        cold_dir,
+        retention_policy=RetentionPolicy.from_days(hot_days=1, cold_days=30),
+    )
+
+    result = archive.archive_file(sample_file, "ict_microstructure")
+
+    assert result.destination.exists()
+    assert result.destination.read_bytes() == sample_file.read_bytes()
+    assert result.metadata_path.exists()
+    payload = result.metadata_path.read_text(encoding="utf-8")
+    assert "ict_microstructure" in payload
+    assert "hot" in payload
+
+
+def test_enforce_retention_moves_hot_to_cold(sample_file: Path, tmp_path: Path) -> None:
+    hot_dir = tmp_path / "hot"
+    cold_dir = tmp_path / "cold"
+    archive = MicrostructureTieredArchive(
+        hot_dir,
+        cold_dir,
+        retention_policy=RetentionPolicy.from_days(hot_days=1, cold_days=30),
+    )
+
+    as_of = datetime.utcnow() - timedelta(days=2)
+    archive.archive_file(sample_file, "ict_microstructure", as_of=as_of)
+
+    report = archive.enforce_retention(now=datetime.utcnow())
+
+    assert report.moved_to_cold == 1
+    assert not any(hot_dir.rglob("*.meta.json"))
+    cold_files = list(cold_dir.rglob("*.meta.json"))
+    assert len(cold_files) == 1
+    cold_payload = cold_files[0].read_text(encoding="utf-8")
+    assert '"tier": "cold"' in cold_payload
+
+
+def test_enforce_retention_deletes_expired_cold(sample_file: Path, tmp_path: Path) -> None:
+    hot_dir = tmp_path / "hot"
+    cold_dir = tmp_path / "cold"
+    archive = MicrostructureTieredArchive(
+        hot_dir,
+        cold_dir,
+        retention_policy=RetentionPolicy.from_days(hot_days=1, cold_days=3),
+    )
+
+    as_of = datetime.utcnow() - timedelta(days=2)
+    archive.archive_file(sample_file, "ict_microstructure", as_of=as_of)
+
+    initial = archive.enforce_retention(now=datetime.utcnow())
+    assert initial.moved_to_cold == 1
+    assert initial.deleted_from_cold == 0
+
+    future = datetime.utcnow() + timedelta(days=5)
+    report = archive.enforce_retention(now=future)
+
+    assert report.deleted_from_cold == 1
+    assert not any(cold_dir.rglob("*.parquet"))
+


### PR DESCRIPTION
## Summary
- add a microstructure tiered archive module with retention enforcement helpers
- provide a CLI and runbook documenting the hot/cold microstructure storage workflow
- update the roadmap status and add regression tests for the archive utility

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68da9f2277dc832cb83cdb1df5b9da8f