### PR TITLE
Add regulatory telemetry aggregation and extend high-impact roadmap evidence

### DIFF
--- a/docs/High-Impact Development Roadmap.md
+++ b/docs/High-Impact Development Roadmap.md
@@ -224,6 +224,7 @@ To reflect the true scope of institutional-grade trading components, the roadmap
 - [x] Capture infrastructure-as-code runbook in `/docs/deployment/`.
 - [x] Establish encyclopedia "Ops Command" checklist covering daily start/stop, failover, and audit logging rotations.
 - [x] Integrate dependency vulnerability scanning (e.g., `pip-audit`, `trivy`) into CI with exemption workflow documented.
+- [x] Extend regulatory telemetry coverage for compliance surfaces (`src/operations/regulatory_telemetry.py`).
 - [x] Simulate disaster recovery drill restoring from latest backups and log results under `/docs/deployment/drills/`.
 
 #### Workstream 3C: Advanced Research Backlog (ongoing within phase)

--- a/docs/status/high_impact_roadmap_detail.md
+++ b/docs/status/high_impact_roadmap_detail.md
@@ -69,6 +69,7 @@
 - operations.strategy_performance.evaluate_strategy_performance
 - compliance.workflow.evaluate_compliance_workflows
 - operations.compliance_readiness.evaluate_compliance_readiness
+- operations.regulatory_telemetry.evaluate_regulatory_telemetry
 - compliance.trade_compliance.TradeComplianceMonitor
 - compliance.kyc.KycAmlMonitor
 - operations.configuration_audit.evaluate_configuration_audit

--- a/docs/status/high_impact_roadmap_portfolio.json
+++ b/docs/status/high_impact_roadmap_portfolio.json
@@ -64,6 +64,7 @@
         "operations.strategy_performance.evaluate_strategy_performance",
         "compliance.workflow.evaluate_compliance_workflows",
         "operations.compliance_readiness.evaluate_compliance_readiness",
+        "operations.regulatory_telemetry.evaluate_regulatory_telemetry",
         "compliance.trade_compliance.TradeComplianceMonitor",
         "compliance.kyc.KycAmlMonitor",
         "operations.configuration_audit.evaluate_configuration_audit",

--- a/src/operations/__init__.py
+++ b/src/operations/__init__.py
@@ -40,6 +40,13 @@ from .compliance_readiness import (
     evaluate_compliance_readiness,
     publish_compliance_readiness,
 )
+from .regulatory_telemetry import (
+    RegulatoryTelemetrySignal,
+    RegulatoryTelemetrySnapshot,
+    RegulatoryTelemetryStatus,
+    evaluate_regulatory_telemetry,
+    publish_regulatory_telemetry,
+)
 from .professional_readiness import (
     ProfessionalReadinessComponent,
     ProfessionalReadinessSnapshot,
@@ -222,6 +229,11 @@ __all__ = [
     "ComplianceReadinessStatus",
     "evaluate_compliance_readiness",
     "publish_compliance_readiness",
+    "RegulatoryTelemetrySignal",
+    "RegulatoryTelemetrySnapshot",
+    "RegulatoryTelemetryStatus",
+    "evaluate_regulatory_telemetry",
+    "publish_regulatory_telemetry",
     "ProfessionalReadinessComponent",
     "ProfessionalReadinessSnapshot",
     "ProfessionalReadinessStatus",

--- a/src/operations/regulatory_telemetry.py
+++ b/src/operations/regulatory_telemetry.py
@@ -1,0 +1,367 @@
+"""Regulatory telemetry aggregation utilities.
+
+This module transforms raw compliance and surveillance telemetry feeds into a
+normalised snapshot that can be published to the wider runtime.  The
+implementation mirrors the high-impact roadmap requirement to provide
+regulatory coverage telemetry alongside the existing execution and compliance
+surfaces.  It purposely avoids heavyweight dependencies so it can operate
+inside the current CI footprint while still surfacing actionable metadata for
+dashboards and runbooks.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import UTC, datetime, timedelta
+from enum import StrEnum
+from typing import Iterable, Mapping, MutableMapping, Sequence
+
+from src.core.event_bus import Event, EventBus, get_global_bus
+
+__all__ = [
+    "RegulatoryTelemetryStatus",
+    "RegulatoryTelemetrySignal",
+    "RegulatoryTelemetrySnapshot",
+    "evaluate_regulatory_telemetry",
+    "publish_regulatory_telemetry",
+]
+
+
+class RegulatoryTelemetryStatus(StrEnum):
+    """Severity levels exposed by regulatory telemetry."""
+
+    ok = "ok"
+    warn = "warn"
+    fail = "fail"
+
+
+_STATUS_ORDER: Mapping[RegulatoryTelemetryStatus, int] = {
+    RegulatoryTelemetryStatus.ok: 0,
+    RegulatoryTelemetryStatus.warn: 1,
+    RegulatoryTelemetryStatus.fail: 2,
+}
+
+
+DEFAULT_REQUIRED_DOMAINS: tuple[str, ...] = (
+    "trade_compliance",
+    "kyc_aml",
+    "trade_reporting",
+    "surveillance",
+)
+
+
+@dataclass(slots=True, frozen=True)
+class RegulatoryTelemetrySignal:
+    """Normalised regulatory telemetry observation."""
+
+    name: str
+    status: RegulatoryTelemetryStatus
+    summary: str
+    observed_at: datetime | None
+    metadata: Mapping[str, object] = field(default_factory=dict)
+
+    def as_dict(self) -> dict[str, object]:
+        payload: dict[str, object] = {
+            "name": self.name,
+            "status": self.status.value,
+            "summary": self.summary,
+        }
+        if self.observed_at is not None:
+            payload["observed_at"] = self.observed_at.isoformat()
+        if self.metadata:
+            payload["metadata"] = dict(self.metadata)
+        return payload
+
+
+@dataclass(slots=True, frozen=True)
+class RegulatoryTelemetrySnapshot:
+    """Aggregated telemetry coverage for regulatory controls."""
+
+    generated_at: datetime
+    status: RegulatoryTelemetryStatus
+    coverage_ratio: float
+    signals: tuple[RegulatoryTelemetrySignal, ...]
+    required_domains: tuple[str, ...]
+    missing_domains: tuple[str, ...]
+    metadata: Mapping[str, object] = field(default_factory=dict)
+
+    def as_dict(self) -> dict[str, object]:
+        return {
+            "generated_at": self.generated_at.isoformat(),
+            "status": self.status.value,
+            "coverage_ratio": self.coverage_ratio,
+            "required_domains": list(self.required_domains),
+            "missing_domains": list(self.missing_domains),
+            "signals": [signal.as_dict() for signal in self.signals],
+            "metadata": dict(self.metadata),
+        }
+
+
+def _escalate(
+    current: RegulatoryTelemetryStatus, candidate: RegulatoryTelemetryStatus
+) -> RegulatoryTelemetryStatus:
+    if _STATUS_ORDER[candidate] > _STATUS_ORDER[current]:
+        return candidate
+    return current
+
+
+def _coerce_mapping(value: object | None) -> MutableMapping[str, object]:
+    if isinstance(value, MutableMapping):
+        return value
+    if isinstance(value, Mapping):
+        return dict(value)
+    return {}
+
+
+def _coerce_sequence(value: object | None) -> Sequence[object]:
+    if value is None:
+        return ()
+    if isinstance(value, (str, bytes, bytearray)):
+        return ()
+    if isinstance(value, Sequence):
+        return value
+    return ()
+
+
+def _coerce_int(value: object | None) -> int:
+    if value is None:
+        return 0
+    if isinstance(value, bool):
+        return int(value)
+    if isinstance(value, int):
+        return value
+    if isinstance(value, float):
+        return int(value)
+    try:
+        return int(float(str(value).strip()))
+    except (TypeError, ValueError):
+        return 0
+
+
+def _parse_datetime(value: object | None) -> datetime | None:
+    if value is None:
+        return None
+    if isinstance(value, datetime):
+        return value.astimezone(UTC) if value.tzinfo else value.replace(tzinfo=UTC)
+    if isinstance(value, str):
+        text = value.strip()
+        if not text:
+            return None
+        try:
+            parsed = datetime.fromisoformat(text)
+        except ValueError:
+            return None
+        return parsed.astimezone(UTC) if parsed.tzinfo else parsed.replace(tzinfo=UTC)
+    return None
+
+
+def _normalise_status(value: object | None) -> RegulatoryTelemetryStatus:
+    if isinstance(value, RegulatoryTelemetryStatus):
+        return value
+    label = str(value or "").strip().lower()
+    if label in {"ok", "pass", "green"}:
+        return RegulatoryTelemetryStatus.ok
+    if label in {"warn", "warning", "amber"}:
+        return RegulatoryTelemetryStatus.warn
+    if label in {"fail", "failed", "red", "error"}:
+        return RegulatoryTelemetryStatus.fail
+    return RegulatoryTelemetryStatus.warn
+
+
+def _normalise_name(value: object | None) -> str:
+    text = str(value or "").strip()
+    if not text:
+        return ""
+    return text.replace(" ", "_").lower()
+
+
+def _derive_summary(payload: Mapping[str, object]) -> str:
+    for key in ("summary", "description", "message"):
+        value = payload.get(key)
+        if value:
+            text = str(value).strip()
+            if text:
+                return text
+    return "no summary provided"
+
+
+def _merge_metadata(*values: Mapping[str, object]) -> MutableMapping[str, object]:
+    merged: MutableMapping[str, object] = {}
+    for value in values:
+        if not isinstance(value, Mapping):
+            continue
+        for key, val in value.items():
+            merged[str(key)] = val
+    return merged
+
+
+def _finalise_signal(
+    name: str,
+    *,
+    status: RegulatoryTelemetryStatus,
+    summary: str,
+    observed_at: datetime | None,
+    generated_at: datetime,
+    stale_after: timedelta,
+    metadata: MutableMapping[str, object],
+) -> RegulatoryTelemetrySignal:
+    effective_status = status
+    stale = False
+    if observed_at is None:
+        stale = True
+    else:
+        if generated_at - observed_at > stale_after:
+            stale = True
+
+    breaches = _coerce_int(metadata.get("breaches"))
+    violations = _coerce_int(metadata.get("violations"))
+
+    if breaches > 0 or violations > 0:
+        effective_status = RegulatoryTelemetryStatus.fail
+    elif stale and effective_status == RegulatoryTelemetryStatus.ok:
+        effective_status = RegulatoryTelemetryStatus.warn
+
+    if stale:
+        metadata.setdefault("stale", True)
+
+    return RegulatoryTelemetrySignal(
+        name=name,
+        status=effective_status,
+        summary=summary,
+        observed_at=observed_at,
+        metadata=dict(metadata),
+    )
+
+
+def evaluate_regulatory_telemetry(
+    *,
+    signals: Iterable[Mapping[str, object] | RegulatoryTelemetrySignal] | None = None,
+    required_domains: Sequence[str] | None = None,
+    metadata: Mapping[str, object] | None = None,
+    stale_after: timedelta | None = None,
+) -> RegulatoryTelemetrySnapshot:
+    """Fuse regulatory telemetry feeds into a normalised snapshot."""
+
+    generated_at = datetime.now(tz=UTC)
+    required = tuple(required_domains or DEFAULT_REQUIRED_DOMAINS)
+    stale_window = stale_after or timedelta(minutes=60)
+
+    processed: dict[str, RegulatoryTelemetrySignal] = {}
+    observed_domains: set[str] = set()
+    overall = RegulatoryTelemetryStatus.ok
+
+    for payload in signals or ():
+        if isinstance(payload, RegulatoryTelemetrySignal):
+            signal = payload
+        else:
+            mapping = _coerce_mapping(payload)
+            name = _normalise_name(
+                mapping.get("name")
+                or mapping.get("domain")
+                or mapping.get("surface")
+            )
+            if not name:
+                continue
+            status = _normalise_status(mapping.get("status"))
+            observed_at = _parse_datetime(
+                mapping.get("observed_at") or mapping.get("timestamp")
+            )
+            summary = _derive_summary(mapping)
+            metadata_payload = _merge_metadata(
+                mapping.get("metadata", {}),
+                {
+                    "violations": mapping.get("violations"),
+                    "breaches": mapping.get("breaches"),
+                },
+            )
+            signal = _finalise_signal(
+                name,
+                status=status,
+                summary=summary,
+                observed_at=observed_at,
+                generated_at=generated_at,
+                stale_after=stale_window,
+                metadata=metadata_payload,
+            )
+
+        key = _normalise_name(signal.name)
+        if not key:
+            continue
+
+        observed_domains.add(key)
+        existing = processed.get(key)
+        if existing is None or _STATUS_ORDER[signal.status] >= _STATUS_ORDER[
+            existing.status
+        ]:
+            processed[key] = signal
+        overall = _escalate(overall, signal.status)
+
+    for domain in required:
+        key = _normalise_name(domain)
+        if key in processed:
+            continue
+        placeholder = RegulatoryTelemetrySignal(
+            name=domain,
+            status=RegulatoryTelemetryStatus.fail,
+            summary="telemetry missing",
+            observed_at=None,
+            metadata={"reason": "telemetry_missing"},
+        )
+        processed[key] = placeholder
+        overall = _escalate(overall, placeholder.status)
+
+    signals_tuple = tuple(processed.values())
+    required_lower = tuple(_normalise_name(domain) for domain in required)
+    coverage = 1.0
+    missing = tuple(
+        domain
+        for domain, key in zip(required, required_lower)
+        if key and key not in observed_domains
+    )
+    if required_lower:
+        covered = sum(1 for key in required_lower if key in observed_domains)
+        coverage = covered / len(required_lower)
+
+    snapshot_metadata = dict(metadata or {})
+    snapshot_metadata.setdefault("signals", [signal.name for signal in signals_tuple])
+    snapshot_metadata["coverage_percent"] = round(coverage * 100.0, 2)
+
+    return RegulatoryTelemetrySnapshot(
+        generated_at=generated_at,
+        status=overall,
+        coverage_ratio=coverage,
+        signals=signals_tuple,
+        required_domains=required,
+        missing_domains=missing,
+        metadata=snapshot_metadata,
+    )
+
+
+def publish_regulatory_telemetry(
+    event_bus: EventBus,
+    snapshot: RegulatoryTelemetrySnapshot,
+    *,
+    channel: str = "telemetry.compliance.regulatory",
+) -> None:
+    """Publish the snapshot to the provided event bus."""
+
+    event = Event(
+        type=channel,
+        payload=snapshot.as_dict(),
+        source="regulatory_telemetry",
+    )
+
+    publish_from_sync = getattr(event_bus, "publish_from_sync", None)
+    if callable(publish_from_sync):
+        try:
+            if event_bus.is_running():
+                publish_from_sync(event)
+                return
+        except Exception:  # pragma: no cover - best-effort logging path
+            pass
+
+    try:
+        topic_bus = get_global_bus()
+        topic_bus.publish_sync(event.type, event.payload, source=event.source)
+    except Exception:  # pragma: no cover - best-effort logging path
+        pass

--- a/tests/operations/test_regulatory_telemetry.py
+++ b/tests/operations/test_regulatory_telemetry.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from src.operations.regulatory_telemetry import (
+    RegulatoryTelemetrySignal,
+    RegulatoryTelemetrySnapshot,
+    RegulatoryTelemetryStatus,
+    evaluate_regulatory_telemetry,
+    publish_regulatory_telemetry,
+)
+
+
+class DummyEventBus:
+    def __init__(self) -> None:
+        self.events: list[object] = []
+        self._running = True
+
+    def publish_from_sync(self, event: object) -> None:
+        self.events.append(event)
+
+    def is_running(self) -> bool:
+        return self._running
+
+
+def _fresh_timestamp(minutes: int = 0) -> str:
+    return (datetime.now(tz=UTC) - timedelta(minutes=minutes)).isoformat()
+
+
+def test_evaluate_regulatory_telemetry_marks_missing_domains() -> None:
+    snapshot = evaluate_regulatory_telemetry(
+        signals=[
+            {
+                "name": "trade_compliance",
+                "status": "ok",
+                "summary": "All checks passing",
+                "observed_at": _fresh_timestamp(),
+            },
+            {
+                "name": "kyc_aml",
+                "status": "warn",
+                "summary": "Backlog present",
+                "observed_at": _fresh_timestamp(),
+            },
+        ],
+        required_domains=("trade_compliance", "kyc_aml", "trade_reporting"),
+    )
+
+    assert snapshot.status == RegulatoryTelemetryStatus.fail
+    assert set(snapshot.missing_domains) == {"trade_reporting"}
+    placeholders = [
+        signal
+        for signal in snapshot.signals
+        if signal.metadata.get("reason") == "telemetry_missing"
+    ]
+    assert placeholders and placeholders[0].name == "trade_reporting"
+
+
+def test_evaluate_regulatory_telemetry_flags_stale_signals() -> None:
+    snapshot = evaluate_regulatory_telemetry(
+        signals=[
+            {
+                "name": "trade_reporting",
+                "status": "ok",
+                "summary": "Reports delivered",
+                "observed_at": _fresh_timestamp(minutes=180),
+            }
+        ],
+        required_domains=("trade_reporting",),
+        stale_after=timedelta(minutes=30),
+    )
+
+    signal = snapshot.signals[0]
+    assert signal.status == RegulatoryTelemetryStatus.warn
+    assert signal.metadata.get("stale") is True
+
+
+def test_evaluate_regulatory_telemetry_handles_existing_signal_instances() -> None:
+    signal = RegulatoryTelemetrySignal(
+        name="surveillance",
+        status=RegulatoryTelemetryStatus.fail,
+        summary="Alert backlog",
+        observed_at=datetime.now(tz=UTC),
+        metadata={"violations": 3},
+    )
+
+    snapshot = evaluate_regulatory_telemetry(
+        signals=[signal],
+        required_domains=("surveillance",),
+    )
+
+    assert isinstance(snapshot, RegulatoryTelemetrySnapshot)
+    assert snapshot.status == RegulatoryTelemetryStatus.fail
+    assert snapshot.coverage_ratio == pytest.approx(1.0)
+
+
+def test_publish_regulatory_telemetry_uses_event_bus() -> None:
+    snapshot = evaluate_regulatory_telemetry(
+        signals=[
+            {
+                "name": "trade_compliance",
+                "status": "ok",
+                "summary": "All good",
+                "observed_at": _fresh_timestamp(),
+            }
+        ],
+        required_domains=("trade_compliance",),
+    )
+
+    bus = DummyEventBus()
+    publish_regulatory_telemetry(bus, snapshot)
+
+    assert bus.events, "expected snapshot to be published"
+    payload = bus.events[0].payload
+    assert payload["status"] == RegulatoryTelemetryStatus.ok.value

--- a/tests/tools/test_high_impact_roadmap.py
+++ b/tests/tools/test_high_impact_roadmap.py
@@ -59,6 +59,7 @@ def test_stream_c_covers_execution_lifecycle_artifacts() -> None:
         "operations.event_bus_health.evaluate_event_bus_health",
         "operations.feed_health.evaluate_feed_health",
         "operations.failover_drill.execute_failover_drill",
+        "operations.regulatory_telemetry.evaluate_regulatory_telemetry",
         "operations.observability_dashboard.build_observability_dashboard",
         "trading.order_management.lifecycle_processor.OrderLifecycleProcessor",
         "trading.order_management.position_tracker.PositionTracker",

--- a/tools/roadmap/high_impact.py
+++ b/tools/roadmap/high_impact.py
@@ -272,6 +272,9 @@ def _stream_definitions() -> Sequence[StreamDefinition]:
                 require_module_attr(
                     "operations.compliance_readiness", "evaluate_compliance_readiness"
                 ),
+                require_module_attr(
+                    "operations.regulatory_telemetry", "evaluate_regulatory_telemetry"
+                ),
                 require_module_attr("compliance.trade_compliance", "TradeComplianceMonitor"),
                 require_module_attr("compliance.kyc", "KycAmlMonitor"),
                 require_module_attr(


### PR DESCRIPTION
## Summary
- add a regulatory telemetry aggregation module with publication helpers to surface coverage gaps alongside execution and compliance feeds
- cover the new telemetry snapshot with dedicated unit tests and export hooks from the operations package
- update roadmap tooling, documentation, and evidence fixtures so Stream C now requires the regulatory telemetry surface

## Testing
- pytest tests/operations/test_regulatory_telemetry.py tests/tools/test_high_impact_roadmap.py

------
https://chatgpt.com/codex/tasks/task_e_68db71816d50832cb2796fe5966e5fd8