### PR TITLE
Include microstructure storage assets in high-impact stream

### DIFF
--- a/docs/status/high_impact_roadmap_portfolio.json
+++ b/docs/status/high_impact_roadmap_portfolio.json
@@ -23,7 +23,10 @@
         "data_foundation.ingest.failover.decide_ingest_failover",
         "operations.cross_region_failover.evaluate_cross_region_failover",
         "operations.backup.evaluate_backup_readiness",
-        "operations.spark_stress.execute_spark_stress_drill"
+        "operations.spark_stress.execute_spark_stress_drill",
+        "data_foundation.storage.tiered_storage.MicrostructureTieredArchive",
+        "scripts/archive_microstructure_data.py",
+        "docs/runbooks/microstructure_storage.md"
       ],
       "missing": [],
       "deferred_summary": null

--- a/tools/roadmap/high_impact.py
+++ b/tools/roadmap/high_impact.py
@@ -194,6 +194,12 @@ def _stream_definitions() -> Sequence[StreamDefinition]:
                     "operations.spark_stress",
                     "execute_spark_stress_drill",
                 ),
+                require_module_attr(
+                    "data_foundation.storage.tiered_storage",
+                    "MicrostructureTieredArchive",
+                ),
+                require_path("scripts/archive_microstructure_data.py"),
+                require_path("docs/runbooks/microstructure_storage.md"),
             ),
         ),
         StreamDefinition(


### PR DESCRIPTION
## Summary
- expand the Stream A requirement list so the roadmap tool enforces the microstructure storage assets that the documentation already cites
- refresh the generated portfolio status JSON so the evidence block now includes the storage orchestrator, archival script, and runbook

## Testing
- pytest tests/tools/test_high_impact_roadmap.py

------
https://chatgpt.com/codex/tasks/task_e_68db71816d50832cb2796fe5966e5fd8