### PR TITLE
Stabilize runtime entrypoints with supervised task orchestration

### DIFF
--- a/docs/context/alignment_briefs/operational_readiness.md
+++ b/docs/context/alignment_briefs/operational_readiness.md
@@ -31,6 +31,9 @@
 ### Now (0–30 days)
 
 - Finish the task supervision rollout across runtime and operational helpers.【F:docs/technical_debt_assessment.md†L33-L56】
+  - ✅ Runtime CLI orchestration and the bootstrap sensory loop now execute under
+    `TaskSupervisor`, eliminating direct `asyncio.create_task` usage for
+    entrypoint workflows and providing deterministic signal/timeout shutdowns.【F:src/runtime/cli.py†L206-L249】【F:src/runtime/bootstrap_runtime.py†L227-L268】
 - Update incident response docs with current limitations and TODOs; remove or
   archive obsolete OpenAPI references where possible.【F:docs/legacy/README.md†L1-L12】
 - Extend CI step summaries to include risk, ingest, and sensory telemetry status so

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -31,9 +31,11 @@ Encyclopedia while acknowledging that most subsystems remain scaffolding.
 
 ### Now (0–30 days)
 
-- [ ] **Stabilise runtime entrypoints** – Move all application starts through
+- [x] **Stabilise runtime entrypoints** – Move all application starts through
   `RuntimeApplication` and register background jobs under a task supervisor to
-  eliminate unsupervised `create_task` usage.【F:docs/technical_debt_assessment.md†L33-L56】
+  eliminate unsupervised `create_task` usage. Runtime CLI invocations and the
+  bootstrap sensory loop now run under `TaskSupervisor`, ensuring graceful
+  signal/time-based shutdown paths.【F:docs/technical_debt_assessment.md†L33-L56】【F:src/runtime/cli.py†L206-L249】【F:src/runtime/bootstrap_runtime.py†L227-L268】
 - [ ] **Security hardening sprint** – Execute the remediation plan’s Phase 0:
   parameterise SQL, remove `eval`, and address blanket exception handlers in
   operational modules.【F:docs/development/remediation_plan.md†L34-L72】

--- a/src/runtime/cli.py
+++ b/src/runtime/cli.py
@@ -22,6 +22,7 @@ from typing import Any, Awaitable, Callable, Mapping, Sequence
 from src.governance.system_config import SystemConfig
 from src.runtime.predator_app import ProfessionalPredatorApp, build_professional_predator_app
 from src.runtime.runtime_builder import RuntimeApplication, build_professional_runtime_application
+from src.runtime.task_supervisor import TaskSupervisor
 
 
 logger = logging.getLogger(__name__)
@@ -207,46 +208,56 @@ async def _handle_summary(
 async def _run_runtime_with_signals(runtime_app: RuntimeApplication, timeout: float | None) -> None:
     loop = asyncio.get_running_loop()
     stop_event = asyncio.Event()
+    supervisor = TaskSupervisor(namespace="runtime.cli")
 
     def _trigger_stop() -> None:
         stop_event.set()
 
+    registered_signals: list[signal.Signals] = []
     for sig in (signal.SIGINT, signal.SIGTERM):
         try:
             loop.add_signal_handler(sig, _trigger_stop)
         except (NotImplementedError, ValueError):  # pragma: no cover - Windows / nested loop
-            pass
+            continue
+        else:
+            registered_signals.append(sig)
 
-    run_task = asyncio.create_task(runtime_app.run(), name="runtime-app-run")
+    run_task = supervisor.create(runtime_app.run(), name="runtime-app-run")
     waiters: set[asyncio.Task[object]] = {run_task}
 
-    stop_task = asyncio.create_task(stop_event.wait(), name="runtime-stop-event")
+    stop_task = supervisor.create(stop_event.wait(), name="runtime-stop-event")
     waiters.add(stop_task)
 
     timeout_task: asyncio.Task[object] | None = None
     if timeout is not None:
-        timeout_task = asyncio.create_task(asyncio.sleep(timeout), name="runtime-timeout")
+        timeout_task = supervisor.create(asyncio.sleep(timeout), name="runtime-timeout")
         waiters.add(timeout_task)
 
-    done, pending = await asyncio.wait(waiters, return_when=asyncio.FIRST_COMPLETED)
+    try:
+        done, pending = await asyncio.wait(waiters, return_when=asyncio.FIRST_COMPLETED)
 
-    if run_task in done:
+        if run_task in done:
+            for task in pending:
+                task.cancel()
+            await asyncio.gather(*pending, return_exceptions=True)
+            return
+
+        if stop_task in done and stop_event.is_set():
+            logger.info("Shutdown signal received; cancelling runtime workloads")
+        elif timeout_task is not None and timeout_task in done:
+            logger.info("Runtime timeout reached after %ss; cancelling workloads", timeout)
+
+        run_task.cancel()
         for task in pending:
             task.cancel()
         await asyncio.gather(*pending, return_exceptions=True)
-        return
-
-    if stop_task in done and stop_event.is_set():
-        logger.info("Shutdown signal received; cancelling runtime workloads")
-    elif timeout_task is not None and timeout_task in done:
-        logger.info("Runtime timeout reached after %ss; cancelling workloads", timeout)
-
-    run_task.cancel()
-    for task in pending:
-        task.cancel()
-    await asyncio.gather(*pending, return_exceptions=True)
-    with suppress(asyncio.CancelledError):
-        await run_task
+        with suppress(asyncio.CancelledError):
+            await run_task
+    finally:
+        await supervisor.cancel_all()
+        for sig in registered_signals:
+            with suppress(NotImplementedError):  # pragma: no cover - mirrors add_signal_handler
+                loop.remove_signal_handler(sig)
 
 
 async def _handle_run(args: argparse.Namespace) -> int:


### PR DESCRIPTION
## Summary
- wrap the runtime CLI signal orchestration in a TaskSupervisor so run, stop, and timeout coroutines are tracked and cleaned up deterministically
- allow the bootstrap sensory runtime to accept a TaskSupervisor and route its run loop through the supervisor for consistent cancellation semantics
- update the roadmap and operational readiness brief to record the supervised-entrypoint milestone

## Testing
- pytest tests/runtime/test_runtime_cli.py

------
https://chatgpt.com/codex/tasks/task_e_68db87c8a65c832cadf0ee74bb627963