### PR TITLE
Supervise health monitor background loop

### DIFF
--- a/docs/context/alignment_briefs/operational_readiness.md
+++ b/docs/context/alignment_briefs/operational_readiness.md
@@ -16,6 +16,9 @@
   and open alerts workflow items.【F:docs/technical_debt_assessment.md†L33-L112】
 - Legacy guides (OpenAPI/cTrader) persist in `docs/legacy`, signalling incomplete
   cleanup and risk of policy drift.【F:docs/legacy/README.md†L1-L12】
+- Operational health monitoring now routes background loops through the runtime
+  task supervisor and surfaces explicit error telemetry instead of silently
+  swallowing failures.【F:src/operational/health_monitor.py†L1-L214】
 
 ## Gap themes
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -34,9 +34,13 @@ Encyclopedia while acknowledging that most subsystems remain scaffolding.
 - [ ] **Stabilise runtime entrypoints** – Move all application starts through
   `RuntimeApplication` and register background jobs under a task supervisor to
   eliminate unsupervised `create_task` usage.【F:docs/technical_debt_assessment.md†L33-L56】
+  - [x] Routed the operational health monitor through supervised background
+    tasks with graceful shutdown signals and metadata for observability.
 - [ ] **Security hardening sprint** – Execute the remediation plan’s Phase 0:
   parameterise SQL, remove `eval`, and address blanket exception handlers in
   operational modules.【F:docs/development/remediation_plan.md†L34-L72】
+  - [x] Replaced blanket exception handlers in health monitoring resource
+    checks with structured logging and explicit error reporting.
 - [ ] **Context pack refresh** – Replace legacy briefs with the updated context in
   `docs/context/alignment_briefs` so discovery and reviews inherit the same
   narrative reset (this change set).

--- a/tests/operational/test_health_monitor.py
+++ b/tests/operational/test_health_monitor.py
@@ -1,0 +1,90 @@
+import asyncio
+from collections.abc import Mapping
+
+import pytest
+
+from src.operational.health_monitor import HealthMonitor
+
+
+class _DummyStateStore:
+    def __init__(self) -> None:
+        self.data: dict[str, tuple[str, int | None]] = {}
+
+    async def set(self, key: str, value: str, expire: int | None = None) -> None:
+        self.data[key] = (value, expire)
+
+    async def get(self, key: str) -> str | None:
+        record = self.data.get(key)
+        return record[0] if record else None
+
+
+class _DummyEventBus:
+    def __init__(self) -> None:
+        self.emitted: list[tuple[str, Mapping[str, object]]] = []
+
+    async def emit(self, event_name: str, payload: Mapping[str, object]) -> None:
+        self.emitted.append((event_name, payload))
+
+
+class _RecordingSupervisor:
+    def __init__(self) -> None:
+        self.calls: list[dict[str, object]] = []
+
+    def create(
+        self,
+        coro,
+        *,
+        name: str | None = None,
+        metadata: Mapping[str, object] | None = None,
+    ):
+        task = asyncio.create_task(coro)
+        self.calls.append({"task": task, "name": name, "metadata": metadata})
+        return task
+
+
+class _MinimalSupervisor:
+    def __init__(self) -> None:
+        self.names: list[str | None] = []
+
+    def create(self, coro, *, name: str | None = None):  # pragma: no cover - compatibility path
+        task = asyncio.create_task(coro)
+        self.names.append(name)
+        return task
+
+
+@pytest.mark.asyncio
+async def test_health_monitor_runs_under_task_supervision():
+    state_store = _DummyStateStore()
+    event_bus = _DummyEventBus()
+    supervisor = _RecordingSupervisor()
+
+    monitor = HealthMonitor(state_store, event_bus, task_supervisor=supervisor)
+    monitor.check_interval = 0.01
+
+    await monitor.start()
+    await asyncio.sleep(0.03)
+    await monitor.stop()
+
+    assert supervisor.calls, "health monitor should register a supervised task"
+    stored_keys = list(state_store.data.keys())
+    assert stored_keys, "health checks should be persisted"
+    for call in supervisor.calls:
+        assert call["metadata"] == {"component": "operational.health_monitor"}
+        assert call["name"] == "health-monitor-loop"
+        assert call["task"].done()
+
+
+@pytest.mark.asyncio
+async def test_health_monitor_falls_back_when_metadata_not_supported():
+    state_store = _DummyStateStore()
+    event_bus = _DummyEventBus()
+    supervisor = _MinimalSupervisor()
+
+    monitor = HealthMonitor(state_store, event_bus, task_supervisor=supervisor)
+    monitor.check_interval = 0.01
+
+    await monitor.start()
+    await asyncio.sleep(0.03)
+    await monitor.stop()
+
+    assert supervisor.names == ["health-monitor-loop"]


### PR DESCRIPTION
## Summary
- route the operational health monitor through the runtime task supervisor with graceful shutdown handling
- replace blanket exception handling in health checks with structured logging and add coverage
- document the operational readiness brief and roadmap with the supervision progress

## Testing
- pytest tests/operational/test_health_monitor.py

------
https://chatgpt.com/codex/tasks/task_e_68db87c8a65c832cadf0ee74bb627963