### PR TITLE
Harden strategy registry and retire risk config shim

### DIFF
--- a/docs/context/alignment_briefs/institutional_data_backbone.md
+++ b/docs/context/alignment_briefs/institutional_data_backbone.md
@@ -15,8 +15,9 @@
   risk sizing pipelines.【F:docs/DEVELOPMENT_STATUS.md†L19-L35】
 - Technical debt findings flag unsupervised async tasks, hollow risk checks, and
   namespace drift that block dependable runtime assembly.【F:docs/technical_debt_assessment.md†L33-L80】
-- Deprecated configs remain in-tree, signalling unfinished de-shimming work that
-  risks misconfiguration when real services arrive.【F:src/config/risk_config.py†L1-L8】【F:src/config/evolution_config.py†L1-L8】
+- Canonical risk configuration now lives under `src/config/risk/risk_config.py`,
+  but the deprecated evolution config shim still signals unfinished de-shimming
+  work that risks misconfiguration when real services arrive.【F:src/config/risk/risk_config.py†L1-L72】【F:src/config/evolution_config.py†L1-L8】
 
 ## Gap themes
 

--- a/docs/context/alignment_briefs/institutional_risk_compliance.md
+++ b/docs/context/alignment_briefs/institutional_risk_compliance.md
@@ -15,8 +15,9 @@
 - Technical debt audits highlight hollow risk enforcement, unsupervised async
   entrypoints, and namespace drift (`get_risk_manager` export) that mislead API
   consumers.【F:docs/technical_debt_assessment.md†L33-L80】【F:src/core/__init__.py†L11-L51】
-- Deprecated config modules remain, and dead-code sweeps list multiple risk and
-  compliance files as unused, complicating canonicalisation.【F:src/config/risk_config.py†L1-L8】【F:docs/reports/CLEANUP_REPORT.md†L71-L175】
+- Canonical risk configuration now resides in `src/config/risk/risk_config.py`,
+  yet dead-code sweeps still list additional risk and compliance files as unused,
+  complicating canonicalisation.【F:src/config/risk/risk_config.py†L1-L72】【F:docs/reports/CLEANUP_REPORT.md†L71-L175】
 
 ## Gap themes
 

--- a/docs/reports/CLEANUP_REPORT.md
+++ b/docs/reports/CLEANUP_REPORT.md
@@ -79,7 +79,7 @@ Dead code candidates (first 100):
 -  src\risk.py
 -  src\config\evolution_config.py
 -  src\config\portfolio_config.py
--  src\config\risk_config.py
+-  ~~src\config\risk_config.py~~ (removed; canonical risk config lives at `src/config/risk/risk_config.py`).【F:src/config/risk/risk_config.py†L1-L72】
 -  src\config\sensory_config.py
 -  src\core\configuration.py
 -  src\core\context_packet.py

--- a/docs/reports/dependency_graph.dot
+++ b/docs/reports/dependency_graph.dot
@@ -5,7 +5,6 @@ digraph emp_deps {
   "src.config.evolution_config";
   "src.config.portfolio_config";
   "src.config.risk.risk_config";
-  "src.config.risk_config";
   "src.config.sensory_config";
   "src.config.system_config";
   "src.core";
@@ -317,7 +316,6 @@ digraph emp_deps {
   "src.risk" -> "src.core.risk.manager";
   "src.risk" -> "src.validation.models";
   "src.config.evolution_config" -> "src.core.evolution.engine";
-  "src.config.risk_config" -> "src.core.risk.manager";
   "src.core.configuration" -> "src.core.exceptions";
   "src.core.event_bus" -> "src.core.events";
   "src.core.population_manager" -> "src.core.interfaces";

--- a/docs/reports/fanin_fanout.csv
+++ b/docs/reports/fanin_fanout.csv
@@ -3,7 +3,6 @@ src,0,0
 src.config.evolution_config,0,1
 src.config.portfolio_config,1,0
 src.config.risk.risk_config,3,0
-src.config.risk_config,0,1
 src.config.sensory_config,0,0
 src.config.system_config,1,0
 src.core,6,3

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -12,7 +12,7 @@ Encyclopedia while acknowledging that most subsystems remain scaffolding.
 | Delivery state | The codebase is still a development framework: evolution, intelligence, execution, and strategy layers run on mocks; there is no production ingest, risk sizing, or portfolio management. | 【F:docs/DEVELOPMENT_STATUS.md†L7-L35】 |
 | Quality posture | CI passes with 76% coverage, but hotspots include operational metrics, position models, and configuration loaders; runtime validation checks still fail. | 【F:docs/ci_baseline_report.md†L8-L27】【F:docs/technical_debt_assessment.md†L31-L112】 |
 | Debt hotspots | Hollow risk management, unsupervised async tasks, namespace drift, and deprecated exports continue to surface in audits. | 【F:docs/technical_debt_assessment.md†L33-L80】【F:src/core/__init__.py†L11-L51】 |
-| Legacy footprint | Deprecated configs and legacy integration guides remain in the tree, signalling unfinished cleanup. | 【F:src/config/risk_config.py†L1-L8】【F:src/config/evolution_config.py†L1-L8】【F:docs/legacy/README.md†L1-L12】 |
+| Legacy footprint | Canonical risk config has replaced the deprecated shim while the evolution shim and legacy integration guides remain, signalling unfinished cleanup. | 【F:src/config/risk/risk_config.py†L1-L72】【F:src/config/evolution_config.py†L1-L8】【F:docs/legacy/README.md†L1-L12】 |
 
 ## Gaps to close
 
@@ -26,6 +26,8 @@ Encyclopedia while acknowledging that most subsystems remain scaffolding.
   documentation gap, and track remediation progress through CI snapshots.
 - [ ] **Dead code and duplication** – Triage the 168-file dead-code backlog and
   eliminate shim exports so operators see a single canonical API surface.【F:docs/reports/CLEANUP_REPORT.md†L71-L188】
+  - *Progress*: Removed the deprecated `src/config/risk_config.py` shim so risk
+    consumers converge on the canonical configuration module.【F:src/config/risk/risk_config.py†L1-L72】
 
 ## Roadmap cadence
 
@@ -42,6 +44,9 @@ Encyclopedia while acknowledging that most subsystems remain scaffolding.
     - *Progress*: Hardened the SQLite-backed real portfolio monitor with managed
       connections, parameterised statements, and narrowed exception handling to
       surface operational failures instead of masking them.【F:src/trading/portfolio/real_portfolio_monitor.py†L1-L572】
+    - *Progress*: Strategy registry now opens per-operation SQLite connections,
+      raises typed errors, and uses parameterised statements so governance writes
+      are supervised instead of silently swallowed.【F:src/governance/strategy_registry.py†L1-L347】
 - [x] **Context pack refresh** – Replace legacy briefs with the updated context in
   `docs/context/alignment_briefs` so discovery and reviews inherit the same
   narrative reset (this change set).
@@ -82,6 +87,8 @@ Encyclopedia while acknowledging that most subsystems remain scaffolding.
 | [ ] | Roll out deterministic risk API and supervised runtime builder across execution modules | Execution & risk squad | Now/Next → Risk and runtime safety |
 | [ ] | Expand CI to cover ingest orchestration, risk policies, and observability guardrails | Quality guild | Now → Quality and observability |
 | [ ] | Purge deprecated shims and close dead-code backlog | Platform hygiene crew | Later → Dead code and duplication |
+
+- *Progress*: Risk configuration now sources exclusively from `src/config/risk/risk_config.py`; the evolution shim remains queued for removal.【F:src/config/risk/risk_config.py†L1-L72】【F:src/config/evolution_config.py†L1-L8】
 
 ## Execution guardrails
 

--- a/docs/status/high_impact_roadmap_detail.md
+++ b/docs/status/high_impact_roadmap_detail.md
@@ -26,14 +26,14 @@ backlog grooming, release readiness reviews, and post-mortems.
    and acceptance tests that demonstrate failover and telemetry parity.
 2. Adopt the runtime builder end to end so ingest, cache warmers, and streaming
    consumers register under supervised tasks instead of ad-hoc loops.
-3. Replace deprecated config shims (`src/config/risk_config.py`,
-   `src/config/evolution_config.py`) with canonical modules throughout the ingest
-   stack to avoid namespace drift.【F:src/config/risk_config.py†L1-L8】【F:src/config/evolution_config.py†L1-L8】
+3. Finish removing deprecated config shims now that the canonical risk
+   configuration lives in `src/config/risk/risk_config.py`; the evolution shim
+   still needs replacement to avoid namespace drift.【F:src/config/risk/risk_config.py†L1-L72】【F:src/config/evolution_config.py†L1-L8】
 
 **Actionable checklist:**
 - [ ] Timescale/Redis/Kafka services provisioned with supervised connectors and failover tests.
 - [ ] Runtime builder adoption complete for ingest, cache warmers, and streaming consumers.
-- [ ] Deprecated config shims replaced with canonical modules across ingest surfaces.【F:src/config/risk_config.py†L1-L8】【F:src/config/evolution_config.py†L1-L8】
+- [ ] Deprecated config shims replaced with canonical modules across ingest surfaces; risk uses `src/config/risk/risk_config.py`, evolution shim remains.【F:src/config/risk/risk_config.py†L1-L72】【F:src/config/evolution_config.py†L1-L8】
 
 **Validation hooks:**
 - Builder-driven smoke test that loads institutional credentials and exercises
@@ -94,7 +94,8 @@ backlog grooming, release readiness reviews, and post-mortems.
 - Runtime entrypoints partially adopt the new builder while legacy modules keep
   spawning unsupervised async tasks, creating shutdown hazards.【F:docs/technical_debt_assessment.md†L33-L56】
 - Public exports advertise helpers that do not exist (`get_risk_manager`), and
-  deprecated config shims remain in the tree.【F:src/core/__init__.py†L11-L51】【F:src/config/risk_config.py†L1-L8】
+  the evolution config shim remains in the tree even after consolidating risk
+  configuration under the canonical module.【F:src/core/__init__.py†L11-L51】【F:src/config/evolution_config.py†L1-L8】
 
 **Gaps to close:**
 1. Finalise the runtime builder migration, introduce a `TaskSupervisor`, and

--- a/src/config/risk_config.py
+++ b/src/config/risk_config.py
@@ -1,8 +1,0 @@
-"""
-Risk Configuration
-Configuration for risk management parameters
-"""
-
-from __future__ import annotations
-
-# Deprecated: use src.core.risk.manager.RiskConfig

--- a/tests/governance/test_strategy_registry.py
+++ b/tests/governance/test_strategy_registry.py
@@ -2,7 +2,10 @@ from types import SimpleNamespace
 
 import pytest
 
-from src.governance.strategy_registry import StrategyRegistry
+from src.governance.strategy_registry import (
+    StrategyRegistry,
+    StrategyRegistryError,
+)
 
 
 def _build_provenance() -> dict[str, object]:
@@ -72,3 +75,11 @@ def test_strategy_registry_records_catalogue_provenance(tmp_path, status: str) -
     assert summary["catalogue_entry_count"] == 1
     assert summary["catalogue_missing_provenance"] == 0
     assert summary["seed_source_counts"].get("catalogue") == 1
+
+
+def test_strategy_registry_surfaces_database_errors(tmp_path) -> None:
+    invalid_path = tmp_path / "registry_dir"
+    invalid_path.mkdir()
+
+    with pytest.raises(StrategyRegistryError):
+        StrategyRegistry(db_path=str(invalid_path))


### PR DESCRIPTION
## Summary
- Harden the strategy registry persistence layer by opening managed SQLite connections, emitting typed errors, and relying on parameterised statements
- Add a governance regression that asserts database failures surface via StrategyRegistryError
- Remove the deprecated risk configuration shim and update roadmap, context briefs, and dependency reports to reflect the canonical risk configuration module

## Testing
- pytest tests/governance/test_strategy_registry.py

------
https://chatgpt.com/codex/tasks/task_e_68db8dc81900832c8334594277def5a4