### PR TITLE
Harden strategy registry security checks

### DIFF
--- a/docs/development/remediation_plan.md
+++ b/docs/development/remediation_plan.md
@@ -38,6 +38,7 @@ Phase 0 — Security P0 Remediations (dedicated, fast-follow PRs)
      - [src/data_foundation/ingest/yahoo_ingest.py](src/data_foundation/ingest/yahoo_ingest.py:66)
      - [src/trading/portfolio/real_portfolio_monitor.py](src/trading/portfolio/real_portfolio_monitor.py:454)
      - [src/trading/portfolio/real_portfolio_monitor.py](src/trading/portfolio/real_portfolio_monitor.py:491)
+     - [src/governance/strategy_registry.py](src/governance/strategy_registry.py:90)
    - Actions:
      - Replace string interpolation/f-strings with parameterized queries or API-native executemany/select constructs.
      - For DuckDB/SQLite, use placeholders (e.g., “?”) and pass parameters list/tuple safely.
@@ -63,6 +64,7 @@ Phase 0 — Security P0 Remediations (dedicated, fast-follow PRs)
    - Files (examples):
      - [src/governance/system_config.py](src/governance/system_config.py:28) → use tempfile.gettempdir() or platformdirs
      - Many operational metrics sites (e.g., [src/operational/metrics.py](src/operational/metrics.py:103)) swallow exceptions
+     - [src/governance/strategy_registry.py](src/governance/strategy_registry.py:112)
    - Actions:
      - Replace os.getenv TMP fallback with stdlib temp APIs.
      - Replace blanket except: with narrow exceptions; log warnings; keep counters.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -42,6 +42,9 @@ Encyclopedia while acknowledging that most subsystems remain scaffolding.
     - *Progress*: Hardened the SQLite-backed real portfolio monitor with managed
       connections, parameterised statements, and narrowed exception handling to
       surface operational failures instead of masking them.【F:src/trading/portfolio/real_portfolio_monitor.py†L1-L572】
+    - *Progress*: Secured the Strategy Registry migrations with static SQL, added
+      targeted exception handling, and logged corrupted payloads so governance
+      operators can diagnose malformed state quickly.【F:src/governance/strategy_registry.py†L1-L374】
 - [x] **Context pack refresh** – Replace legacy briefs with the updated context in
   `docs/context/alignment_briefs` so discovery and reviews inherit the same
   narrative reset (this change set).
@@ -50,6 +53,9 @@ Encyclopedia while acknowledging that most subsystems remain scaffolding.
   - *Progress*: Added an end-to-end regression for the real portfolio monitor to
     exercise data writes, analytics, and reporting flows under pytest, closing a
     previously untested gap in the trading surface.【F:tests/trading/test_real_portfolio_monitor.py†L1-L77】
+  - *Progress*: Extended governance coverage with failure-path tests for the
+    Strategy Registry, asserting telemetry on malformed JSON and ensuring
+    corrupted rows no longer silently pass through dashboards.【F:tests/governance/test_strategy_registry.py†L1-L120】
 
 ### Next (30–90 days)
 


### PR DESCRIPTION
## Summary
- secure the strategy registry schema migration with static SQL statements and targeted database/error handling
- document the security hardening and coverage progress in the roadmap and remediation plan
- extend governance coverage with regression tests that assert telemetry for malformed strategy payloads

## Testing
- pytest tests/governance/test_strategy_registry.py

------
https://chatgpt.com/codex/tasks/task_e_68db8dc81900832c8334594277def5a4