### PR TITLE
Add coverage guardrail regressions for ingest plan helpers and risk config

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -55,6 +55,9 @@ Encyclopedia while acknowledging that most subsystems remain scaffolding.
   - *Progress*: Added an end-to-end regression for the real portfolio monitor to
     exercise data writes, analytics, and reporting flows under pytest, closing a
     previously untested gap in the trading surface.【F:tests/trading/test_real_portfolio_monitor.py†L1-L77】
+  - *Progress*: Landed ingest plan helper tests and a `RiskConfig` extras
+    regression so CI now tracks Timescale plan metadata normalisation alongside
+    deterministic risk enforcement derived from runtime configuration.【F:tests/runtime/test_runtime_ingest_plan_helpers.py†L1-L33】【F:tests/runtime/test_predator_app_risk.py†L1-L35】
 
 ### Next (30–90 days)
 

--- a/tests/runtime/test_predator_app_risk.py
+++ b/tests/runtime/test_predator_app_risk.py
@@ -1,0 +1,48 @@
+from decimal import Decimal
+
+import pytest
+
+from src.config.risk.risk_config import RiskConfig
+from src.runtime.predator_app import _resolve_risk_config
+
+
+def test_resolve_risk_config_respects_extras_overrides() -> None:
+    extras = {
+        "RISK_MAX_TOTAL_EXPOSURE_PCT": "0.25",
+        "RISK_MAX_LEVERAGE": "5.5",
+        "RISK_MIN_POSITION_SIZE": "5000",
+        "RISK_MAX_POSITION_SIZE": "750000",
+        "RISK_MANDATORY_STOP_LOSS": "false",
+        "RISK_RESEARCH_MODE": "true",
+    }
+
+    config = _resolve_risk_config(extras, risk_per_trade=0.05, max_drawdown=0.12)
+
+    assert isinstance(config, RiskConfig)
+    assert config.max_risk_per_trade_pct == Decimal("0.05")
+    assert config.max_total_exposure_pct == Decimal("0.25")
+    assert config.max_leverage == Decimal("5.5")
+    assert config.max_drawdown_pct == Decimal("0.12")
+    assert config.min_position_size == 5000
+    assert config.max_position_size == 750000
+    assert config.mandatory_stop_loss is False
+    assert config.research_mode is True
+
+
+@pytest.mark.parametrize(
+    "extras",
+    [
+        {"RISK_MIN_POSITION_SIZE": "abc", "RISK_MAX_POSITION_SIZE": ""},
+        {"RISK_MANDATORY_STOP_LOSS": "maybe", "RISK_RESEARCH_MODE": "-"},
+        {"RISK_MAX_LEVERAGE": "invalid", "RISK_MAX_TOTAL_EXPOSURE_PCT": "not-a-number"},
+    ],
+)
+def test_resolve_risk_config_falls_back_on_invalid_extras(extras: dict[str, str]) -> None:
+    config = _resolve_risk_config(extras, risk_per_trade=0.02, max_drawdown=0.1)
+
+    assert config.min_position_size == 1
+    assert config.max_position_size == 1_000_000
+    assert config.mandatory_stop_loss is True
+    assert config.research_mode is False
+    assert config.max_leverage == Decimal("10.0")
+    assert config.max_total_exposure_pct == Decimal("0.5")

--- a/tests/runtime/test_runtime_ingest_plan_helpers.py
+++ b/tests/runtime/test_runtime_ingest_plan_helpers.py
@@ -1,0 +1,29 @@
+from src.data_foundation.ingest.timescale_pipeline import (
+    DailyBarIngestPlan,
+    IntradayTradeIngestPlan,
+    MacroEventIngestPlan,
+    TimescaleBackbonePlan,
+)
+from src.runtime.runtime_builder import _normalise_ingest_plan_metadata, _plan_dimensions
+
+
+def test_plan_dimensions_lists_enabled_slices() -> None:
+    plan = TimescaleBackbonePlan(
+        daily=DailyBarIngestPlan(symbols=["EURUSD", " GBPUSD "]),
+        intraday=IntradayTradeIngestPlan(symbols=["EURUSD"], lookback_days=1, interval="5m"),
+        macro=MacroEventIngestPlan(events=({"event": "NFP"},), start="2024-01-01", end="2024-01-02"),
+    )
+
+    assert _plan_dimensions(plan) == ["daily_bars", "intraday_trades", "macro_events"]
+
+
+def test_normalise_ingest_plan_metadata_handles_structures() -> None:
+    mapping_result = _normalise_ingest_plan_metadata({"daily_bars": {"symbols": ["EURUSD"]}})
+    sequence_result = _normalise_ingest_plan_metadata(["intraday_trades", "macro_events"])
+    scalar_result = _normalise_ingest_plan_metadata("daily_bars")
+    none_result = _normalise_ingest_plan_metadata(None)
+
+    assert mapping_result == ["daily_bars"]
+    assert sequence_result == ["intraday_trades", "macro_events"]
+    assert scalar_result == ["daily_bars"]
+    assert none_result == []


### PR DESCRIPTION
## Summary
- add runtime ingest plan helper regression tests documenting plan dimension extraction and metadata normalisation
- exercise RiskConfig extras resolution so CI enforces deterministic risk guardrails derived from runtime configuration
- note the new coverage guardrail progress in the roadmap tracking document

## Testing
- pytest tests/runtime/test_predator_app_risk.py tests/runtime/test_runtime_ingest_plan_helpers.py

------
https://chatgpt.com/codex/tasks/task_e_68db916d1fa8832cad2b26ab8cb6ad00