### PR TITLE
Expand risk policy regression coverage

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -55,6 +55,10 @@ Encyclopedia while acknowledging that most subsystems remain scaffolding.
   - *Progress*: Added an end-to-end regression for the real portfolio monitor to
     exercise data writes, analytics, and reporting flows under pytest, closing a
     previously untested gap in the trading surface.【F:tests/trading/test_real_portfolio_monitor.py†L1-L77】
+  - *Progress*: Hardened risk policy coverage with regressions that enforce
+    stop-loss mandates, reuse canonical position pricing, and validate equity
+    derivation from cash + exposure so policy thresholds stay deterministic in
+    CI.【F:tests/trading/test_risk_policy.py†L73-L138】
 
 ### Next (30–90 days)
 


### PR DESCRIPTION
## Summary
- add risk policy regression tests covering canonical price resolution, mandatory stop-loss enforcement, and equity derivation
- document roadmap progress for coverage guardrails with the new scenarios

## Testing
- pytest tests/trading/test_risk_policy.py

------
https://chatgpt.com/codex/tasks/task_e_68db916d1fa8832cad2b26ab8cb6ad00