### PR TITLE
Tighten event bus health publish fallback handling

### DIFF
--- a/src/operations/event_bus_health.py
+++ b/src/operations/event_bus_health.py
@@ -249,10 +249,15 @@ def publish_event_bus_health(event_bus: EventBus, snapshot: EventBusHealthSnapsh
                 "Primary event bus publish_from_sync failed; falling back to global bus",
                 exc_info=exc,
             )
-        except Exception:  # pragma: no cover - unexpected failure path
+        except Exception:
+            # Unexpected failures should surface instead of being silently
+            # swallowed behind the fallback path so operators see the root
+            # cause. This keeps the remediation-plan promise of tightening
+            # blanket exception handlers in operational modules.
             logger.exception(
-                "Unexpected error publishing event bus health; falling back to global bus",
+                "Unexpected error publishing event bus health from primary bus",
             )
+            raise
         else:
             if publish_result is not None:
                 return


### PR DESCRIPTION
## Summary
- ensure unexpected failures from `publish_from_sync` bubble up instead of being swallowed by the health publisher
- extend the event bus health regression tests to cover fallback behaviour and unexpected error propagation

## Testing
- pytest tests/operations/test_event_bus_health.py

------
https://chatgpt.com/codex/tasks/task_e_68dbbb8d8ddc832cafc57adc7afe1410