### PR TITLE
Align trading runtime with deterministic risk manager

### DIFF
--- a/src/trading/trading_manager.py
+++ b/src/trading/trading_manager.py
@@ -16,7 +16,7 @@ except Exception:  # pragma: no cover
 
 from src.config.risk.risk_config import RiskConfig as TradingRiskConfig
 from src.core.coercion import coerce_float, coerce_int
-from src.risk.real_risk_manager import RealRiskConfig, RealRiskManager
+from src.core.risk.manager import RiskManager, get_risk_manager
 from src.risk.telemetry import (
     RiskTelemetrySnapshot,
     evaluate_risk_posture,
@@ -121,14 +121,10 @@ class TradingManager:
             }
         )
         self._risk_config = effective_config
-        risk_manager_config = RealRiskConfig(
-            max_position_risk=float(effective_config.max_risk_per_trade_pct),
-            max_total_exposure=float(effective_config.max_total_exposure_pct),
-            max_drawdown=float(effective_config.max_drawdown_pct),
-            max_leverage=float(effective_config.max_leverage),
-            equity=float(initial_equity),
+        self._portfolio_risk_manager: RiskManager = get_risk_manager(
+            config=effective_config,
+            initial_balance=initial_equity,
         )
-        self._portfolio_risk_manager = RealRiskManager(risk_manager_config)
         self._risk_policy = risk_policy or RiskPolicy.from_config(effective_config)
         self._last_policy_snapshot: RiskPolicyEvaluationSnapshot | None = None
 


### PR DESCRIPTION
## Summary
- switch the trading manager to the RiskManager facade so trade validation uses deterministic limits
- expose update_equity, assess_risk, and last_snapshot on RiskManagerImpl for downstream integrations

## Testing
- pytest tests/trading/test_trading_manager_execution.py

------
https://chatgpt.com/codex/tasks/task_e_68dbc27d68e4832cabcb2215e89e791e