### PR TITLE
Harden JSONL writer error handling

### DIFF
--- a/src/data_foundation/persist/jsonl_writer.py
+++ b/src/data_foundation/persist/jsonl_writer.py
@@ -1,15 +1,43 @@
 from __future__ import annotations
 
 import json
+import logging
 import os
+from contextlib import suppress
+
+
+logger = logging.getLogger(__name__)
+
+
+class JsonlWriterError(RuntimeError):
+    """Raised when JSONL persistence fails."""
 
 
 def write_events_jsonl(events: list[dict[str, object]], out_path: str) -> str:
+    """Persist a list of event dictionaries to a JSONL file.
+
+    The implementation avoids swallowing unexpected exceptions so operational
+    tooling sees genuine filesystem/serialisation failures instead of silently
+    receiving an empty path.
+    """
+
     os.makedirs(os.path.dirname(out_path) or ".", exist_ok=True)
+
     try:
         with open(out_path, "w", encoding="utf-8") as fh:
-            for e in events:
-                fh.write(json.dumps(e) + "\n")
-        return out_path
-    except Exception:
-        return ""
+            for event in events:
+                try:
+                    payload = json.dumps(event)
+                except (TypeError, ValueError) as exc:  # defensive against unsafe payloads
+                    logger.error("Event payload is not JSON serialisable for %s: %s", out_path, exc)
+                    raise JsonlWriterError("Event payload is not JSON serialisable") from exc
+                fh.write(f"{payload}\n")
+    except JsonlWriterError:
+        with suppress(OSError):
+            os.remove(out_path)
+        raise
+    except OSError as exc:
+        logger.error("Failed to write events JSONL to %s: %s", out_path, exc)
+        raise JsonlWriterError(f"Failed to write JSONL to {out_path}") from exc
+
+    return out_path

--- a/tests/data_foundation/test_jsonl_writer.py
+++ b/tests/data_foundation/test_jsonl_writer.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from src.data_foundation.persist.jsonl_writer import JsonlWriterError, write_events_jsonl
+
+
+def test_write_events_jsonl_success(tmp_path: Path) -> None:
+    out_path = tmp_path / "events.jsonl"
+    events = [{"symbol": "EURUSD", "price": 1.1234}, {"symbol": "GBPUSD", "price": 1.2567}]
+
+    result = write_events_jsonl(events, str(out_path))
+
+    assert Path(result).exists()
+    contents = out_path.read_text(encoding="utf-8").splitlines()
+    assert [json.loads(line) for line in contents] == events
+
+
+def test_write_events_jsonl_raises_for_unserialisable_payload(tmp_path: Path) -> None:
+    out_path = tmp_path / "events.jsonl"
+    events = [{"callback": lambda: None}]
+
+    with pytest.raises(JsonlWriterError):
+        write_events_jsonl(events, str(out_path))
+
+    assert not out_path.exists()
+
+
+def test_write_events_jsonl_raises_for_os_errors(tmp_path: Path) -> None:
+    output_dir = tmp_path / "target"
+    output_dir.mkdir()
+
+    with pytest.raises(JsonlWriterError):
+        write_events_jsonl([{"symbol": "EURUSD"}], str(output_dir))


### PR DESCRIPTION
## Summary
- harden the JSONL event writer to raise explicit errors and log serialization issues instead of silently returning an empty path
- clean up partial files on serialization failure and surface filesystem errors as JsonlWriterError
- add regression tests covering successful writes, serialization errors, and OS errors

## Testing
- pytest tests/data_foundation/test_jsonl_writer.py


------
https://chatgpt.com/codex/tasks/task_e_68dbd11f0594832ca737ebba724a964e