### PR TITLE
Add sensory lineage telemetry for HOW and ANOMALY sensors

### DIFF
--- a/src/sensory/lineage.py
+++ b/src/sensory/lineage.py
@@ -1,0 +1,99 @@
+"""Lineage helpers for sensory telemetry.
+
+The roadmap calls for executable sensory organs that surface lineage telemetry
+alongside their primary readings so downstream systems can trace how signals
+were produced.  This module provides a small, serialization-safe container that
+the HOW/ANOMALY sensors can embed inside their metadata payloads.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from datetime import date, datetime
+from decimal import Decimal
+from typing import Any, MutableMapping
+
+__all__ = ["SensorLineageRecord", "build_lineage_record"]
+
+
+def _coerce_value(value: Any) -> Any:
+    """Convert *value* into a JSON-serialisable primitive."""
+
+    if value is None:
+        return None
+    if isinstance(value, (str, int, float, bool)):
+        return value
+    if isinstance(value, Decimal):
+        return float(value)
+    if isinstance(value, datetime):
+        return value.isoformat()
+    if isinstance(value, date):
+        return datetime.combine(value, datetime.min.time()).isoformat()
+    if isinstance(value, Mapping):
+        return {str(key): _coerce_value(val) for key, val in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_coerce_value(item) for item in value]
+
+    try:
+        return float(value)  # type: ignore[arg-type]
+    except (TypeError, ValueError):
+        return str(value)
+
+
+def _sanitise_mapping(mapping: Mapping[str, Any] | None) -> dict[str, Any]:
+    cleaned: MutableMapping[str, Any] = {}
+    if not mapping:
+        return {}
+    for key, value in mapping.items():
+        try:
+            cleaned[str(key)] = _coerce_value(value)
+        except Exception:
+            cleaned[str(key)] = "<unserialisable>"
+    return dict(cleaned)
+
+
+@dataclass(slots=True, frozen=True)
+class SensorLineageRecord:
+    """Immutable snapshot describing how a sensory signal was produced."""
+
+    dimension: str
+    source: str
+    inputs: Mapping[str, Any]
+    outputs: Mapping[str, Any]
+    telemetry: Mapping[str, Any] = field(default_factory=dict)
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+    generated_at: datetime = field(default_factory=datetime.utcnow)
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "dimension": self.dimension,
+            "source": self.source,
+            "generated_at": self.generated_at.isoformat(),
+            "inputs": _sanitise_mapping(self.inputs),
+            "outputs": _sanitise_mapping(self.outputs),
+            "telemetry": _sanitise_mapping(self.telemetry),
+            "metadata": _sanitise_mapping(self.metadata),
+        }
+
+
+def build_lineage_record(
+    dimension: str,
+    source: str,
+    *,
+    inputs: Mapping[str, Any] | None = None,
+    outputs: Mapping[str, Any] | None = None,
+    telemetry: Mapping[str, Any] | None = None,
+    metadata: Mapping[str, Any] | None = None,
+) -> SensorLineageRecord:
+    """Create a :class:`SensorLineageRecord` with sanitised payloads."""
+
+    return SensorLineageRecord(
+        dimension=dimension,
+        source=source,
+        inputs=dict(inputs or {}),
+        outputs=dict(outputs or {}),
+        telemetry=dict(telemetry or {}),
+        metadata=dict(metadata or {}),
+    )
+

--- a/tests/sensory/test_how_anomaly_sensors.py
+++ b/tests/sensory/test_how_anomaly_sensors.py
@@ -50,6 +50,13 @@ def test_how_sensor_emits_liquidity_audit() -> None:
     audit = metadata.get("audit")
     assert isinstance(audit, dict)
     assert set(audit.keys()) >= {"signal", "confidence", "liquidity", "participation"}
+    lineage = metadata.get("lineage")
+    assert isinstance(lineage, dict)
+    assert lineage.get("dimension") == "HOW"
+    assert lineage.get("source") == "sensory.how"
+    assert lineage.get("inputs", {}).get("symbol") == "EURUSD"
+    assert "liquidity" in lineage.get("telemetry", {})
+    assert lineage.get("metadata", {}).get("mode") == "market_data"
 
 
 def test_anomaly_sensor_sequence_mode_detects_spike() -> None:
@@ -65,6 +72,11 @@ def test_anomaly_sensor_sequence_mode_detects_spike() -> None:
     assert metadata.get("mode") == "sequence"
     assert metadata.get("thresholds") == {"warn": 0.4, "alert": 0.7}
     assert signal.value["strength"] >= 0.0
+    lineage = metadata.get("lineage")
+    assert isinstance(lineage, dict)
+    assert lineage.get("metadata", {}).get("mode") == "sequence"
+    assert lineage.get("inputs", {}).get("sequence_length") == 12
+    assert "baseline" in lineage.get("telemetry", {})
 
 
 def test_anomaly_sensor_falls_back_to_market_payload() -> None:
@@ -78,3 +90,7 @@ def test_anomaly_sensor_falls_back_to_market_payload() -> None:
     metadata = signal.metadata or {}
     assert metadata.get("mode") == "market_data"
     assert "baseline" in metadata.get("audit", {})
+    lineage = metadata.get("lineage")
+    assert isinstance(lineage, dict)
+    assert lineage.get("metadata", {}).get("mode") == "market_data"
+    assert lineage.get("inputs", {}).get("symbol") == "EURUSD"

--- a/tests/sensory/test_lineage.py
+++ b/tests/sensory/test_lineage.py
@@ -1,0 +1,28 @@
+from datetime import datetime, timezone
+from decimal import Decimal
+
+from src.sensory.lineage import build_lineage_record
+
+
+def test_build_lineage_record_sanitises_inputs() -> None:
+    record = build_lineage_record(
+        "HOW",
+        "sensory.how",
+        inputs={
+            "timestamp": datetime(2024, 1, 1, tzinfo=timezone.utc),
+            "volume": Decimal("123.45"),
+        },
+        outputs={"signal": 0.5, "confidence": 0.75},
+        telemetry={"liquidity": Decimal("0.9")},
+        metadata={"mode": "market_data"},
+    )
+
+    payload = record.as_dict()
+    assert payload["dimension"] == "HOW"
+    assert payload["source"] == "sensory.how"
+    assert payload["inputs"]["timestamp"].endswith("+00:00")
+    assert payload["inputs"]["volume"] == 123.45
+    assert payload["outputs"] == {"signal": 0.5, "confidence": 0.75}
+    assert payload["telemetry"]["liquidity"] == 0.9
+    assert payload["metadata"]["mode"] == "market_data"
+    assert "generated_at" in payload


### PR DESCRIPTION
## Summary
- introduce a reusable SensorLineageRecord helper to capture sanitised lineage payloads for sensory readings
- attach lineage snapshots to HOW and ANOMALY sensor metadata alongside existing audit details
- extend sensory regression tests to validate lineage exposure and add targeted coverage for the lineage helper

## Testing
- pytest tests/sensory/test_how_anomaly_sensors.py tests/sensory/test_lineage.py


------
https://chatgpt.com/codex/tasks/task_e_68dbe262a124832c84028aa9d4266bda