### PR TITLE
Refresh roadmap for sensory lineage and governance cadence updates

### DIFF
--- a/docs/context/alignment_briefs/institutional_data_backbone.md
+++ b/docs/context/alignment_briefs/institutional_data_backbone.md
@@ -48,6 +48,9 @@
   unserialisable payloads, logs filesystem failures, and deletes partial files so
   ingest tooling reports genuine write issues instead of silently returning empty
   paths.【F:src/data_foundation/persist/jsonl_writer.py†L1-L69】【F:tests/data_foundation/test_jsonl_writer.py†L1-L37】
+- Progress: Timescale ingest regression now covers migrator bootstrap,
+  idempotent upserts for empty plans, and macro event ingestion so coverage
+  catches silent failures before institutional pipelines depend on them.【F:tests/data_foundation/test_timescale_ingest.py†L1-L213】
 - Wire all runtime entrypoints through `RuntimeApplication` and a task supervisor
   so ingest, cache, and stream jobs are supervised.【F:docs/technical_debt_assessment.md†L33-L56】
 - Document current gaps and expected telemetry in updated runbooks and status

--- a/docs/context/alignment_briefs/institutional_risk_compliance.md
+++ b/docs/context/alignment_briefs/institutional_risk_compliance.md
@@ -41,6 +41,10 @@
 - Progress: Risk policy regression enforces mandatory stop losses, positive
   equity budgets, and violation telemetry so CI fails fast when policy guardrails
   drift, keeping execution blockers visible to compliance reviewers.【F:src/trading/risk/risk_policy.py†L120-L246】【F:tests/trading/test_risk_policy.py†L117-L157】
+- Progress: Compliance readiness snapshots now consolidate trade surveillance and
+  KYC telemetry, escalate severities deterministically, and expose markdown
+  evidence with pytest guardrails so governance cadences inherit truthful
+  compliance posture summaries.【F:src/operations/compliance_readiness.py†L1-L220】【F:tests/operations/test_compliance_readiness.py†L1-L173】
 
 ### Next (30–90 days)
 
@@ -50,6 +54,10 @@
     canonical deterministic facade and exposes the core engine’s snapshot and
     assessment hooks so execution flows share the same enforcement path as the
     runtime builder.【F:src/trading/trading_manager.py†L105-L147】【F:src/risk/risk_manager_impl.py†L533-L573】
+- Progress: Governance cadence runner orchestrates interval gating, audit
+  evidence collection, report persistence, and event-bus publishing so the
+  compliance squad has a single supervised entrypoint for regulatory reporting
+  under pytest coverage.【F:src/operations/governance_cadence.py†L1-L167】【F:tests/operations/test_governance_cadence.py†L1-L206】
 - Wire compliance workflows (KYC, trade surveillance) with markdown exports and
   optional Timescale journaling to satisfy audit requirements.
 - Complete runtime builder adoption so FIX pilots, simulators, and eventual live

--- a/docs/context/alignment_briefs/quality_observability.md
+++ b/docs/context/alignment_briefs/quality_observability.md
@@ -59,6 +59,9 @@
     fallbacks, raises on unexpected errors, and escalates global bus outages with
     pytest coverage so data backbone dashboards expose genuine gaps instead of
     silently skipping degraded snapshots.【F:src/operations/ingest_trends.py†L303-L336】【F:tests/operations/test_ingest_trends.py†L90-L148】
+  - Progress: Timescale ingest regressions now cover migrator bootstrap,
+    idempotent upserts for empty/changed plans, and macro event ingestion so
+    coverage catches silent failures across institutional ingest windows.【F:tests/data_foundation/test_timescale_ingest.py†L1-L213】
   - Progress: Cache health publishing now logs primary bus errors, only falls back
     when runtime failures occur, and raises on unexpected or global-bus outages
     under pytest guardrails so readiness telemetry surfaces real cache incidents

--- a/docs/context/alignment_briefs/sensory_cortex.md
+++ b/docs/context/alignment_briefs/sensory_cortex.md
@@ -17,6 +17,10 @@
   underscoring the lack of executable coverage.【F:docs/reports/CLEANUP_REPORT.md†L71-L175】
 - Technical debt priorities call out async hazards and namespace drift that block
   reliable runtime wiring for sensory subscriptions.【F:docs/technical_debt_assessment.md†L33-L80】
+- HOW and ANOMALY organs now emit sanitised lineage records with threshold
+  metadata and deterministic telemetry so downstream consumers can trace signal
+  provenance under pytest coverage, though inputs remain synthetic until the
+  ingest backbone is live.【F:src/sensory/how/how_sensor.py†L1-L140】【F:src/sensory/anomaly/anomaly_sensor.py†L1-L163】【F:src/sensory/lineage.py†L1-L87】【F:tests/sensory/test_how_anomaly_sensors.py†L1-L134】【F:tests/sensory/test_lineage.py†L1-L143】
 
 ## Gap themes
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -49,6 +49,10 @@ Encyclopedia while acknowledging that most subsystems remain scaffolding.
     exception capture, markdown fallback logging, and pytest scenarios that
     simulate transport failures so dashboards and runbooks inherit reliable
     snapshots of paper-trading ROI and backlog posture.【F:src/operations/evolution_experiments.py†L40-L196】【F:tests/operations/test_evolution_experiments.py†L1-L126】
+  - *Progress*: HOW and ANOMALY sensors now embed sanitised lineage records,
+    propagate threshold metadata, and expose deterministic telemetry snapshots so
+    downstream consumers can audit signal provenance, with pytest coverage across
+    lineage coercion and sensory processing flows.【F:src/sensory/how/how_sensor.py†L1-L140】【F:src/sensory/anomaly/anomaly_sensor.py†L1-L163】【F:src/sensory/lineage.py†L1-L87】【F:tests/sensory/test_how_anomaly_sensors.py†L1-L134】【F:tests/sensory/test_lineage.py†L1-L143】
 - [ ] **Risk and runtime safety** – Enforce `RiskConfig`, finish the builder rollout,
   adopt supervised async lifecycles, and purge deprecated facades.
   - *Progress*: The trading risk gateway now drives portfolio checks through the
@@ -159,6 +163,9 @@ Encyclopedia while acknowledging that most subsystems remain scaffolding.
   - *Progress*: Trading position model guardrails now run under pytest,
     asserting timestamp updates, profit recalculations, and close flows so the
     lightweight execution telemetry remains deterministic under CI coverage.【F:tests/trading/test_position_model_guardrails.py†L1-L105】
+  - *Progress*: Timescale ingest coverage now exercises migrator setup, idempotent
+    daily/intraday upserts, and macro event pathways so empty plans and windowed
+    flows keep writing deterministic telemetry under CI guardrails.【F:tests/data_foundation/test_timescale_ingest.py†L1-L213】
 
 ### Next (30–90 days)
 
@@ -190,6 +197,14 @@ Encyclopedia while acknowledging that most subsystems remain scaffolding.
     publishes the snapshot on the event bus, and trims persisted histories so
     audits inherit deterministic evidence, with pytest covering scheduling,
     publishing, and storage flows.【F:src/operations/governance_reporting.py†L1-L200】【F:tests/operations/test_governance_reporting.py†L1-L152】
+  - *Progress*: Compliance readiness snapshots now normalise trade-surveillance and
+    KYC components, escalate severities deterministically, and render markdown
+    evidence with regression coverage so governance cadences inherit reliable
+    compliance posture telemetry.【F:src/operations/compliance_readiness.py†L1-L220】【F:tests/operations/test_compliance_readiness.py†L1-L173】
+  - *Progress*: Governance cadence runner orchestrates interval gating, audit
+    evidence collection, report persistence, and event-bus publishing with
+    injectable providers so institutional deployments can trigger the cadence
+    from a single supervised entrypoint under pytest coverage.【F:src/operations/governance_cadence.py†L1-L167】【F:tests/operations/test_governance_cadence.py†L1-L206】
 
 ## Actionable to-do tracker
 


### PR DESCRIPTION
## Summary
- document the new sensory lineage telemetry, ingest coverage guardrails, and governance cadence orchestration in the roadmap
- refresh the sensory cortex, institutional data backbone, risk/compliance, and quality/observability briefs to reflect the latest telemetry and regression coverage

## Testing
- not run (documentation updates only)

------
https://chatgpt.com/codex/tasks/task_e_68dbe423b820832c8659f70fdfd31253