### PR TITLE
Expand coverage telemetry domain mapping for additional subsystems

### DIFF
--- a/tools/telemetry/coverage_matrix.py
+++ b/tools/telemetry/coverage_matrix.py
@@ -10,19 +10,42 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import Iterable, Sequence
 
+_TRACKED_DOMAINS: tuple[str, ...] = (
+    "core",
+    "data_foundation",
+    "sensory",
+    "trading",
+    "risk",
+    "operations",
+    "operational",
+    "observability",
+    "runtime",
+    "evolution",
+    "compliance",
+    "strategies",
+    "intelligence",
+    "governance",
+    "data_integration",
+    "data_sources",
+    "ecosystem",
+    "market_intelligence",
+    "performance",
+    "portfolio",
+    "simulation",
+    "orchestration",
+    "validation",
+    "deployment",
+    "integration",
+    "domain",
+    "thinking",
+    "testing",
+    "structlog",
+    "system",
+    "ui",
+)
+
 _DOMAIN_PREFIXES: dict[tuple[str, ...], str] = {
-    ("src", "core"): "core",
-    ("src", "data_foundation"): "data_foundation",
-    ("src", "sensory"): "sensory",
-    ("src", "trading"): "trading",
-    ("src", "risk"): "risk",
-    ("src", "operations"): "operations",
-    ("src", "operational"): "operational",
-    ("src", "observability"): "observability",
-    ("src", "runtime"): "runtime",
-    ("src", "evolution"): "evolution",
-    ("src", "compliance"): "compliance",
-    ("src", "strategies"): "strategies",
+    ("src", domain): domain for domain in _TRACKED_DOMAINS
 }
 
 


### PR DESCRIPTION
## Summary
- extend the coverage telemetry domain catalogue so reports recognise newer subsystems such as intelligence and governance
- update the coverage matrix regression suite to cover the expanded domain mapping and refreshed totals

## Testing
- pytest tests/tools/test_coverage_matrix.py

------
https://chatgpt.com/codex/tasks/task_e_68dc10256578832cb0343f5b7af14a3d