### PR TITLE
Gate adaptive evolution runs behind feature flag

### DIFF
--- a/src/evolution/__init__.py
+++ b/src/evolution/__init__.py
@@ -23,6 +23,7 @@ from src.evolution.catalogue_telemetry import (
     EvolutionCatalogueSnapshot,
     build_catalogue_snapshot,
 )
+from src.evolution.feature_flags import EvolutionFeatureFlags
 from src.evolution.lineage_telemetry import (
     EvolutionLineageSnapshot,
     build_lineage_snapshot,
@@ -44,4 +45,5 @@ __all__ = [
     "build_catalogue_snapshot",
     "EvolutionLineageSnapshot",
     "build_lineage_snapshot",
+    "EvolutionFeatureFlags",
 ]

--- a/src/evolution/feature_flags.py
+++ b/src/evolution/feature_flags.py
@@ -1,0 +1,44 @@
+"""Feature flag helpers for evolution experiments and adaptive runs."""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from typing import Mapping
+
+ADAPTIVE_RUNS_FLAG = "EVOLUTION_ENABLE_ADAPTIVE_RUNS"
+_TRUTHY = {"1", "true", "yes", "on", "enable", "enabled"}
+
+
+def _coerce_bool(value: object) -> bool:
+    """Normalise loose flag values into a strict boolean."""
+
+    if isinstance(value, bool):
+        return value
+    if value is None:
+        return False
+    if isinstance(value, (int, float)):
+        return bool(value)
+    if isinstance(value, str):
+        return value.strip().lower() in _TRUTHY
+    return False
+
+
+@dataclass(slots=True)
+class EvolutionFeatureFlags:
+    """Resolve evolution feature flags with optional overrides for tests."""
+
+    env: Mapping[str, str] | None = None
+
+    def adaptive_runs_enabled(self, override: bool | None = None) -> bool:
+        """Return whether adaptive evolution runs are enabled."""
+
+        if override is not None:
+            return bool(override)
+
+        source = self.env if self.env is not None else os.environ
+        raw = source.get(ADAPTIVE_RUNS_FLAG)
+        return _coerce_bool(raw)
+
+
+__all__ = ["EvolutionFeatureFlags", "ADAPTIVE_RUNS_FLAG"]

--- a/tests/evolution/test_feature_flags.py
+++ b/tests/evolution/test_feature_flags.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+import pytest
+
+from src.evolution.feature_flags import ADAPTIVE_RUNS_FLAG, EvolutionFeatureFlags
+
+
+@pytest.fixture(autouse=True)
+def _clear_flags(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv(ADAPTIVE_RUNS_FLAG, raising=False)
+
+
+def test_adaptive_runs_disabled_by_default() -> None:
+    flags = EvolutionFeatureFlags()
+    assert flags.adaptive_runs_enabled() is False
+
+
+def test_adaptive_runs_enabled_via_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(ADAPTIVE_RUNS_FLAG, "yes")
+    flags = EvolutionFeatureFlags()
+    assert flags.adaptive_runs_enabled() is True
+
+
+def test_adaptive_runs_override_and_custom_env() -> None:
+    flags = EvolutionFeatureFlags(env={ADAPTIVE_RUNS_FLAG: "on"})
+    assert flags.adaptive_runs_enabled() is True
+    assert flags.adaptive_runs_enabled(override=False) is False


### PR DESCRIPTION
## Summary
- add an EvolutionFeatureFlags helper to centralize the EVOLUTION_ENABLE_ADAPTIVE_RUNS gate
- update the EvolutionCycleOrchestrator to honour the feature flag, produce static summaries when disabled, and publish telemetry updates
- extend the orchestration test suite with coverage for the new flag behaviour and add focused unit tests for the resolver

## Testing
- pytest tests/evolution/test_feature_flags.py tests/current/test_evolution_orchestrator.py


------
https://chatgpt.com/codex/tasks/task_e_68dc10256578832cb0343f5b7af14a3d