### PR TITLE
Centralize operational event bus failover handling

### DIFF
--- a/src/operations/event_bus_failover.py
+++ b/src/operations/event_bus_failover.py
@@ -1,0 +1,86 @@
+"""Helpers for securely publishing operational telemetry events.
+
+These utilities centralise the guarded publish-from-runtime → fall back to global
+bus pattern so individual modules do not need to implement their own blanket
+``except Exception`` handling.  The helpers log contextual warnings for expected
+failure modes and raise a typed :class:`EventPublishError` when an unexpected
+exception bubbles up.  This keeps the telemetry path explicit while satisfying
+the security roadmap requirement to replace broad exception handlers in
+operational modules.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Callable
+
+from src.core.event_bus import Event, EventBus, TopicBus, get_global_bus
+
+__all__ = [
+    "EventPublishError",
+    "publish_event_with_failover",
+]
+
+
+@dataclass(slots=True)
+class EventPublishError(RuntimeError):
+    """Raised when an event cannot be published via the runtime or global bus."""
+
+    stage: str
+    event_type: str
+
+    def __post_init__(self) -> None:
+        RuntimeError.__init__(
+            self,
+            f"Failed to publish event {self.event_type!r} via {self.stage} bus",
+        )
+
+
+def publish_event_with_failover(
+    event_bus: EventBus,
+    event: Event,
+    *,
+    logger: logging.Logger,
+    runtime_fallback_message: str,
+    runtime_unexpected_message: str,
+    runtime_none_message: str,
+    global_not_running_message: str,
+    global_unexpected_message: str,
+    global_bus_factory: Callable[[], TopicBus] | None = None,
+) -> None:
+    """Publish ``event`` using ``event_bus`` with a deterministic fallback.
+
+    The helper mirrors the operational telemetry contract used across multiple
+    modules: attempt to publish via the runtime bus when available and fall back
+    to the global topic bus if the runtime path rejects the event.  Unexpected
+    exceptions from either bus are wrapped in :class:`EventPublishError` to keep
+    the calling code free from blanket ``except Exception`` clauses.
+    """
+
+    publish_from_sync = getattr(event_bus, "publish_from_sync", None)
+    if callable(publish_from_sync) and event_bus.is_running():
+        try:
+            result = publish_from_sync(event)
+        except RuntimeError as exc:
+            logger.warning(runtime_fallback_message, exc_info=exc)
+        except Exception as exc:  # pragma: no cover - defensive guardrail
+            logger.exception(runtime_unexpected_message, exc_info=exc)
+            raise EventPublishError("runtime", event.type) from exc
+        else:
+            if result is None:
+                logger.warning(runtime_none_message)
+            else:
+                return
+
+    factory = global_bus_factory or get_global_bus
+
+    try:
+        topic_bus = factory()
+        topic_bus.publish_sync(event.type, event.payload, source=event.source)
+    except RuntimeError as exc:
+        logger.error(global_not_running_message, exc_info=exc)
+        raise EventPublishError("global", event.type) from exc
+    except Exception as exc:  # pragma: no cover - defensive guardrail
+        logger.exception(global_unexpected_message, exc_info=exc)
+        raise EventPublishError("global", event.type) from exc

--- a/src/operations/security.py
+++ b/src/operations/security.py
@@ -8,7 +8,8 @@ from datetime import UTC, datetime
 from enum import StrEnum
 from typing import Mapping, MutableMapping, Sequence
 
-from src.core.event_bus import Event, EventBus, get_global_bus
+from src.core.event_bus import Event, EventBus
+from src.operations.event_bus_failover import publish_event_with_failover
 
 
 logger = logging.getLogger(__name__)
@@ -542,41 +543,21 @@ def publish_security_posture(event_bus: EventBus, snapshot: SecurityPostureSnaps
         source="operations.security",
     )
 
-    publish_from_sync = getattr(event_bus, "publish_from_sync", None)
-    if callable(publish_from_sync) and event_bus.is_running():
-        try:
-            publish_result = publish_from_sync(event)
-        except RuntimeError as exc:
-            logger.warning(
-                "Primary event bus publish_from_sync failed; falling back to global bus",
-                exc_info=exc,
-            )
-        except Exception:
-            logger.exception(
-                "Unexpected error publishing security posture via runtime event bus",
-            )
-            raise
-        else:
-            if publish_result is not None:
-                return
-            logger.warning(
-                "Primary event bus publish_from_sync returned None; falling back to global bus",
-            )
-
-    topic_bus = get_global_bus()
-    try:
-        topic_bus.publish_sync(event.type, event.payload, source=event.source)
-    except RuntimeError as exc:
-        logger.error(
-            "Global event bus not running while publishing security posture snapshot",
-            exc_info=exc,
-        )
-        raise
-    except Exception:
-        logger.exception(
-            "Unexpected error publishing security posture snapshot via global bus",
-        )
-        raise
+    publish_event_with_failover(
+        event_bus,
+        event,
+        logger=logger,
+        runtime_fallback_message=
+        "Primary event bus publish_from_sync failed; falling back to global bus",
+        runtime_unexpected_message=
+        "Unexpected error publishing security posture via runtime event bus",
+        runtime_none_message=
+        "Primary event bus publish_from_sync returned None; falling back to global bus",
+        global_not_running_message=
+        "Global event bus not running while publishing security posture snapshot",
+        global_unexpected_message=
+        "Unexpected error publishing security posture snapshot via global bus",
+    )
 
 
 __all__ = [

--- a/tests/operations/test_event_bus_failover.py
+++ b/tests/operations/test_event_bus_failover.py
@@ -1,0 +1,127 @@
+import logging
+from collections.abc import Callable
+from typing import Any
+
+import pytest
+
+from src.core.event_bus import Event
+from src.operations.event_bus_failover import EventPublishError, publish_event_with_failover
+
+
+class _StubEventBus:
+    def __init__(self, *, running: bool = True) -> None:
+        self.events: list[Event] = []
+        self._running = running
+        self.publish_from_sync: Callable[[Event], Any] | None = self._publish  # type: ignore[assignment]
+
+    def _publish(self, event: Event) -> int:
+        self.events.append(event)
+        return 1
+
+    def is_running(self) -> bool:
+        return self._running
+
+
+class _StubTopicBus:
+    def __init__(self) -> None:
+        self.events: list[tuple[str, Any, str | None]] = []
+
+    def publish_sync(self, event_type: str, payload: Any, *, source: str | None = None) -> None:
+        self.events.append((event_type, payload, source))
+
+
+def _event() -> Event:
+    return Event(type="telemetry.test", payload={"ok": True}, source="test")
+
+
+def test_publish_event_with_failover_prefers_runtime_bus() -> None:
+    bus = _StubEventBus()
+    topic_bus = _StubTopicBus()
+
+    publish_event_with_failover(
+        bus,
+        _event(),
+        logger=logging.getLogger("test"),
+        runtime_fallback_message="runtime fallback",
+        runtime_unexpected_message="runtime unexpected",
+        runtime_none_message="runtime none",
+        global_not_running_message="global missing",
+        global_unexpected_message="global unexpected",
+        global_bus_factory=lambda: topic_bus,
+    )
+
+    assert len(bus.events) == 1
+    assert topic_bus.events == []
+
+
+def test_publish_event_with_failover_falls_back_on_runtime_none() -> None:
+    bus = _StubEventBus()
+    topic_bus = _StubTopicBus()
+
+    def _none(_: Event) -> None:
+        return None
+
+    bus.publish_from_sync = _none  # type: ignore[method-assign]
+
+    publish_event_with_failover(
+        bus,
+        _event(),
+        logger=logging.getLogger("test"),
+        runtime_fallback_message="runtime fallback",
+        runtime_unexpected_message="runtime unexpected",
+        runtime_none_message="runtime none",
+        global_not_running_message="global missing",
+        global_unexpected_message="global unexpected",
+        global_bus_factory=lambda: topic_bus,
+    )
+
+    assert topic_bus.events
+
+
+def test_publish_event_with_failover_raises_on_unexpected_runtime_error() -> None:
+    bus = _StubEventBus()
+    topic_bus = _StubTopicBus()
+
+    def _boom(_: Event) -> None:
+        raise ValueError("boom")
+
+    bus.publish_from_sync = _boom  # type: ignore[method-assign]
+
+    with pytest.raises(EventPublishError) as exc_info:
+        publish_event_with_failover(
+            bus,
+            _event(),
+            logger=logging.getLogger("test"),
+            runtime_fallback_message="runtime fallback",
+            runtime_unexpected_message="runtime unexpected",
+            runtime_none_message="runtime none",
+            global_not_running_message="global missing",
+            global_unexpected_message="global unexpected",
+            global_bus_factory=lambda: topic_bus,
+        )
+
+    assert exc_info.value.stage == "runtime"
+    assert topic_bus.events == []
+
+
+def test_publish_event_with_failover_raises_on_global_error() -> None:
+    bus = _StubEventBus(running=False)
+
+    class _FailingTopicBus(_StubTopicBus):
+        def publish_sync(self, event_type: str, payload: Any, *, source: str | None = None) -> None:  # type: ignore[override]
+            raise RuntimeError("offline")
+
+    with pytest.raises(EventPublishError) as exc_info:
+        publish_event_with_failover(
+            bus,
+            _event(),
+            logger=logging.getLogger("test"),
+            runtime_fallback_message="runtime fallback",
+            runtime_unexpected_message="runtime unexpected",
+            runtime_none_message="runtime none",
+            global_not_running_message="global missing",
+            global_unexpected_message="global unexpected",
+            global_bus_factory=_FailingTopicBus,
+        )
+
+    assert exc_info.value.stage == "global"


### PR DESCRIPTION
## Summary
- add an operations utility that wraps runtime-to-global event bus failover behind a typed `EventPublishError`
- refactor compliance, security, and system validation publishers to use the shared helper instead of blanket exception handlers
- extend and update regression tests to cover the helper behaviour and new error type across operational telemetry modules

## Testing
- pytest tests/operations/test_event_bus_failover.py tests/operations/test_compliance_readiness.py tests/operations/test_security.py tests/operations/test_system_validation.py


------
https://chatgpt.com/codex/tasks/task_e_68dcc3d717c8832cb4412536f475fefe