### PR TITLE
Add guardrail suite to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,6 +81,12 @@ jobs:
     needs: [types]
     steps:
       - uses: ./.github/actions/python-setup
+      - name: Pytest (guardrail suite)
+        env:
+          PYTHONPATH: ${{ github.workspace }}
+        run: |
+          set -euo pipefail
+          pytest -m guardrail --maxfail=1 -q
       - name: Pytest (coverage)
         env:
           PYTHONPATH: ${{ github.workspace }}

--- a/pytest.ini
+++ b/pytest.ini
@@ -14,9 +14,10 @@ addopts =
     --disable-warnings
 markers =
     unit: Unit tests for individual components
-    integration: Integration tests for system components  
+    integration: Integration tests for system components
     end_to_end: Full system tests
     slow: Tests that take longer to run
     fix_api: Tests related to FIX API functionality
     asyncio: Tests that require an asyncio event loop
+    guardrail: Regression guardrails for ingest orchestration, risk policies, and observability suites
 

--- a/tests/data_foundation/test_timescale_backbone_orchestrator.py
+++ b/tests/data_foundation/test_timescale_backbone_orchestrator.py
@@ -21,6 +21,9 @@ from src.data_foundation.persist.timescale import TimescaleIngestResult
 from src.data_foundation.schemas import MacroEvent
 
 
+pytestmark = pytest.mark.guardrail
+
+
 class _FailingSettings:
     """Settings stub that fails if the engine is constructed."""
 

--- a/tests/operations/test_event_bus_health.py
+++ b/tests/operations/test_event_bus_health.py
@@ -15,6 +15,9 @@ from src.operations.event_bus_health import (
 )
 
 
+pytestmark = pytest.mark.guardrail
+
+
 @pytest.mark.asyncio()
 async def test_event_bus_health_reports_failure_when_bus_not_running() -> None:
     bus = EventBus()

--- a/tests/trading/test_risk_policy.py
+++ b/tests/trading/test_risk_policy.py
@@ -9,6 +9,9 @@ from src.config.risk.risk_config import RiskConfig
 from src.trading.risk.risk_policy import RiskPolicy
 
 
+pytestmark = pytest.mark.guardrail
+
+
 def _state(open_positions: Mapping[str, Mapping[str, float]] | None = None) -> Mapping[str, object]:
     return {
         "equity": 100_000.0,


### PR DESCRIPTION
## Summary
- add a dedicated `guardrail` pytest marker for ingest orchestration, risk policy, and observability regression coverage
- tag the existing ingest, risk policy, and event bus health test suites with the guardrail marker and run them in CI ahead of the full coverage job
- document the new marker in `pytest.ini` so contributors can discover and reuse it locally

## Testing
- pytest -m guardrail -q

------
https://chatgpt.com/codex/tasks/task_e_68dcd0959f20832cac86548c7f683fc1