### PR TITLE
Expand CI suite coverage for runtime, risk, and observability tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,6 +91,9 @@ jobs:
             tests/data_foundation \
             tests/operations \
             tests/trading \
+            tests/runtime \
+            tests/observability \
+            tests/risk \
             --cov=src \
             --cov-report=term \
             -q | tee pytest.log

--- a/pytest.ini
+++ b/pytest.ini
@@ -4,6 +4,9 @@ testpaths =
     tests/data_foundation
     tests/operations
     tests/trading
+    tests/runtime
+    tests/observability
+    tests/risk
 python_files = test_*.py
 python_classes = Test*
 python_functions = test_*


### PR DESCRIPTION
## Summary
- ensure the CI coverage job executes the runtime, observability, and risk test suites alongside the existing ingest and trading domains
- extend the default pytest configuration so local runs automatically cover the newly enforced domains

## Testing
- pytest tests/observability/test_logging.py -q
- pytest tests/runtime/test_runtime_builder.py::test_runtime_application_runs_workloads_and_shutdown_callbacks -q
- pytest tests/trading/test_risk_policy.py::test_risk_policy_requires_stop_loss_and_equity_budget -q

------
https://chatgpt.com/codex/tasks/task_e_68dcd0959f20832cac86548c7f683fc1