### PR TITLE
Add risk policy violation telemetry and escalation runbook

### DIFF
--- a/docs/operations/runbooks/README.md
+++ b/docs/operations/runbooks/README.md
@@ -14,6 +14,9 @@ briefs and CI health snapshot.
 - [Kafka ingest offset recovery](kafka_ingest_offset_recovery.md) – Guides the
   ingest event bridge through consumer lag diagnosis, manual offset commits, and
   replay validation using the Kafka telemetry helpers.
+- [Risk policy violation escalation](risk_policy_violation.md) – Surfaces the
+  policy snapshot, Markdown alert, and governance escalation path for trade
+  intents rejected by the deterministic risk gateway.
 
 Keep these documents close to the institutional data backbone alignment brief so
 runbooks, roadmap status, and acceptance hooks evolve together.

--- a/docs/operations/runbooks/risk_policy_violation.md
+++ b/docs/operations/runbooks/risk_policy_violation.md
@@ -1,0 +1,51 @@
+# Risk policy violation escalation runbook
+
+This runbook explains how to triage and escalate trade intents that fail the
+institutional risk policy enforced by the trading gateway.  It links the
+runtime telemetry surfaces exposed by the trading manager to the recovery steps
+operators must follow during a breach.
+
+## Detection
+
+1. Monitor the runtime event bus topic `telemetry.risk.policy_violation`.
+   - Every rejection publishes a structured alert containing the serialized
+     policy snapshot and a Markdown summary.【F:src/trading/risk/policy_telemetry.py†L214-L285】
+   - The trading manager forwards alerts whenever a policy decision is rejected
+     or recorded with outstanding violations.【F:src/trading/trading_manager.py†L617-L666】
+2. Secondary confirmation is available on `telemetry.risk.policy`, which
+   streams the latest decision snapshot for dashboards and notebooks.
+3. The FIX broker adapter mirrors the last snapshot in the rejection payload
+   so manual operators see the same telemetry surface as automated flows.【F:src/trading/integration/fix_broker_interface.py†L207-L254】
+
+## Immediate actions
+
+1. Pull the Markdown summary from the alert payload or the trading-manager
+   logs to identify the primary violation (`policy.*` guardrail).
+2. Inspect the runbook metadata embedded in the alert.  This file is the
+   canonical escalation path—notify the governance desk and pause affected
+   strategies if the violation is not a configuration error.
+3. Review `risk_policy.limit_snapshot()` values in the payload to confirm the
+   configured thresholds match the approved governance file.
+4. If the alert originated from the FIX bridge, cross-check the `policy_snapshot`
+   stored on the order record for parity with the runtime builder.
+
+## Remediation steps
+
+1. Correct invalid strategy configuration or position metadata if the
+   violation highlights stale exposure data.  Re-run the policy evaluation via
+   `TradingManager.on_trade_intent` in research mode to confirm the fix before
+   resuming live trading.
+2. If the policy violation is genuine (e.g., exposure or min size breach),
+   escalate to the governance contact list and keep the offending strategy in
+   a halted state until approvals arrive.
+3. After remediation, verify that new policy snapshots publish with
+   `approved=true` and no outstanding violations before clearing the alert.
+4. File an incident report if the breach crossed governance thresholds or
+   required manual intervention beyond configuration hygiene.
+
+## References
+
+- `RiskPolicy` evaluation logic and limit mapping: `src/trading/risk/risk_policy.py`
+- Trading manager telemetry bridge: `src/trading/trading_manager.py`
+- FIX bridge risk escalation: `src/trading/integration/fix_broker_interface.py`
+- Policy telemetry publisher: `src/trading/risk/policy_telemetry.py`

--- a/tests/current/test_risk_gateway_validation.py
+++ b/tests/current/test_risk_gateway_validation.py
@@ -134,6 +134,9 @@ async def test_risk_gateway_clips_position_and_adds_liquidity_metadata(
     policy_decision = gateway.get_last_policy_decision()
     assert policy_decision is not None
     assert policy_decision.approved is True
+    snapshot = gateway.get_last_policy_snapshot()
+    assert snapshot is not None
+    assert snapshot.approved is True
 
 
 @pytest.mark.asyncio()
@@ -217,6 +220,9 @@ async def test_risk_gateway_rejects_on_policy_violation(
     policy_decision = gateway.get_last_policy_decision()
     assert policy_decision is not None
     assert "policy.min_position_size" in policy_decision.violations
+    snapshot = gateway.get_last_policy_snapshot()
+    assert snapshot is not None
+    assert "policy.min_position_size" in snapshot.violations
 
 
 @pytest.mark.asyncio()


### PR DESCRIPTION
## Summary
- add a structured policy violation alert surface and wire it through the risk gateway, trading manager, and FIX broker to expose deterministic snapshots on rejections
- document the new risk policy violation escalation runbook and list it alongside existing operational playbooks

## Testing
- pytest tests/current/test_risk_gateway_validation.py tests/trading/test_trading_manager_execution.py tests/trading/test_risk_policy_telemetry.py tests/trading/test_fix_broker_interface_events.py

------
https://chatgpt.com/codex/tasks/task_e_68dcd0959f20832cac86548c7f683fc1