### PR TITLE
Update roadmap and briefs for policy telemetry and guardrail CI job

### DIFF
--- a/docs/context/alignment_briefs/institutional_risk_compliance.md
+++ b/docs/context/alignment_briefs/institutional_risk_compliance.md
@@ -41,6 +41,10 @@
   - Progress: Risk policy regression enforces mandatory stop losses, positive
     equity budgets, and violation telemetry so CI fails fast when policy guardrails
     drift, keeping execution blockers visible to compliance reviewers.【F:src/trading/risk/risk_policy.py†L120-L246】【F:tests/trading/test_risk_policy.py†L117-L205】
+- Progress: Policy telemetry builders serialise decision snapshots, emit Markdown
+  summaries, and publish violation alerts with embedded escalation metadata while
+  the trading manager mirrors the feed and the new runbook documents the response,
+  giving governance a deterministic alert surface when violations occur.【F:src/trading/risk/policy_telemetry.py†L1-L285】【F:src/trading/trading_manager.py†L642-L686】【F:docs/operations/runbooks/risk_policy_violation.md†L1-L51】【F:tests/trading/test_risk_policy_telemetry.py†L1-L199】
 - Progress: Runtime builder now resolves the canonical `RiskConfig`, validates
   risk thresholds, and records enforced metadata under regression coverage so
   supervised launches cannot proceed without mandatory limits, aligning runtime

--- a/docs/context/alignment_briefs/quality_observability.md
+++ b/docs/context/alignment_briefs/quality_observability.md
@@ -74,7 +74,7 @@
   - Progress: Cache health publishing now logs primary bus errors, only falls back
     when runtime failures occur, and raises on unexpected or global-bus outages
     under pytest guardrails so readiness telemetry surfaces real cache incidents
-    instead of quietly failing to publish.【F:src/operations/cache_health.py†L230-L303】【F:tests/operations/test_cache_health.py†L64-L131】
+    instead of quietly failing to publish.【F:src/operations/cache_health.py†L143-L245】【F:tests/operations/test_cache_health.py†L15-L138】
 - Progress: Operational metrics instrumentation now has targeted regressions for
   logging escalation, lazy gauge fallbacks, Prometheus exporter idempotence, and
   registry sink adapters so CI surfaces metric failures deterministically and
@@ -85,6 +85,10 @@
 - Refresh CI dashboard rows as telemetry lands, noting validation hooks and
   outstanding actions so stakeholders see live gaps (e.g., sensory fixture
   rollout, ingest metrics coverage).【F:docs/status/ci_health.md†L21-L76】
+- Progress: CI now runs a dedicated guardrail marker job ahead of the coverage
+  sweep so ingest, risk, and observability guardrails run in isolation and fail
+  fast when regressions surface, with the workflow and pytest marker contract
+  documenting the enforced scope.【F:.github/workflows/ci.yml†L79-L123】【F:pytest.ini†L1-L25】【F:tests/data_foundation/test_timescale_backbone_orchestrator.py†L1-L28】
 
 ### Next (30–90 days)
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -87,6 +87,12 @@ Encyclopedia while acknowledging that most subsystems remain scaffolding.
     positive equity budgets, and resolved price fallbacks, documenting violation
     telemetry and metadata so CI catches policy drift before it reaches
     execution flows.【F:src/trading/risk/risk_policy.py†L120-L246】【F:tests/trading/test_risk_policy.py†L117-L205】
+  - *Progress*: Policy telemetry helpers now serialise deterministic decision
+    snapshots, render Markdown summaries, and publish violation alerts with
+    embedded runbook metadata while the trading manager escalates breached
+    guardrails and regression tests lock the payload contract, giving operators
+    an actionable feed plus an escalation playbook whenever policy violations
+    surface.【F:src/trading/risk/policy_telemetry.py†L1-L285】【F:src/trading/trading_manager.py†L642-L686】【F:docs/operations/runbooks/risk_policy_violation.md†L1-L51】【F:tests/trading/test_risk_policy_telemetry.py†L1-L199】
   - *Progress*: FIX broker interface now routes every manual intent through the real
     risk gateway, publishes structured rejection telemetry, and records the gateway
     decision/portfolio metadata on approved orders so FIX pilots inherit the same
@@ -207,7 +213,7 @@ Encyclopedia while acknowledging that most subsystems remain scaffolding.
   - *Progress*: Cache health telemetry now logs primary bus failures, only falls
     back once runtime errors are captured, and raises on unexpected or global-bus
     errors with pytest guardrails so readiness dashboards record real outages
-    instead of silent drops.【F:src/operations/cache_health.py†L230-L303】【F:tests/operations/test_cache_health.py†L64-L131】
+    instead of silent drops.【F:src/operations/cache_health.py†L143-L245】【F:tests/operations/test_cache_health.py†L15-L138】
   - *Progress*: Trading position model guardrails now run under pytest,
     asserting timestamp updates, profit recalculations, and close flows so the
     lightweight execution telemetry remains deterministic under CI coverage.【F:tests/trading/test_position_model_guardrails.py†L1-L105】
@@ -216,7 +222,11 @@ Encyclopedia while acknowledging that most subsystems remain scaffolding.
     flows keep writing deterministic telemetry under CI guardrails.【F:tests/data_foundation/test_timescale_ingest.py†L1-L213】
   - *Progress*: Timescale ingest orchestrator regression suite now validates engine
     lifecycle hooks, publisher metadata, empty-plan short-circuits, and guardrails
-    for missing intraday fetchers so institutional ingest cannot regress silently.【F:tests/data_foundation/test_timescale_backbone_orchestrator.py†L1-L150】
+    for missing intraday fetchers so institutional ingest cannot regress silently.【F:tests/data_foundation/test_timescale_backbone_orchestrator.py†L1-L200】
+  - *Progress*: CI now runs a dedicated `pytest -m guardrail` job ahead of the
+    coverage sweep, ensuring ingest, risk, and observability guardrail tests are
+    executed in isolation with deterministic markers and failing fast when
+    regressions surface.【F:.github/workflows/ci.yml†L79-L123】【F:pytest.ini†L1-L25】【F:tests/data_foundation/test_timescale_backbone_orchestrator.py†L1-L28】【F:tests/operations/test_event_bus_health.py†L1-L155】
   - *Progress*: Runtime builder coverage now snapshots ingest plan dimensions,
     trading metadata, and enforced risk summaries, while risk policy regressions
     assert portfolio price fallbacks so ingest orchestration and risk sizing


### PR DESCRIPTION
## Summary
- document the new risk policy telemetry and escalation runbook across the roadmap and institutional risk brief
- record the cache health telemetry refinements and dedicated guardrail CI job in the roadmap and quality/observability alignment brief

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dcd51fd364832cbc554cc70f44bb72