### PR TITLE
Harden sensory organ import fallback logging

### DIFF
--- a/src/core/__init__.py
+++ b/src/core/__init__.py
@@ -8,7 +8,11 @@ Provides concrete implementations of all critical interfaces.
 
 from __future__ import annotations
 
+import logging
+
 from .population_manager import PopulationManager
+
+logger = logging.getLogger(__name__)
 
 try:
     from .sensory_organ import (
@@ -19,12 +23,22 @@ try:
         SensoryOrgan,
         create_sensory_organ,
     )
-except Exception:  # pragma: no cover
+except (ImportError, AttributeError) as exc:  # pragma: no cover - defensive import
+    logger.warning(
+        "Falling back to sensory organ stubs due to import failure: %s",
+        exc,
+        exc_info=True,
+    )
+
     # Legacy compatibility placeholders
     class SensoryOrgan:  # type: ignore
+        """Fallback sensory organ placeholder used when the real module is unavailable."""
+
         pass
 
     def create_sensory_organ(*_args, **_kwargs):  # type: ignore
+        """Fallback creator returning ``None`` when the real implementation is missing."""
+
         return None
 
     WHAT_ORGAN = WHEN_ORGAN = ANOMALY_ORGAN = CHAOS_ORGAN = None  # type: ignore
@@ -53,16 +67,3 @@ __all__ = [
 # Re-export for convenience
 from .population_manager import PopulationManager
 
-try:
-    from .sensory_organ import (
-        ANOMALY_ORGAN,
-        CHAOS_ORGAN,
-        WHAT_ORGAN,
-        WHEN_ORGAN,
-        SensoryOrgan,
-        create_sensory_organ,
-    )
-except Exception:  # pragma: no cover
-    pass
-from .instrument import Instrument, get_all_instruments, get_instrument
-from .risk.manager import RiskManager, get_risk_manager

--- a/tests/core/test_core_init_fallback.py
+++ b/tests/core/test_core_init_fallback.py
@@ -1,0 +1,43 @@
+"""Tests for the defensive imports in :mod:`src.core`."""
+
+from __future__ import annotations
+
+import importlib
+import sys
+import types
+from typing import Optional
+
+
+def test_sensory_fallback_triggers_logging(monkeypatch, caplog):
+    """The module should log and provide stubs when the sensory organ import fails."""
+
+    import src.core as core  # Ensure the module is importable before tampering
+
+    original_module: Optional[types.ModuleType] = sys.modules.get("src.core.sensory_organ")
+
+    stub = types.ModuleType("src.core.sensory_organ")
+
+    def _missing_attr(_name: str):
+        raise AttributeError("sensory organ module missing")
+
+    stub.__getattr__ = _missing_attr  # type: ignore[assignment]
+    monkeypatch.setitem(sys.modules, "src.core.sensory_organ", stub)
+
+    caplog.clear()
+    caplog.set_level("WARNING", logger="src.core")
+
+    reloaded = importlib.reload(core)
+
+    try:
+        assert any(
+            "Falling back to sensory organ stubs" in record.message for record in caplog.records
+        ), "Expected fallback warning log to be emitted."
+        assert reloaded.create_sensory_organ() is None
+        assert reloaded.WHAT_ORGAN is None
+    finally:
+        if original_module is None:
+            sys.modules.pop("src.core.sensory_organ", None)
+        else:
+            sys.modules["src.core.sensory_organ"] = original_module
+        importlib.reload(core)
+


### PR DESCRIPTION
## Summary
- log and document the defensive sensory organ fallback in `src.core` so import failures are observable while still returning safe stubs
- add a regression test that simulates a failing sensory organ import and asserts the warning plus stubbed behaviour

## Testing
- pytest tests/core/test_core_init_fallback.py

------
https://chatgpt.com/codex/tasks/task_e_68dcd6828950832caa4558d55a8ffdfe