### PR TITLE
Add operational readiness metadata breakdown

### DIFF
--- a/docs/status/operational_readiness.md
+++ b/docs/status/operational_readiness.md
@@ -1,0 +1,36 @@
+# Operational readiness telemetry
+
+The operational readiness snapshot fuses system validation, incident response,
+and SLO telemetry into a single payload that dashboards can ingest directly.
+Recent hardening work adds structured metadata so downstream consumers can track
+how many components are warning or failing without re-implementing severity
+logic.
+
+## Snapshot contract
+
+`evaluate_operational_readiness` now enriches the snapshot metadata with two
+fields:
+
+- `status_breakdown` – counts of components per readiness status, expressed as a
+  mapping such as `{ "warn": 2, "fail": 1 }`.
+- `component_statuses` – a mapping from component name to its status value so
+  dashboards can highlight degraded services directly (for example,
+  `{ "incident_response": "fail" }`).
+
+Both fields accompany the existing `component_count` and remain present in the
+snapshot dictionary returned by `OperationalReadinessSnapshot.as_dict()` and the
+payload attached to derived alert events. The regression suite
+(`tests/operations/test_operational_readiness.py`) locks the contract so CI fails
+if the breakdown or component mapping drift.
+
+## Using the metadata
+
+- Dashboards can render stacked bar charts or summary chips by reading the
+  `status_breakdown` map instead of recomputing severities.
+- Alerting policies receive the enriched metadata via the alert context, making
+  it trivial to route failures for specific components.
+- Additional metadata can still be supplied via the `metadata` parameter when
+  evaluating readiness; custom keys override defaults if needed.
+
+Combine the snapshot with the observability dashboard output to give operators a
+clear view of which operational slices need attention each run.

--- a/src/operations/operational_readiness.py
+++ b/src/operations/operational_readiness.py
@@ -220,6 +220,15 @@ def evaluate_operational_readiness(
     generated_at = max(moments) if moments else datetime.now(tz=UTC)
 
     snapshot_metadata: dict[str, object] = {"component_count": len(components)}
+    if components:
+        breakdown: dict[str, int] = {}
+        component_statuses: dict[str, str] = {}
+        for component in components:
+            status_value = component.status.value
+            breakdown[status_value] = breakdown.get(status_value, 0) + 1
+            component_statuses[component.name] = status_value
+        snapshot_metadata["status_breakdown"] = breakdown
+        snapshot_metadata["component_statuses"] = component_statuses
     if metadata:
         snapshot_metadata.update(dict(metadata))
 

--- a/tests/operations/test_operational_readiness.py
+++ b/tests/operations/test_operational_readiness.py
@@ -55,6 +55,11 @@ def test_operational_readiness_combines_components() -> None:
 
     assert readiness.status is OperationalReadinessStatus.fail
     assert readiness.metadata["component_count"] == 2
+    assert readiness.metadata["status_breakdown"] == {"warn": 1, "fail": 1}
+    assert readiness.metadata["component_statuses"] == {
+        "system_validation": "warn",
+        "incident_response": "fail",
+    }
     names = {component.name for component in readiness.components}
     assert names == {"system_validation", "incident_response"}
 
@@ -82,6 +87,7 @@ def test_operational_readiness_alert_generation() -> None:
     assert overall.severity is AlertSeverity.warning
     assert component.severity is AlertSeverity.warning
     assert "status warn" in component.message
+    assert overall.context["snapshot"]["metadata"]["status_breakdown"] == {"warn": 1}
 
     suppressed = derive_operational_alerts(
         readiness, threshold=OperationalReadinessStatus.fail, include_overall=False


### PR DESCRIPTION
## Summary
- enrich the operational readiness snapshot with per-status counts and component status metadata so dashboards can consume a richer payload
- document the new telemetry fields for downstream consumers
- extend the operational readiness regression tests to lock the metadata contract

## Testing
- pytest tests/operations/test_operational_readiness.py

------
https://chatgpt.com/codex/tasks/task_e_68dcdd3c9f2c832cb990511a5b9cf957