### PR TITLE
Harden risk configuration enforcement

### DIFF
--- a/src/config/risk/risk_config.py
+++ b/src/config/risk/risk_config.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from decimal import Decimal
 from typing import Dict
 
-from pydantic import BaseModel, Field, validator
+from pydantic import BaseModel, Field, root_validator, validator
 
 
 class RiskConfig(BaseModel):
@@ -90,11 +90,37 @@ class RiskConfig(BaseModel):
             raise ValueError("Annualisation factor must be positive")
         return v
 
+    @validator("min_position_size", "max_position_size")
+    def validate_position_size(cls, v: int) -> int:
+        if v <= 0:
+            raise ValueError("Position sizes must be positive")
+        return v
+
     @validator("sector_exposure_limits", each_item=True)
     def validate_sector_limits(cls, v: Decimal) -> Decimal:
         if v <= 0 or v > 1:
             raise ValueError("Sector exposure limits must be between 0 and 1")
         return v
+
+    @root_validator
+    def validate_consistency(cls, values: dict[str, object]) -> dict[str, object]:
+        min_size = values.get("min_position_size")
+        max_size = values.get("max_position_size")
+        if isinstance(min_size, int) and isinstance(max_size, int) and min_size > max_size:
+            raise ValueError("min_position_size cannot exceed max_position_size")
+
+        max_risk = values.get("max_risk_per_trade_pct")
+        max_exposure = values.get("max_total_exposure_pct")
+        if isinstance(max_risk, Decimal) and isinstance(max_exposure, Decimal):
+            if max_risk > max_exposure:
+                raise ValueError("max_total_exposure_pct must be >= max_risk_per_trade_pct")
+
+        mandatory_stop_loss = values.get("mandatory_stop_loss")
+        research_mode = values.get("research_mode")
+        if mandatory_stop_loss is False and research_mode is not True:
+            raise ValueError("Disabling mandatory_stop_loss requires research_mode=True")
+
+        return values
 
 
 __all__ = ["RiskConfig"]

--- a/tests/risk/test_risk_config_validation.py
+++ b/tests/risk/test_risk_config_validation.py
@@ -1,0 +1,35 @@
+from decimal import Decimal
+
+import pytest
+from pydantic import ValidationError
+
+from src.config.risk.risk_config import RiskConfig
+
+
+def test_min_position_size_must_be_positive() -> None:
+    with pytest.raises(ValidationError):
+        RiskConfig(min_position_size=0)
+
+
+def test_min_position_size_cannot_exceed_maximum() -> None:
+    with pytest.raises(ValidationError):
+        RiskConfig(min_position_size=2_000, max_position_size=1_000)
+
+
+def test_max_exposure_must_cover_risk_per_trade() -> None:
+    with pytest.raises(ValidationError):
+        RiskConfig(
+            max_risk_per_trade_pct=Decimal("0.20"),
+            max_total_exposure_pct=Decimal("0.10"),
+        )
+
+
+def test_mandatory_stop_loss_requires_research_mode_when_disabled() -> None:
+    with pytest.raises(ValidationError):
+        RiskConfig(mandatory_stop_loss=False, research_mode=False)
+
+
+def test_stop_loss_can_be_disabled_in_research_mode() -> None:
+    cfg = RiskConfig(mandatory_stop_loss=False, research_mode=True)
+    assert cfg.research_mode is True
+    assert cfg.mandatory_stop_loss is False


### PR DESCRIPTION
## Summary
- add structural validations to the canonical `RiskConfig` covering position sizes, exposure ratios, and stop-loss flags
- surface invalid trading manager risk payloads as runtime errors during application build
- backfill regression coverage for the new validations and runtime guardrail

## Testing
- pytest tests/risk/test_risk_config_validation.py tests/runtime/test_runtime_builder.py::test_builder_rejects_invalid_trading_risk_config

------
https://chatgpt.com/codex/tasks/task_e_68dceeb18d3c832c8c071ec2bd05fe78