### PR TITLE
Improve guardrail coverage for ingest orchestrator and risk policy

### DIFF
--- a/src/data_foundation/ingest/timescale_pipeline.py
+++ b/src/data_foundation/ingest/timescale_pipeline.py
@@ -146,6 +146,7 @@ class TimescaleBackboneOrchestrator:
                     "source": plan.daily.source,
                     "requested_symbols": symbols,
                     "lookback_days": plan.daily.lookback_days,
+                    "fetched_rows": 0,
                 }
 
                 if not symbols:
@@ -175,6 +176,7 @@ class TimescaleBackboneOrchestrator:
                     "requested_symbols": symbols,
                     "lookback_days": plan.intraday.lookback_days,
                     "interval": plan.intraday.interval,
+                    "fetched_rows": 0,
                 }
                 if not symbols:
                     result = TimescaleIngestResult.empty(
@@ -206,6 +208,8 @@ class TimescaleBackboneOrchestrator:
                     if plan.macro.has_window()
                     else None,
                     "provided_events": len(events) if events is not None else 0,
+                    "fetched_events": 0,
+                    "frame_rows": 0,
                 }
 
                 if events is None:


### PR DESCRIPTION
## Summary
- ensure the Timescale backbone orchestrator always includes fetched-row and event metadata for empty slices so ingest telemetry stays consistent
- add guardrail regression covering empty-symbol ingest plans alongside metadata assertions
- add a risk policy guardrail test that fails trades when market prices cannot be resolved

## Testing
- pytest tests/data_foundation/test_timescale_backbone_orchestrator.py tests/trading/test_risk_policy.py -q

------
https://chatgpt.com/codex/tasks/task_e_68dceeb18d3c832c8c071ec2bd05fe78