### PR TITLE
Enhance sensory threshold state telemetry

### DIFF
--- a/src/sensory/thresholds.py
+++ b/src/sensory/thresholds.py
@@ -1,0 +1,88 @@
+"""Threshold evaluation utilities for sensory organs."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+__all__ = ["ThresholdAssessment", "evaluate_thresholds"]
+
+
+@dataclass(frozen=True, slots=True)
+class ThresholdAssessment:
+    """Describe the relationship between a signal value and configured limits."""
+
+    state: str
+    magnitude: float
+    thresholds: dict[str, float]
+    breached_level: str | None
+    breach_ratio: float
+    distance_to_warn: float
+    distance_to_alert: float
+
+    def as_dict(self) -> dict[str, float | str | None]:
+        return {
+            "state": self.state,
+            "magnitude": self.magnitude,
+            "breached_level": self.breached_level,
+            "breach_ratio": self.breach_ratio,
+            "thresholds": dict(self.thresholds),
+            "distance_to_warn": self.distance_to_warn,
+            "distance_to_alert": self.distance_to_alert,
+        }
+
+
+def evaluate_thresholds(
+    value: float,
+    warn_threshold: float,
+    alert_threshold: float,
+    *,
+    mode: str = "absolute",
+) -> ThresholdAssessment:
+    """Return the threshold posture for ``value``.
+
+    ``mode`` controls how ``value`` is converted into a magnitude:
+
+    ``"absolute"``
+        Use ``abs(value)`` so deviations in either direction contribute to the
+        threshold assessment.
+
+    ``"positive"``
+        Clamp to the positive domain so only values greater than zero
+        contribute to the assessment.
+    """
+
+    if mode not in {"absolute", "positive"}:
+        raise ValueError(f"Unsupported evaluation mode: {mode}")
+
+    if mode == "absolute":
+        magnitude = abs(float(value))
+    else:
+        magnitude = max(0.0, float(value))
+
+    warn = max(0.0, float(warn_threshold))
+    alert = max(warn, float(alert_threshold))
+
+    if magnitude >= alert:
+        state = "alert"
+        breached_level: str | None = "alert"
+    elif magnitude >= warn:
+        state = "warning"
+        breached_level = "warn"
+    else:
+        state = "nominal"
+        breached_level = None
+
+    distance_to_warn = max(0.0, warn - magnitude)
+    distance_to_alert = max(0.0, alert - magnitude)
+    breach_ratio = magnitude / alert if alert > 0 else 0.0
+
+    thresholds = {"warn": warn, "alert": alert}
+    return ThresholdAssessment(
+        state=state,
+        magnitude=magnitude,
+        thresholds=thresholds,
+        breached_level=breached_level,
+        breach_ratio=breach_ratio,
+        distance_to_warn=distance_to_warn,
+        distance_to_alert=distance_to_alert,
+    )

--- a/tests/sensory/test_how_anomaly_sensors.py
+++ b/tests/sensory/test_how_anomaly_sensors.py
@@ -1,11 +1,60 @@
 from __future__ import annotations
 
+from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 
 import pandas as pd
 
 from src.sensory.anomaly import AnomalySensor
 from src.sensory.how.how_sensor import HowSensor
+
+
+@dataclass(slots=True)
+class _StubReading:
+    signal_strength: float
+    confidence: float
+    context: dict[str, object]
+    regime: object | None = None
+
+
+class _StubAdapter(dict):
+    def __init__(self, reading: _StubReading, **extras: float) -> None:
+        super().__init__(extras)
+        self.reading = reading
+
+
+class _StubHowEngine:
+    def __init__(self, *, strength: float, confidence: float, **extras: float) -> None:
+        self._strength = strength
+        self._confidence = confidence
+        self._extras = extras
+
+    def analyze_institutional_intelligence(self, payload):  # type: ignore[override]
+        return _StubAdapter(
+            _StubReading(
+                signal_strength=self._strength,
+                confidence=self._confidence,
+                context={"mode": "test"},
+            ),
+            **self._extras,
+        )
+
+
+class _StubAnomalyEngine:
+    def __init__(self, *, strength: float, confidence: float, **extras: float) -> None:
+        self._strength = strength
+        self._confidence = confidence
+        self._extras = extras
+
+    def analyze_anomaly_intelligence(self, payload):  # type: ignore[override]
+        return _StubAdapter(
+            _StubReading(
+                signal_strength=self._strength,
+                confidence=self._confidence,
+                context={"mode": "test"},
+            ),
+            **self._extras,
+        )
 
 
 def _build_market_frame(rows: int = 12, *, anomaly_spike: bool = False) -> pd.DataFrame:
@@ -47,6 +96,7 @@ def test_how_sensor_emits_liquidity_audit() -> None:
     assert -1.0 <= float(signal.value["strength"]) <= 1.0
     metadata = signal.metadata or {}
     assert metadata.get("source") == "sensory.how"
+    assert metadata.get("state") in {"nominal", "warning", "alert"}
     audit = metadata.get("audit")
     assert isinstance(audit, dict)
     assert set(audit.keys()) >= {"signal", "confidence", "liquidity", "participation"}
@@ -57,6 +107,7 @@ def test_how_sensor_emits_liquidity_audit() -> None:
     assert lineage.get("inputs", {}).get("symbol") == "EURUSD"
     assert "liquidity" in lineage.get("telemetry", {})
     assert lineage.get("metadata", {}).get("mode") == "market_data"
+    assert "state" in lineage.get("metadata", {})
 
 
 def test_anomaly_sensor_sequence_mode_detects_spike() -> None:
@@ -72,6 +123,7 @@ def test_anomaly_sensor_sequence_mode_detects_spike() -> None:
     assert metadata.get("mode") == "sequence"
     assert metadata.get("thresholds") == {"warn": 0.4, "alert": 0.7}
     assert signal.value["strength"] >= 0.0
+    assert signal.value["state"] in {"nominal", "warning", "alert"}
     lineage = metadata.get("lineage")
     assert isinstance(lineage, dict)
     assert lineage.get("metadata", {}).get("mode") == "sequence"
@@ -94,3 +146,30 @@ def test_anomaly_sensor_falls_back_to_market_payload() -> None:
     assert isinstance(lineage, dict)
     assert lineage.get("metadata", {}).get("mode") == "market_data"
     assert lineage.get("inputs", {}).get("symbol") == "EURUSD"
+
+
+def test_how_sensor_threshold_state_escalates() -> None:
+    engine = _StubHowEngine(strength=0.9, confidence=0.8, liquidity=0.6)
+    sensor = HowSensor(engine=engine)
+    frame = _build_market_frame()
+
+    signal = sensor.process(frame)[0]
+
+    assert signal.value["state"] == "alert"
+    metadata = signal.metadata or {}
+    assessment = metadata.get("threshold_assessment")
+    assert assessment["breached_level"] == "alert"
+    assert assessment["state"] == "alert"
+
+
+def test_anomaly_sensor_threshold_state_escalates() -> None:
+    engine = _StubAnomalyEngine(strength=0.65, confidence=0.9, baseline=0.2, latest=0.5)
+    sensor = AnomalySensor(engine=engine)
+
+    signal = sensor.process({"payload": "ignored"})[0]
+
+    assert signal.value["state"] == "warning"
+    metadata = signal.metadata or {}
+    assessment = metadata.get("threshold_assessment")
+    assert assessment["state"] == "warning"
+    assert assessment["breached_level"] == "warn"

--- a/tests/sensory/test_thresholds.py
+++ b/tests/sensory/test_thresholds.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+import pytest
+
+from src.sensory.thresholds import ThresholdAssessment, evaluate_thresholds
+
+
+def test_evaluate_thresholds_absolute_alert() -> None:
+    assessment = evaluate_thresholds(0.8, warn_threshold=0.3, alert_threshold=0.6)
+
+    assert assessment.state == "alert"
+    assert assessment.breached_level == "alert"
+    assert assessment.magnitude == pytest.approx(0.8)
+    assert assessment.distance_to_alert == 0.0
+    assert assessment.distance_to_warn == pytest.approx(0.0)
+    assert assessment.breach_ratio == pytest.approx(0.8 / 0.6)
+
+
+def test_evaluate_thresholds_positive_warning() -> None:
+    assessment = evaluate_thresholds(
+        -0.7,
+        warn_threshold=0.5,
+        alert_threshold=0.9,
+        mode="positive",
+    )
+
+    assert assessment.state == "nominal"
+    assert assessment.breached_level is None
+    assert assessment.magnitude == 0.0
+
+    assessment = evaluate_thresholds(
+        0.55,
+        warn_threshold=0.5,
+        alert_threshold=0.9,
+        mode="positive",
+    )
+
+    assert assessment.state == "warning"
+    assert assessment.breached_level == "warn"
+    assert assessment.distance_to_alert == pytest.approx(0.35)
+
+
+def test_threshold_assessment_as_dict_contains_expected_fields() -> None:
+    assessment = ThresholdAssessment(
+        state="warning",
+        magnitude=0.4,
+        thresholds={"warn": 0.3, "alert": 0.6},
+        breached_level="warn",
+        breach_ratio=0.4 / 0.6,
+        distance_to_warn=0.0,
+        distance_to_alert=0.2,
+    )
+
+    payload = assessment.as_dict()
+    assert payload["state"] == "warning"
+    assert payload["thresholds"] == {"warn": 0.3, "alert": 0.6}
+    assert payload["breached_level"] == "warn"


### PR DESCRIPTION
## Summary
- add reusable threshold evaluation utilities and feed threshold states into HOW and ANOMALY sensory outputs
- expose severity posture in sensor metadata/lineage while supporting injectable engines for deterministic testing
- expand regression coverage for sensory thresholds, including dedicated unit tests for the evaluation helper

## Testing
- pytest tests/sensory/test_how_anomaly_sensors.py tests/sensory/test_thresholds.py

------
https://chatgpt.com/codex/tasks/task_e_68dcfce3eecc832ca58cc76b637d1874