### PR TITLE
Update roadmap and briefs for latest guardrails

### DIFF
--- a/docs/context/alignment_briefs/evolution_engine.md
+++ b/docs/context/alignment_briefs/evolution_engine.md
@@ -45,6 +45,11 @@
 
 - Implement catalogue-backed genome seeding with configuration toggles and pytest
   coverage.
+- Progress: Realistic genome seeding now rotates through catalogue templates,
+  jitters institutional parameters, and applies lineage/performance metadata to
+  default populations so baseline genomes reflect the strategy library, with
+  pytest verifying sampler cycling and seeded context on the evolution engine.
+  【F:src/core/evolution/seeding.py†L1-L335】【F:src/core/evolution/engine.py†L250-L335】【F:tests/evolution/test_realistic_seeding.py†L1-L47】
 - Build population management routines (selection, mutation, evaluation) tied to
   recorded datasets; expose metrics via runtime summaries.
 - Surface lineage telemetry and integrate with compliance workflow templates for

--- a/docs/context/alignment_briefs/institutional_risk_compliance.md
+++ b/docs/context/alignment_briefs/institutional_risk_compliance.md
@@ -63,10 +63,11 @@
   exposes runtime-ready metadata snapshots, and drives the runtime builder’s
   enforcement path so supervisors and docs consume a single hardened contract
   under pytest coverage.【F:src/trading/risk/risk_api.py†L1-L134】【F:src/runtime/runtime_builder.py†L313-L343】【F:tests/trading/test_risk_api.py†L1-L115】【F:tests/trading/test_trading_manager_execution.py†L208-L224】
-- Progress: Compliance readiness snapshots now consolidate trade surveillance and
-  KYC telemetry, escalate severities deterministically, and expose markdown
-  evidence with pytest guardrails so governance cadences inherit truthful
-  compliance posture summaries.【F:src/operations/compliance_readiness.py†L1-L220】【F:tests/operations/test_compliance_readiness.py†L1-L173】
+- Progress: Compliance readiness snapshots now consolidate trade surveillance,
+  KYC telemetry, and workflow checklist status, escalating blocked items,
+  surfacing active task counts, and exposing markdown evidence with pytest
+  guardrails so governance cadences inherit truthful compliance posture
+  summaries.【F:src/operations/compliance_readiness.py†L262-L420】【F:tests/operations/test_compliance_readiness.py†L58-L213】
 
 ### Next (30–90 days)
 

--- a/docs/context/alignment_briefs/operational_readiness.md
+++ b/docs/context/alignment_briefs/operational_readiness.md
@@ -34,6 +34,11 @@
   - ✅ Runtime CLI orchestration and the bootstrap sensory loop now execute under
     `TaskSupervisor`, eliminating direct `asyncio.create_task` usage for
     entrypoint workflows and providing deterministic signal/timeout shutdowns.【F:src/runtime/cli.py†L206-L249】【F:src/runtime/bootstrap_runtime.py†L227-L268】
+  - Progress: A dedicated runtime runner now wraps professional workloads in a
+    shared `TaskSupervisor`, wiring signal handlers, optional timeouts, and
+    shutdown callbacks so production launches share the same supervised lifecycle
+    contract as the builder, with pytest covering normal completion and timeout
+    cancellation flows.【F:src/runtime/runtime_runner.py†L1-L120】【F:main.py†L71-L125】【F:tests/runtime/test_runtime_runner.py†L1-L58】
 - Harden operational telemetry publishers so security and system validation
   feeds warn on runtime bus failures, fall back deterministically, and raise on
   unexpected errors with pytest coverage guarding the behaviour, including

--- a/docs/context/alignment_briefs/quality_observability.md
+++ b/docs/context/alignment_briefs/quality_observability.md
@@ -57,6 +57,10 @@
     publishers, replacing ad-hoc blanket handlers with typed errors and
     structured logging so transport regressions escalate consistently across
     modules.【F:src/operations/event_bus_failover.py†L1-L174】【F:src/operations/incident_response.py†L350-L375】【F:src/operations/evolution_experiments.py†L297-L342】【F:tests/operations/test_event_bus_failover.py†L1-L164】【F:tests/operations/test_incident_response.py†L123-L167】【F:tests/operations/test_evolution_experiments.py†L135-L191】
+  - Progress: Guardrail manifest tests pin the ingest orchestration, risk policy,
+    and observability suites to the CI guardrail marker so coverage drops or
+    marker drift block merges before the broader regression run, with pytest
+    verifying target existence and guardrail tagging.【F:tests/runtime/test_guardrail_suite_manifest.py†L1-L40】
   - Progress: Event bus health tests now assert queue backlog escalation,
     dropped-event surfacing, and global bus failure propagation so operational
     telemetry keeps raising alarms when both primary and fallback paths degrade.【F:src/operations/event_bus_health.py†L118-L281】【F:tests/operations/test_event_bus_health.py†L1-L206】

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -46,6 +46,11 @@ Encyclopedia while acknowledging that most subsystems remain scaffolding.
     malformed regime metadata by normalising canonical models, skipping
     non-numeric parameters, and logging adapter failures with pytest coverage on
     each guardrail so evolution runs cannot silently corrupt state.【F:src/ecosystem/optimization/ecosystem_optimizer.py†L59-L230】【F:tests/ecosystem/test_ecosystem_optimizer_hardening.py†L1-L70】
+  - *Progress*: Default evolution seeding now cycles through catalogue-inspired
+    genome templates, injecting lineage metadata, realistic performance
+    fingerprints, and species diversity so baseline populations resemble the
+    institutional strategy library, with pytest guarding the sampler rotation and
+    seeded genome context.【F:src/core/evolution/seeding.py†L1-L335】【F:src/core/evolution/engine.py†L250-L335】【F:tests/evolution/test_realistic_seeding.py†L1-L47】
   - *Progress*: Portfolio evolution falls back gracefully when optional
     scikit-learn dependencies are missing by logging the degraded path, returning
     deterministic cluster bucketing, and exercising the guards under
@@ -97,6 +102,11 @@ Encyclopedia while acknowledging that most subsystems remain scaffolding.
     deterministic runtime error, and logs the enforced posture under regression
     coverage so supervised launches cannot proceed with missing or malformed
     limits.【F:src/runtime/runtime_builder.py†L298-L337】【F:tests/runtime/test_runtime_builder.py†L158-L200】
+  - *Progress*: A supervised runtime runner now wraps professional workloads in a
+    shared `TaskSupervisor`, wiring graceful signal handling, optional timeouts,
+    and deterministic shutdown callbacks so runtime launches inherit the same
+    lifecycle guarantees as the builder, with pytest exercising normal and
+    timeout-driven exits.【F:src/runtime/runtime_runner.py†L1-L120】【F:main.py†L71-L125】【F:tests/runtime/test_runtime_runner.py†L1-L58】
   - *Progress*: Risk policy regression now enforces mandatory stop losses,
     positive equity budgets, and resolved price fallbacks, documenting violation
     telemetry and metadata so CI catches policy drift before it reaches
@@ -132,10 +142,11 @@ Encyclopedia while acknowledging that most subsystems remain scaffolding.
     metadata with a status breakdown plus component map so dashboards can render
     severity chips without recomputing the logic, under pytest coverage and
     documented contract updates.【F:src/operations/operational_readiness.py†L1-L256】【F:tests/operations/test_operational_readiness.py†L1-L86】【F:docs/status/operational_readiness.md†L1-L34】【F:tests/runtime/test_professional_app_timescale.py†L722-L799】
-  - *Progress*: Compliance readiness publishing now warns on runtime bus rejections,
-    escalates unexpected failures, and retries on the global bus so telemetry does
-    not silently disappear when transports degrade, with hardened logging guiding
-    operators during outages.【F:src/operations/compliance_readiness.py†L284-L344】
+  - *Progress*: Compliance readiness snapshots now include workflow portfolio
+    status alongside trade and KYC telemetry, escalating blocked checklists,
+    surfacing active task counts, and retaining the hardened publish failover so
+    governance teams see actionable workflow posture even during runtime bus
+    outages.【F:src/operations/compliance_readiness.py†L262-L420】【F:tests/operations/test_compliance_readiness.py†L58-L213】
   - *Progress*: System validation telemetry escalates runtime publish failures
     into warnings, raises on unexpected errors, and regression tests capture the
     fallback handling so readiness dashboards surface degraded validation runs
@@ -148,6 +159,10 @@ Encyclopedia while acknowledging that most subsystems remain scaffolding.
     execution, FIX wrapper sanitisation, and bounded latency histograms so guardrail
     telemetry captures instrumentation failures instead of dropping them silently.
     【F:src/operational/metrics.py†L1-L200】【F:tests/operational/test_metrics.py†L200-L328】
+  - *Progress*: Guardrail manifest tests now enforce the presence and pytest marker
+    coverage of ingest orchestration, risk policy, and observability suites so the
+    CI guardrail job fails fast if critical regression files or markers drift out
+    of the matrix.【F:tests/runtime/test_guardrail_suite_manifest.py†L1-L40】
   - *Progress*: CI telemetry tooling now records remediation status snapshots via
     the `--remediation-status` CLI flag and validates the JSON contract under
     pytest so roadmap evidence, dashboard feeds, and audits inherit structured


### PR DESCRIPTION
## Summary
- Document the realistic catalogue-backed genome seeding work in the roadmap and evolution brief.
- Capture the supervised runtime runner helper across roadmap and operational readiness context.
- Note workflow-aware compliance readiness telemetry and the guardrail manifest test across roadmap and relevant briefs.

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dd14ea4d04832caf759bbcc4c65003