### PR TITLE
Add structured runbook metadata to risk API errors

### DIFF
--- a/docs/api/risk.md
+++ b/docs/api/risk.md
@@ -1,3 +1,18 @@
-# Risk API (Stub)
+# Risk API
 
-Core risk lives in src/core/risk/.
+The trading runtime resolves every `RiskConfig` through
+`src/trading/risk/risk_api.py`.  The module exposes helpers that give
+supervisors and orchestration code a deterministic surface over the trading
+manager's risk posture:
+
+* `resolve_trading_risk_config` – returns a fully validated `RiskConfig`
+  instance and raises `RiskApiError` if the manager exposes malformed data.
+* `resolve_trading_risk_interface` – wraps the resolved configuration together
+  with any status payload exposed by `TradingManager.get_risk_status()`.
+* `build_runtime_risk_metadata` – converts the interface into a serialisable
+  summary used by `RuntimeApplication` metadata and telemetry publishers.
+
+`RiskApiError` now carries structured metadata and a default runbook link at
+`docs/operations/runbooks/risk_api_contract.md`.  Callers should surface the
+`runbook` URL in error messages and log the accompanying details so operators
+can triage missing or invalid contracts quickly.

--- a/docs/operations/runbooks/risk_api_contract.md
+++ b/docs/operations/runbooks/risk_api_contract.md
@@ -1,0 +1,31 @@
+# Risk API contract violation
+
+The runtime builder and trading manager raise a `RiskApiError` when a trading
+manager fails to expose a canonical `RiskConfig`.  Use this runbook to restore
+compliance.
+
+## Detection
+
+* Runtime startup logs include an error similar to `Trading manager risk
+  configuration is invalid`.  The message references this runbook.
+* `RuntimeApplication.summary()` contains a `risk_error` section with the
+  failure metadata.
+* `TradingManager.describe_risk_interface()` returns an `error` payload instead
+  of the normal configuration summary.
+
+## Immediate response
+
+1. Identify the failing trading manager instance from the error details.
+2. Confirm that the manager initialised `_risk_config` with a valid
+   `RiskConfig` or exposes a compliant payload from `get_risk_status()`.
+3. If initialisation relies on configuration files, validate the numeric ranges
+   (`max_risk_per_trade_pct`, `max_total_exposure_pct`, and `mandatory_stop_loss`).
+4. Restart the runtime once the configuration is corrected and verify that the
+   summary payload returns without the `error` field.
+
+## Escalation
+
+* If the manager cannot provide a valid configuration, escalate to the Execution
+  & Risk squad with the captured `risk_error` metadata.
+* Record the incident in the operational readiness log and link this runbook to
+  the remediation ticket.

--- a/src/runtime/runtime_builder.py
+++ b/src/runtime/runtime_builder.py
@@ -321,7 +321,8 @@ def _prepare_trading_risk_enforcement(
     try:
         risk_config = resolve_trading_risk_config(trading_manager)
     except RiskApiError as exc:
-        raise RuntimeError(str(exc)) from exc
+        metadata["risk_error"] = exc.to_metadata()
+        raise RuntimeError(f"{exc}. See {exc.runbook}") from exc
     if risk_config.max_risk_per_trade_pct <= 0:
         raise RuntimeError("RiskConfig.max_risk_per_trade_pct must be positive")
     if risk_config.max_total_exposure_pct <= 0:

--- a/src/trading/trading_manager.py
+++ b/src/trading/trading_manager.py
@@ -36,7 +36,7 @@ from src.trading.risk.policy_telemetry import (
 )
 from src.trading.risk.risk_gateway import RiskGateway
 from src.trading.risk.risk_policy import RiskPolicy
-from src.trading.risk.risk_api import resolve_trading_risk_interface
+from src.trading.risk.risk_api import RiskApiError, resolve_trading_risk_interface
 
 from src.operations.roi import (
     RoiCostModel,
@@ -502,7 +502,15 @@ class TradingManager:
     def describe_risk_interface(self) -> dict[str, object]:
         """Expose a deterministic snapshot of the trading risk interface."""
 
-        interface = resolve_trading_risk_interface(self)
+        try:
+            interface = resolve_trading_risk_interface(self)
+        except RiskApiError as exc:
+            return {
+                "error": str(exc),
+                "runbook": exc.runbook,
+                "details": exc.to_metadata().get("details", {}),
+            }
+
         payload: dict[str, object] = {
             "config": interface.config.dict(),
             "summary": interface.summary(),

--- a/tests/runtime/test_runtime_builder.py
+++ b/tests/runtime/test_runtime_builder.py
@@ -183,13 +183,16 @@ async def test_builder_rejects_invalid_trading_risk_config(tmp_path):
         setattr(app.sensory_organ, "trading_manager", StubTradingManager())
 
     try:
-        with pytest.raises(RuntimeError, match="risk configuration is invalid"):
+        with pytest.raises(RuntimeError) as excinfo:
             build_professional_runtime_application(
                 app,
                 skip_ingest=True,
                 symbols_csv="EURUSD",
                 duckdb_path=str(tmp_path / "tier0.duckdb"),
             )
+        message = str(excinfo.value)
+        assert "risk configuration is invalid" in message
+        assert "risk_api_contract.md" in message
     finally:
         await app.shutdown()
 

--- a/tests/trading/test_risk_api.py
+++ b/tests/trading/test_risk_api.py
@@ -114,3 +114,13 @@ def test_resolve_trading_risk_interface_exposes_status_mapping() -> None:
     assert interface.status is not None
     assert interface.status["policy_limits"]["max_leverage"] == 5
 
+
+def test_risk_api_error_surfaces_metadata_and_runbook() -> None:
+    error = RiskApiError("example failure", details={"manager": "StubManager"})
+
+    metadata = error.to_metadata()
+
+    assert metadata["message"] == "example failure"
+    assert metadata["runbook"].endswith("risk_api_contract.md")
+    assert metadata["details"]["manager"] == "StubManager"
+


### PR DESCRIPTION
## Summary
- add structured runbook metadata to `RiskApiError` so runtime surfaces can expose actionable remediation details
- update trading manager and runtime builder to return runbook hints and capture risk error metadata
- document the risk API contract, add an escalation runbook, and extend regression coverage for error handling

## Testing
- pytest tests/trading/test_risk_api.py
- pytest tests/runtime/test_runtime_builder.py
- pytest tests/trading/test_trading_manager_execution.py

------
https://chatgpt.com/codex/tasks/task_e_68de2e69e094832c828f920b9ac4b9cf