### PR TITLE
chore: include observability guardrail tests in CI

### DIFF
--- a/tests/observability/test_logging.py
+++ b/tests/observability/test_logging.py
@@ -15,6 +15,9 @@ from src.observability.logging import (
 )
 
 
+pytestmark = pytest.mark.guardrail
+
+
 @pytest.fixture()
 def reset_logging() -> Iterator[None]:
     root = logging.getLogger()

--- a/tests/operations/test_observability_dashboard.py
+++ b/tests/operations/test_observability_dashboard.py
@@ -24,6 +24,9 @@ from src.risk.analytics.expected_shortfall import ExpectedShortfallResult
 from src.risk.analytics.var import VarResult
 
 
+pytestmark = pytest.mark.guardrail
+
+
 def _now() -> datetime:
     return datetime.now(tz=UTC)
 


### PR DESCRIPTION
## Summary
- mark the structured logging regression suite as guardrail coverage
- ensure the observability dashboard regression suite participates in the guardrail CI job

## Testing
- pytest tests/observability -m guardrail -q
- pytest tests/operations/test_observability_dashboard.py -m guardrail -q

------
https://chatgpt.com/codex/tasks/task_e_68de2e69e094832c828f920b9ac4b9cf