### PR TITLE
Add remediation summary export to observability dashboard

### DIFF
--- a/src/operations/observability_dashboard.py
+++ b/src/operations/observability_dashboard.py
@@ -84,6 +84,33 @@ class ObservabilityDashboard:
             "metadata": dict(self.metadata),
         }
 
+    def remediation_summary(self) -> dict[str, Any]:
+        """Summarise remediation posture for CI progress tracking."""
+
+        panel_counts = Counter(panel.status for panel in self.panels)
+        failing = tuple(
+            panel.name for panel in self.panels if panel.status is DashboardStatus.fail
+        )
+        warnings = tuple(
+            panel.name for panel in self.panels if panel.status is DashboardStatus.warn
+        )
+        healthy = tuple(
+            panel.name for panel in self.panels if panel.status is DashboardStatus.ok
+        )
+
+        return {
+            "generated_at": self.generated_at.astimezone(UTC).isoformat(),
+            "overall_status": self.status.value,
+            "panel_counts": {
+                DashboardStatus.ok.value: panel_counts.get(DashboardStatus.ok, 0),
+                DashboardStatus.warn.value: panel_counts.get(DashboardStatus.warn, 0),
+                DashboardStatus.fail.value: panel_counts.get(DashboardStatus.fail, 0),
+            },
+            "failing_panels": failing,
+            "warning_panels": warnings,
+            "healthy_panels": healthy,
+        }
+
     def to_markdown(self) -> str:
         lines = [
             "# Operational observability dashboard",

--- a/tests/operations/test_observability_dashboard.py
+++ b/tests/operations/test_observability_dashboard.py
@@ -182,6 +182,18 @@ def test_build_dashboard_composes_panels_and_status() -> None:
     assert "# Operational observability dashboard" in markdown
     assert "Risk & exposure" in markdown
 
+    remediation = dashboard.remediation_summary()
+    assert remediation["overall_status"] == DashboardStatus.fail.value
+    assert remediation["panel_counts"][DashboardStatus.fail.value] == 1
+    assert remediation["panel_counts"][DashboardStatus.warn.value] == 2
+    assert remediation["panel_counts"][DashboardStatus.ok.value] == 1
+    assert remediation["failing_panels"] == ("Risk & exposure",)
+    assert set(remediation["warning_panels"]) == {
+        "Latency & throughput",
+        "System health",
+    }
+    assert remediation["healthy_panels"] == ("PnL & ROI",)
+
 
 def test_dashboard_handles_missing_inputs() -> None:
     dashboard = build_observability_dashboard()
@@ -195,6 +207,17 @@ def test_dashboard_handles_missing_inputs() -> None:
     payload = dashboard.as_dict()
     assert payload["status"] == DashboardStatus.ok.value
     assert payload["panels"] == []
+
+    remediation = dashboard.remediation_summary()
+    assert remediation["overall_status"] == DashboardStatus.ok.value
+    assert remediation["panel_counts"] == {
+        DashboardStatus.ok.value: 0,
+        DashboardStatus.warn.value: 0,
+        DashboardStatus.fail.value: 0,
+    }
+    assert remediation["failing_panels"] == ()
+    assert remediation["warning_panels"] == ()
+    assert remediation["healthy_panels"] == ()
 
 
 def test_dashboard_merges_additional_panels() -> None:


### PR DESCRIPTION
## Summary
- add a remediation_summary helper to ObservabilityDashboard so CI snapshots can track panel posture
- extend observability dashboard guardrail tests to assert remediation summary payloads for populated and empty dashboards

## Testing
- pytest tests/operations/test_observability_dashboard.py

------
https://chatgpt.com/codex/tasks/task_e_68de5845ce68832c9f766cbd678168d0