### PR TITLE
Refresh roadmap and briefs for recent risk and observability work

### DIFF
--- a/docs/context/alignment_briefs/institutional_data_backbone.md
+++ b/docs/context/alignment_briefs/institutional_data_backbone.md
@@ -48,6 +48,10 @@
   unserialisable payloads, logs filesystem failures, and deletes partial files so
   ingest tooling reports genuine write issues instead of silently returning empty
   paths.【F:src/data_foundation/persist/jsonl_writer.py†L1-L69】【F:tests/data_foundation/test_jsonl_writer.py†L1-L37】
+- Progress: Parquet ingest writer now guards the pandas DataFrame constructor,
+  logs conversion and filesystem errors, and returns explicit sentinels under
+  regression coverage so institutional ingest slices capture failed telemetry
+  persists rather than silently discarding events.【F:src/data_foundation/persist/parquet_writer.py†L1-L75】【F:tests/data_foundation/test_parquet_writer.py†L1-L93】
 - Progress: Timescale ingest scheduler now registers with the runtime task
   supervisor, tagging interval/jitter metadata and exposing live snapshots so
   institutional pipelines inherit supervised background jobs instead of orphaned

--- a/docs/context/alignment_briefs/institutional_risk_compliance.md
+++ b/docs/context/alignment_briefs/institutional_risk_compliance.md
@@ -63,6 +63,11 @@
   exposes runtime-ready metadata snapshots, and drives the runtime builder’s
   enforcement path so supervisors and docs consume a single hardened contract
   under pytest coverage.【F:src/trading/risk/risk_api.py†L1-L134】【F:src/runtime/runtime_builder.py†L313-L343】【F:tests/trading/test_risk_api.py†L1-L115】【F:tests/trading/test_trading_manager_execution.py†L208-L224】
+- Progress: Trading risk interface telemetry helpers now publish structured
+  snapshots and contract-violation alerts with Markdown summaries, updating the
+  trading manager’s cached posture and emitting event-bus payloads under pytest
+  coverage so governance receives actionable enforcement evidence when the
+  interface degrades.【F:src/trading/risk/risk_interface_telemetry.py†L1-L156】【F:src/trading/trading_manager.py†L635-L678】【F:tests/trading/test_trading_manager_execution.py†L190-L287】
 - Progress: Compliance readiness snapshots now consolidate trade surveillance,
   KYC telemetry, and workflow checklist status, escalating blocked items,
   surfacing active task counts, and exposing markdown evidence with pytest

--- a/docs/context/alignment_briefs/quality_observability.md
+++ b/docs/context/alignment_briefs/quality_observability.md
@@ -77,6 +77,10 @@
     violation states to observability dashboard entries while preserving the
     serialised payloads, with pytest coverage asserting limit-status escalation
     so operators inherit actionable risk summaries instead of opaque aggregates.【F:src/operations/observability_dashboard.py†L254-L309】【F:tests/operations/test_observability_dashboard.py†L201-L241】
+  - Progress: Observability dashboard now exposes a remediation summary capsule
+    that counts failing/warning/healthy panels and lists affected slices under
+    regression coverage so CI exporters can consume a canonical operational
+    readiness signal without recomputing severities.【F:src/operations/observability_dashboard.py†L60-L109】【F:tests/operations/test_observability_dashboard.py†L60-L116】
   - Progress: Operational readiness telemetry now enriches snapshots with
     per-status breakdowns and component maps so dashboards can render severity
     chips without reimplementing escalation logic, with pytest and docs locking
@@ -99,6 +103,10 @@
   remediation plans inherit documented evidence. Latest coverage exercises the
   failure fallback hook, sanitised FIX wrappers, and latency bounds so telemetry
   captures degraded instrumentation instead of silently dropping metrics.【F:src/operational/metrics.py†L1-L200】【F:tests/operational/test_metrics.py†L200-L328】
+- Progress: Bootstrap stack now logs sensory listener, liquidity prober, and
+  control-centre callback failures with structured metadata so optional hooks
+  surface errors without disrupting bootstrap decisions, under pytest coverage
+  that captures the emitted diagnostics.【F:src/orchestration/bootstrap_stack.py†L81-L258】【F:tests/current/test_bootstrap_stack.py†L164-L213】
 - Wire Slack/webhook mirrors for CI alerts, rehearse the forced-failure drill,
   and record MTTA/MTTR in the health dashboard per the operational telemetry
   stream roadmap.【F:docs/technical_debt_assessment.md†L156-L174】【F:docs/status/ci_health.md†L74-L76】

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -40,6 +40,11 @@ Encyclopedia while acknowledging that most subsystems remain scaffolding.
     logs filesystem failures, and cleans up partial files so ingest tooling surfaces
     genuine persistence faults instead of emitting empty paths under silent
     fallbacks.【F:src/data_foundation/persist/jsonl_writer.py†L1-L69】【F:tests/data_foundation/test_jsonl_writer.py†L1-L37】
+  - *Progress*: Parquet ingest persistence now resolves the pandas DataFrame
+    constructor defensively, logs conversion and filesystem failures, and
+    returns explicit sentinels under regression coverage so institutional
+    ingest slices capture telemetry write issues instead of silently losing
+    events.【F:src/data_foundation/persist/parquet_writer.py†L1-L75】【F:tests/data_foundation/test_parquet_writer.py†L1-L93】
 - [ ] **Sensory + evolution execution** – Replace HOW/ANOMALY stubs, wire lineage
   telemetry, and prove adaptive strategies against recorded data.
   - *Progress*: Ecosystem optimizer now defends against unsafe genomes and
@@ -93,6 +98,11 @@ Encyclopedia while acknowledging that most subsystems remain scaffolding.
     and a contract runbook to every `RiskApiError`, with the runtime builder and
     trading manager surfacing the runbook URL so supervisors can escalate broken
     risk interfaces using the documented playbook.【F:docs/api/risk.md†L1-L23】【F:docs/operations/runbooks/risk_api_contract.md†L1-L31】【F:src/trading/risk/risk_api.py†L20-L118】【F:src/runtime/runtime_builder.py†L321-L337】【F:src/trading/trading_manager.py†L493-L529】【F:tests/runtime/test_runtime_builder.py†L183-L198】【F:tests/trading/test_risk_api.py†L114-L123】【F:tests/trading/test_trading_manager_execution.py†L222-L247】
+  - *Progress*: Trading manager now emits dedicated risk interface telemetry via
+    snapshot/error helpers that render Markdown summaries, publish structured
+    payloads on the event bus, and persist the latest posture for discovery,
+    with pytest asserting snapshot and alert propagation so supervisors inherit
+    actionable evidence when enforcement fails.【F:src/trading/risk/risk_interface_telemetry.py†L1-L156】【F:src/trading/trading_manager.py†L635-L678】【F:tests/trading/test_trading_manager_execution.py†L190-L287】
   - *Progress*: `RiskConfig` now enforces positive position sizing, cross-field
     exposure relationships, and research-mode overrides, emitting warnings when
     mandatory stop losses are disabled outside research and blocking
@@ -145,10 +155,18 @@ Encyclopedia while acknowledging that most subsystems remain scaffolding.
     trading-manager method, and formatter failures, keeping operational
     diagnostics visible during bootstrap runs and documenting the logging
     behaviour under pytest.【F:src/operations/bootstrap_control_center.py†L31-L115】【F:tests/current/test_bootstrap_control_center.py†L178-L199】
+  - *Progress*: Bootstrap orchestration now wraps sensory listeners,
+    liquidity probers, and control-centre callbacks with structured error
+    logging so optional observability hooks surface failures without breaking
+    the decision loop, with pytest capturing the emitted diagnostics.【F:src/orchestration/bootstrap_stack.py†L81-L258】【F:tests/current/test_bootstrap_stack.py†L164-L213】
   - *Progress*: Observability dashboard risk telemetry now annotates each metric
     with limit values, ratios, and violation statuses while preserving serialised
     payloads, backed by regression coverage so operators inherit actionable risk
     summaries instead of opaque aggregates.【F:src/operations/observability_dashboard.py†L254-L309】【F:tests/operations/test_observability_dashboard.py†L201-L241】
+  - *Progress*: Observability dashboard now emits a remediation summary capsule
+    that aggregates panel severities, highlights failing/warning slices, and is
+    regression-tested so CI status exporters can consume a canonical
+    institutional readiness snapshot without re-deriving counts.【F:src/operations/observability_dashboard.py†L60-L109】【F:tests/operations/test_observability_dashboard.py†L60-L116】
   - *Progress*: Operational readiness aggregation now fuses system validation,
     incident response, and ingest SLO snapshots into a single severity grade,
     emits Markdown/JSON for dashboards, derives alert events, and enriches the


### PR DESCRIPTION
## Summary
- capture the new trading risk interface telemetry, observability remediation capsule, and bootstrap logging hardening in the roadmap
- update the risk/compliance, quality/observability, and data backbone briefs so context packs reflect the latest persistence and telemetry improvements

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68de5b95b838832cbd6818edcebc2a2f