### PR TITLE
Update roadmap and briefs for recent telemetry and evolution work

### DIFF
--- a/docs/context/alignment_briefs/evolution_engine.md
+++ b/docs/context/alignment_briefs/evolution_engine.md
@@ -52,6 +52,10 @@
   【F:src/core/evolution/seeding.py†L1-L335】【F:src/core/evolution/engine.py†L250-L335】【F:tests/evolution/test_realistic_seeding.py†L1-L47】
 - Build population management routines (selection, mutation, evaluation) tied to
   recorded datasets; expose metrics via runtime summaries.
+- Progress: Recorded sensory replay evaluator converts archived sensory
+  snapshots into deterministic evaluation metrics, wiring price/confidence
+  extraction and replay scoring under pytest coverage so genomes can be vetted
+  against recorded data before live ingest arrives.【F:src/evolution/evaluation/recorded_replay.py†L1-L193】【F:tests/evolution/test_recorded_replay_evaluator.py†L1-L108】
 - Surface lineage telemetry and integrate with compliance workflow templates for
   strategy approvals.
 - Progress: Evolution experiment telemetry now guards publish failures, records

--- a/docs/context/alignment_briefs/operational_readiness.md
+++ b/docs/context/alignment_briefs/operational_readiness.md
@@ -53,6 +53,10 @@
   summaries, derives alert events, and now exposes status breakdown/component
   metadata so dashboards can render severity chips without recomputing logic,
   with pytest guarding the contract and docs capturing the payload update.【F:src/operations/operational_readiness.py†L1-L256】【F:tests/operations/test_operational_readiness.py†L1-L86】【F:docs/status/operational_readiness.md†L1-L34】【F:tests/runtime/test_professional_app_timescale.py†L722-L799】
+- Wire the observability dashboard to consume the readiness snapshot directly,
+  rendering a dedicated panel with component summaries and remediation roll-ups
+  under pytest coverage so operators see readiness posture alongside risk,
+  latency, and backbone panels without bespoke integrations.【F:src/operations/observability_dashboard.py†L443-L493】【F:tests/operations/test_observability_dashboard.py†L135-L236】
 - Update incident response docs with current limitations and TODOs; remove or
   archive obsolete OpenAPI references where possible.【F:docs/legacy/README.md†L1-L12】
 - Extend CI step summaries to include risk, ingest, and sensory telemetry status so

--- a/docs/context/alignment_briefs/quality_observability.md
+++ b/docs/context/alignment_briefs/quality_observability.md
@@ -85,6 +85,14 @@
     per-status breakdowns and component maps so dashboards can render severity
     chips without reimplementing escalation logic, with pytest and docs locking
     the contract alongside the runtime exposure.【F:src/operations/operational_readiness.py†L200-L256】【F:tests/operations/test_operational_readiness.py†L1-L86】【F:docs/status/operational_readiness.md†L1-L34】【F:tests/runtime/test_professional_app_timescale.py†L722-L799】
+  - Progress: Coverage matrix CLI now exposes lagging domains via the new
+    `identify_laggards` helper, supports a `--fail-below-threshold` guardrail,
+    and carries pytest coverage so CI can fail fast when coverage drops instead
+    of relying on manual dashboards.【F:tools/telemetry/coverage_matrix.py†L184-L304】【F:tests/tools/test_coverage_matrix.py†L1-L182】
+  - Progress: Observability dashboard surfaces operational readiness as a
+    first-class panel, counting component severities, embedding metadata, and
+    feeding remediation summaries under pytest coverage so responders inherit a
+    consolidated operational view without bespoke wiring.【F:src/operations/observability_dashboard.py†L443-L493】【F:tests/operations/test_observability_dashboard.py†L135-L236】
   - Progress: Ingest trend telemetry logging now records runtime publish
     fallbacks, raises on unexpected errors, and escalates global bus outages with
     pytest coverage so data backbone dashboards expose genuine gaps instead of

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -45,6 +45,10 @@ Encyclopedia while acknowledging that most subsystems remain scaffolding.
     returns explicit sentinels under regression coverage so institutional
     ingest slices capture telemetry write issues instead of silently losing
     events.【F:src/data_foundation/persist/parquet_writer.py†L1-L75】【F:tests/data_foundation/test_parquet_writer.py†L1-L93】
+  - *Progress*: Ingest telemetry publisher now logs recoverable local bus
+    failures, escalates unexpected exceptions, and falls back to the global bus
+    under pytest coverage so ingest snapshots are not silently dropped when the
+    runtime transport degrades.【F:src/data_foundation/ingest/telemetry.py†L33-L99】【F:tests/data_foundation/test_ingest_publishers.py†L1-L164】
 - [ ] **Sensory + evolution execution** – Replace HOW/ANOMALY stubs, wire lineage
   telemetry, and prove adaptive strategies against recorded data.
   - *Progress*: Ecosystem optimizer now defends against unsafe genomes and
@@ -70,6 +74,10 @@ Encyclopedia while acknowledging that most subsystems remain scaffolding.
     exception capture, markdown fallback logging, and pytest scenarios that
     simulate transport failures so dashboards and runbooks inherit reliable
     snapshots of paper-trading ROI and backlog posture.【F:src/operations/evolution_experiments.py†L40-L196】【F:tests/operations/test_evolution_experiments.py†L1-L126】
+  - *Progress*: Recorded sensory replay evaluator converts archived sensory
+    snapshots into deterministic fitness metrics, wiring price/confidence
+    extraction and regression coverage so adaptive runs can be validated without
+    live feeds while preserving reproducible fitness payloads.【F:src/evolution/evaluation/recorded_replay.py†L1-L193】【F:tests/evolution/test_recorded_replay_evaluator.py†L1-L108】
   - *Progress*: HOW and ANOMALY sensors now embed sanitised lineage records,
     compute shared threshold posture assessments, and surface state/breach
     metadata on every signal so downstream consumers can audit provenance and
@@ -147,6 +155,15 @@ Encyclopedia while acknowledging that most subsystems remain scaffolding.
     publishes the payload via the shared failover helper so dashboards and
     runtime reports inherit the same hardened transport guarantees under pytest
     coverage.【F:src/operations/strategy_performance.py†L200-L531】【F:tests/operations/test_strategy_performance.py†L68-L193】
+  - *Progress*: Coverage matrix CLI now surfaces lagging domains and can fail
+    the build when coverage drops below a configurable threshold, with helper
+    utilities and pytest coverage documenting the contract so guardrail
+    enforcement becomes part of CI instead of manual review.【F:tools/telemetry/coverage_matrix.py†L184-L304】【F:tests/tools/test_coverage_matrix.py†L1-L182】
+  - *Progress*: Observability dashboard integrates operational readiness
+    snapshots as a first-class panel, summarising component severities and
+    surfacing degraded services alongside risk, latency, and backbone telemetry
+    under regression coverage so responders inherit a consolidated operational
+    view.【F:src/operations/observability_dashboard.py†L443-L493】【F:tests/operations/test_observability_dashboard.py†L135-L236】
   - *Progress*: Health monitor resource probes now normalise psutil import
     failures, log probe errors, retain bounded history, and surface event-bus
     diagnostics so operational responders get actionable state even when optional

--- a/docs/status/operational_readiness.md
+++ b/docs/status/operational_readiness.md
@@ -34,3 +34,12 @@ if the breakdown or component mapping drift.
 
 Combine the snapshot with the observability dashboard output to give operators a
 clear view of which operational slices need attention each run.
+
+## Dashboard integration
+
+The observability dashboard now renders operational readiness as a dedicated
+panel, summarising component severities, highlighting degraded services, and
+embedding the full snapshot metadata in panel payloads. Regression coverage
+asserts that the panel headlines, remediation summaries, and Markdown export all
+surface the readiness status so responders inherit the enriched snapshot without
+custom wiring.【F:src/operations/observability_dashboard.py†L443-L493】【F:tests/operations/test_observability_dashboard.py†L135-L236】


### PR DESCRIPTION
## Summary
- document the hardened ingest telemetry publisher and recorded sensory replay evaluator in the roadmap and supporting briefs
- capture the new coverage matrix guardrail and operational readiness dashboard panel across roadmap, status, and context packs
- extend the operational readiness status doc with dashboard integration guidance

## Testing
- not run (documentation updates only)

------
https://chatgpt.com/codex/tasks/task_e_68de644457f4832c8216728db2fabcd4