### PR TITLE
Enhance evolution seed provenance telemetry

### DIFF
--- a/tests/evolution/test_lineage_snapshot.py
+++ b/tests/evolution/test_lineage_snapshot.py
@@ -28,6 +28,10 @@ def test_build_lineage_snapshot_fuses_stats_and_champion_metadata():
         "species_distribution": {"trend_following": 3, "carry": 2},
         "seed_source": "catalogue",
         "catalogue": {"name": "institutional", "seeded_at": 1234.0},
+        "seed_metadata": {
+            "seed_names": {"Trend Surfer Alpha": 3},
+            "seed_tags": {"trend": 3, "fx": 2},
+        },
     }
     summary = EvolutionSummary(
         generation=6,
@@ -48,12 +52,14 @@ def test_build_lineage_snapshot_fuses_stats_and_champion_metadata():
     assert snapshot.seed_source == "catalogue"
     assert snapshot.species_distribution["trend_following"] == 3
     assert snapshot.catalogue["name"] == "institutional"
+    assert snapshot.seed_metadata["seed_names"]["Trend Surfer Alpha"] == 3
 
     payload = snapshot.as_dict(max_parents=1, max_mutations=1)
     assert payload["champion"]["parent_ids"] == ["core-evo-0000"]
     assert payload["champion"]["mutation_history"] == ["g1:mutation:drift"]
     assert payload["champion"]["metadata"]["desk"] == "trend"
     assert payload["population"]["seed_source"] == "catalogue"
+    assert payload["population"]["seed_metadata"]["seed_names"]["Trend Surfer Alpha"] == 3
 
     fingerprint = snapshot.fingerprint()
     assert fingerprint[0] == 6


### PR DESCRIPTION
## Summary
- capture realistic genome seed provenance within the evolution engine and expose the metadata via the population manager
- extend lineage telemetry snapshots to surface seed distributions alongside catalogue and summary data
- add regression coverage ensuring seed metadata is emitted and consumed by the evolution orchestrator

## Testing
- pytest tests/current/test_evolution_orchestrator.py -q
- pytest tests/evolution/test_lineage_snapshot.py -q

------
https://chatgpt.com/codex/tasks/task_e_68de654507ec832c93c117ecd6ea040b