### PR TITLE
Update roadmap and briefs for recent telemetry upgrades

### DIFF
--- a/docs/context/alignment_briefs/evolution_engine.md
+++ b/docs/context/alignment_briefs/evolution_engine.md
@@ -62,6 +62,11 @@
   markdown fallbacks, and documents exception paths via pytest so dashboards and
   status packs retain reliable ROI and backlog metrics even when transports
   misbehave.【F:src/operations/evolution_experiments.py†L40-L196】【F:tests/operations/test_evolution_experiments.py†L1-L126】
+- Progress: Evolution engine now records seed provenance on population
+  initialization and after each generation, summarising catalogue templates,
+  seed tags, and totals for the population manager while lineage telemetry emits
+  the enriched payload under pytest coverage so orchestrator dashboards expose
+  deterministic seed metadata instead of opaque populations.【F:src/core/evolution/engine.py†L65-L336】【F:src/core/population_manager.py†L115-L183】【F:src/evolution/lineage_telemetry.py†L1-L200】【F:tests/current/test_evolution_orchestrator.py†L83-L120】【F:tests/evolution/test_lineage_snapshot.py†L8-L66】
 - Progress: Adaptive runs remain gated behind the `EVOLUTION_ENABLE_ADAPTIVE_RUNS`
   flag, with orchestrator wiring skipping champion registration and telemetry
   when the flag is disabled and pytest coverage documenting the contract so

--- a/docs/context/alignment_briefs/institutional_data_backbone.md
+++ b/docs/context/alignment_briefs/institutional_data_backbone.md
@@ -52,6 +52,10 @@
   logs conversion and filesystem errors, and returns explicit sentinels under
   regression coverage so institutional ingest slices capture failed telemetry
   persists rather than silently discarding events.【F:src/data_foundation/persist/parquet_writer.py†L1-L75】【F:tests/data_foundation/test_parquet_writer.py†L1-L93】
+- Progress: Core configuration shim now proxies legacy sections to the canonical
+  `SystemConfig`, normalising environment overrides and YAML parsing so ingest and
+  runtime modules consume the same source of truth while migration off the legacy
+  surface continues.【F:src/core/configuration.py†L1-L188】
 - Progress: Timescale ingest scheduler now registers with the runtime task
   supervisor, tagging interval/jitter metadata and exposing live snapshots so
   institutional pipelines inherit supervised background jobs instead of orphaned

--- a/docs/context/alignment_briefs/operational_readiness.md
+++ b/docs/context/alignment_briefs/operational_readiness.md
@@ -39,11 +39,12 @@
     shutdown callbacks so production launches share the same supervised lifecycle
     contract as the builder, with pytest covering normal completion and timeout
     cancellation flows.【F:src/runtime/runtime_runner.py†L1-L120】【F:main.py†L71-L125】【F:tests/runtime/test_runtime_runner.py†L1-L58】
-- Harden operational telemetry publishers so security and system validation
-  feeds warn on runtime bus failures, fall back deterministically, and raise on
-  unexpected errors with pytest coverage guarding the behaviour, including
-  regressions that capture global-bus fallbacks, runtime-not-running paths, and
-  unexpected error escalation for security publishing.【F:src/operations/security.py†L536-L579】【F:tests/operations/test_security.py†L101-L211】【F:src/operations/system_validation.py†L269-L312】【F:tests/operations/test_system_validation.py†L85-L137】
+- Harden operational telemetry publishers so security, system validation, and
+  professional readiness feeds warn on runtime bus failures, fall back
+  deterministically, and raise on unexpected errors with pytest coverage
+  guarding the behaviour, while system validation now records failing-check
+  metadata so responders see the exact degradation in Markdown and payloads.
+  【F:src/operations/security.py†L536-L579】【F:tests/operations/test_security.py†L101-L211】【F:src/operations/system_validation.py†L127-L321】【F:tests/operations/test_system_validation.py†L77-L160】【F:src/operations/professional_readiness.py†L268-L305】【F:tests/operations/test_professional_readiness.py†L164-L239】
 - Harden incident response telemetry with the shared failover helper so
   snapshots reuse the guarded runtime→global publish path, surface warning/error
   logs for degraded transports, and raise typed errors under pytest coverage

--- a/docs/context/alignment_briefs/quality_observability.md
+++ b/docs/context/alignment_briefs/quality_observability.md
@@ -130,6 +130,10 @@
   event-bus failover helper, logging runtime and global-bus degradations while
   tests assert the fallback contract so operators keep receiving deterministic
   drift alerts when the primary transport misbehaves.【F:src/operations/sensory_drift.py†L247-L276】【F:tests/operations/test_sensory_drift.py†L17-L163】
+- Progress: System validation snapshots now attach failing-check names and
+  messages to metadata and Markdown while reusing the shared failover helper so
+  operational dashboards display the exact broken checks even during runtime bus
+  degradation, with pytest covering metadata capture and failover paths.【F:src/operations/system_validation.py†L127-L321】【F:tests/operations/test_system_validation.py†L77-L160】
 
 ### Next (30–90 days)
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -70,6 +70,12 @@ Encyclopedia while acknowledging that most subsystems remain scaffolding.
     catalogue updates, and telemetry so governance can disable adaptive loops
     until approvals land, with pytest coverage documenting the flag contract and
     orchestration fallbacks.【F:src/evolution/feature_flags.py†L1-L44】【F:src/orchestration/evolution_cycle.py†L65-L340】【F:tests/current/test_evolution_orchestrator.py†L64-L240】【F:tests/evolution/test_feature_flags.py†L1-L27】
+  - *Progress*: Evolution engine now records seed provenance on every
+    initialization and generation, summarising catalogue template counts,
+    species tags, and seeded totals for the population manager while lineage
+    telemetry emits the enriched payload under pytest coverage so dashboards and
+    governance reviews inherit deterministic seed metadata instead of opaque
+    populations.【F:src/core/evolution/engine.py†L65-L336】【F:src/core/population_manager.py†L115-L183】【F:src/evolution/lineage_telemetry.py†L1-L200】【F:tests/current/test_evolution_orchestrator.py†L83-L120】【F:tests/evolution/test_lineage_snapshot.py†L8-L66】
   - *Progress*: Evolution experiment telemetry hardens publishing with explicit
     exception capture, markdown fallback logging, and pytest scenarios that
     simulate transport failures so dashboards and runbooks inherit reliable
@@ -195,10 +201,16 @@ Encyclopedia while acknowledging that most subsystems remain scaffolding.
     surfacing active task counts, and retaining the hardened publish failover so
     governance teams see actionable workflow posture even during runtime bus
     outages.【F:src/operations/compliance_readiness.py†L262-L420】【F:tests/operations/test_compliance_readiness.py†L58-L213】
-  - *Progress*: System validation telemetry escalates runtime publish failures
-    into warnings, raises on unexpected errors, and regression tests capture the
-    fallback handling so readiness dashboards surface degraded validation runs
-    instead of missing them.【F:src/operations/system_validation.py†L269-L312】【F:tests/operations/test_system_validation.py†L85-L137】
+  - *Progress*: System validation telemetry now attaches failing check names and
+    messages to snapshot metadata and Markdown output while continuing to route
+    through the shared failover helper, so readiness dashboards surface the
+    precise failing checks even when the runtime bus degrades, with pytest
+    verifying metadata capture and failover escalation.【F:src/operations/system_validation.py†L127-L321】【F:tests/operations/test_system_validation.py†L77-L160】
+  - *Progress*: Professional readiness publisher now reuses the hardened
+    failover helper, logging runtime fallbacks, refusing unexpected errors, and
+    supporting injected global bus factories under pytest coverage so
+    operational readiness telemetry is preserved when the primary transport
+    fails instead of silently dropping snapshots.【F:src/operations/professional_readiness.py†L268-L305】【F:tests/operations/test_professional_readiness.py†L164-L239】
   - *Progress*: Sensory drift telemetry publisher now routes through the shared
     failover helper, logging runtime and global-bus degradation while retaining
     deterministic payload metadata so dashboards receive alerts even when the
@@ -229,6 +241,11 @@ Encyclopedia while acknowledging that most subsystems remain scaffolding.
     canonical mean reversion regression to exercise the modern trading
     strategies API, shrinking the dead-code backlog and aligning tests with the
     production surface.【F:docs/reports/CLEANUP_REPORT.md†L87-L106】【F:tests/current/test_mean_reversion_strategy.py†L1-L80】
+  - *Progress*: Core configuration module now proxies every legacy accessor to
+    the canonical `SystemConfig`, preserving environment overrides, YAML import
+    compatibility, and debug coercion so downstream consumers can migrate
+    without duplicating parsing logic while the shim stops drifting from the
+    source of truth.【F:src/core/configuration.py†L1-L188】
 
 ## Roadmap cadence
 


### PR DESCRIPTION
## Summary
- document evolution seed provenance telemetry and lineage metadata in the roadmap and evolution brief
- capture system validation failing-check metadata and professional readiness failover in roadmap and operational briefs
- note the SystemConfig-backed configuration shim in roadmap and data backbone brief

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68de7e05bc44832cab34da3681ce604d