### PR TITLE
Add incident response and system validation alert routing helpers

### DIFF
--- a/src/operations/__init__.py
+++ b/src/operations/__init__.py
@@ -67,9 +67,11 @@ from .incident_response import (
     IncidentResponseSnapshot,
     IncidentResponseState,
     IncidentResponseStatus,
+    derive_incident_response_alerts,
     evaluate_incident_response,
     format_incident_response_markdown,
     publish_incident_response_snapshot,
+    route_incident_response_alerts,
 )
 from .execution import (
     ExecutionIssue,
@@ -138,8 +140,10 @@ from .system_validation import (
     SystemValidationCheck,
     SystemValidationSnapshot,
     SystemValidationStatus,
+    derive_system_validation_alerts,
     evaluate_system_validation,
     format_system_validation_markdown,
+    route_system_validation_alerts,
     publish_system_validation_snapshot,
     load_system_validation_snapshot,
 )


### PR DESCRIPTION
## Summary
- add alert derivation and routing helpers for incident response snapshots, including policy aware detail events
- expose system validation alert derivation and routing helpers through the operations facade
- extend incident response and system validation tests to cover alert generation and dispatch flows

## Testing
- pytest tests/operations/test_incident_response.py tests/operations/test_system_validation.py

------
https://chatgpt.com/codex/tasks/task_e_68de8030ed90832c9f08374a6a6d550c