### PR TITLE
Update roadmap for new readiness telemetry

### DIFF
--- a/docs/context/alignment_briefs/evolution_engine.md
+++ b/docs/context/alignment_briefs/evolution_engine.md
@@ -62,6 +62,10 @@
   markdown fallbacks, and documents exception paths via pytest so dashboards and
   status packs retain reliable ROI and backlog metrics even when transports
   misbehave.【F:src/operations/evolution_experiments.py†L40-L196】【F:tests/operations/test_evolution_experiments.py†L1-L126】
+- Progress: Evolution readiness evaluator merges the adaptive-run feature flag,
+  population seed metadata, and lineage telemetry into a governance snapshot,
+  rendering Markdown/JSON summaries with champion provenance and blocking issues
+  so reviewers can gate adaptive runs deterministically under pytest coverage.【F:src/operations/evolution_readiness.py†L1-L206】【F:tests/operations/test_evolution_readiness.py†L1-L118】
 - Progress: Evolution engine now records seed provenance on population
   initialization and after each generation, summarising catalogue templates,
   seed tags, and totals for the population manager while lineage telemetry emits

--- a/docs/context/alignment_briefs/institutional_risk_compliance.md
+++ b/docs/context/alignment_briefs/institutional_risk_compliance.md
@@ -49,11 +49,11 @@
   summaries, and publish violation alerts with embedded escalation metadata while
   the trading manager mirrors the feed and the new runbook documents the response,
   giving governance a deterministic alert surface when violations occur.【F:src/trading/risk/policy_telemetry.py†L1-L285】【F:src/trading/trading_manager.py†L642-L686】【F:docs/operations/runbooks/risk_policy_violation.md†L1-L51】【F:tests/trading/test_risk_policy_telemetry.py†L1-L199】
-- Progress: Canonical `RiskConfig` enforces positive position sizing, cross-field
-  exposure relationships, and research-mode overrides, emitting warnings when
-  mandatory stop losses are disabled outside research and blocking inconsistent
-  payloads under pytest coverage so compliance reviews inherit deterministic
-  guardrails.【F:src/config/risk/risk_config.py†L1-L161】【F:tests/risk/test_risk_config_validation.py†L1-L36】
+- Progress: Canonical `RiskConfig` now normalises instrument/sector inputs,
+  rejects duplicate sector limits, enforces sector budgets against the global
+  exposure cap, and retains the research-mode and position-sizing guards so
+  compliance reviews inherit deterministic, de-duplicated limits under pytest
+  coverage.【F:src/config/risk/risk_config.py†L10-L205】【F:tests/risk/test_risk_config_validation.py†L39-L70】
 - Progress: Runtime builder now resolves the canonical `RiskConfig`, validates
   thresholds, wraps invalid payloads in runtime errors, and records enforced
   metadata under regression coverage so supervised launches cannot proceed with

--- a/docs/context/alignment_briefs/operational_readiness.md
+++ b/docs/context/alignment_briefs/operational_readiness.md
@@ -42,13 +42,15 @@
 - Harden operational telemetry publishers so security, system validation, and
   professional readiness feeds warn on runtime bus failures, fall back
   deterministically, and raise on unexpected errors with pytest coverage
-  guarding the behaviour, while system validation now records failing-check
-  metadata so responders see the exact degradation in Markdown and payloads.
-  【F:src/operations/security.py†L536-L579】【F:tests/operations/test_security.py†L101-L211】【F:src/operations/system_validation.py†L127-L321】【F:tests/operations/test_system_validation.py†L77-L160】【F:src/operations/professional_readiness.py†L268-L305】【F:tests/operations/test_professional_readiness.py†L164-L239】
-- Harden incident response telemetry with the shared failover helper so
-  snapshots reuse the guarded runtime→global publish path, surface warning/error
-  logs for degraded transports, and raise typed errors under pytest coverage
-  instead of silently skipping outage evidence.【F:src/operations/incident_response.py†L350-L375】【F:tests/operations/test_incident_response.py†L123-L167】【F:src/operations/event_bus_failover.py†L1-L174】
+  guarding the behaviour. The system validation track now evaluates structured
+  reports into readiness snapshots, derives alert events, and publishes via the
+  shared failover helper while preserving failing-check metadata in Markdown and
+  payloads so responders see the exact degradation.【F:src/operations/security.py†L536-L579】【F:tests/operations/test_security.py†L101-L211】【F:src/operations/system_validation.py†L1-L312】【F:tests/operations/test_system_validation.py†L1-L195】【F:src/operations/professional_readiness.py†L268-L305】【F:tests/operations/test_professional_readiness.py†L164-L239】
+- Harden incident response readiness by parsing policy/state mappings into a
+  severity snapshot, deriving targeted alert events, and publishing telemetry
+  via the guarded runtime→global failover path so outage evidence, roster gaps,
+  and postmortem backlog context stay visible under pytest coverage documenting
+  escalation and publish failures.【F:src/operations/incident_response.py†L1-L715】【F:tests/operations/test_incident_response.py†L1-L200】【F:src/operations/event_bus_failover.py†L1-L174】
 - Aggregate operational readiness into a single severity snapshot that merges
   system validation, incident response, and ingest SLO posture, emits Markdown
   summaries, derives alert events, and now exposes status breakdown/component

--- a/docs/context/alignment_briefs/quality_observability.md
+++ b/docs/context/alignment_briefs/quality_observability.md
@@ -49,14 +49,19 @@
   - Progress: Added guardrail regressions for the trading position model to
     assert timestamp updates, profit recalculations, and close flows so the
     lightweight execution telemetry remains deterministic under CI coverage.【F:tests/trading/test_position_model_guardrails.py†L1-L105】
-  - Progress: System validation telemetry regressions now capture runtime bus
-    fallbacks and unexpected-error escalations, hardening operational coverage so
-    readiness dashboards surface degraded runs instead of swallowing failures.【F:src/operations/system_validation.py†L269-L312】【F:tests/operations/test_system_validation.py†L85-L137】
+  - Progress: System validation evaluator now normalises structured reports into
+    readiness snapshots, annotates failing checks, derives alert events, and
+    publishes via the failover helper under pytest coverage so dashboards retain
+    degradation evidence even when the runtime bus misbehaves.【F:src/operations/system_validation.py†L1-L312】【F:tests/operations/test_system_validation.py†L1-L195】
   - Progress: Event bus failover helper now powers security, system validation,
     compliance readiness, incident response, and evolution experiment
     publishers, replacing ad-hoc blanket handlers with typed errors and
     structured logging so transport regressions escalate consistently across
-    modules.【F:src/operations/event_bus_failover.py†L1-L174】【F:src/operations/incident_response.py†L350-L375】【F:src/operations/evolution_experiments.py†L297-L342】【F:tests/operations/test_event_bus_failover.py†L1-L164】【F:tests/operations/test_incident_response.py†L123-L167】【F:tests/operations/test_evolution_experiments.py†L135-L191】
+    modules.【F:src/operations/event_bus_failover.py†L1-L174】【F:src/operations/incident_response.py†L675-L715】【F:src/operations/evolution_experiments.py†L297-L342】【F:tests/operations/test_event_bus_failover.py†L1-L164】【F:tests/operations/test_incident_response.py†L135-L179】【F:tests/operations/test_evolution_experiments.py†L135-L191】
+  - Progress: Incident response readiness now evaluates policy/state mappings,
+    emits Markdown snapshots, derives roster/backlog alerts, and publishes via
+    the failover helper under pytest coverage so operators inherit actionable
+    escalations instead of silent outages.【F:src/operations/incident_response.py†L1-L715】【F:tests/operations/test_incident_response.py†L1-L200】
   - Progress: Guardrail manifest tests pin the ingest orchestration, risk policy,
     and observability suites to the CI guardrail marker so coverage drops or
     marker drift block merges before the broader regression run, with pytest

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -80,6 +80,11 @@ Encyclopedia while acknowledging that most subsystems remain scaffolding.
     exception capture, markdown fallback logging, and pytest scenarios that
     simulate transport failures so dashboards and runbooks inherit reliable
     snapshots of paper-trading ROI and backlog posture.【F:src/operations/evolution_experiments.py†L40-L196】【F:tests/operations/test_evolution_experiments.py†L1-L126】
+  - *Progress*: Evolution readiness evaluator now fuses the adaptive-run feature
+    flag, seed provenance statistics, and lineage telemetry into a governance
+    snapshot, rendering Markdown/JSON summaries, capturing issues, and exposing
+    champion metadata so reviewers can gate adaptive runs deterministically
+    under pytest coverage.【F:src/operations/evolution_readiness.py†L1-L206】【F:tests/operations/test_evolution_readiness.py†L1-L118】
   - *Progress*: Recorded sensory replay evaluator converts archived sensory
     snapshots into deterministic fitness metrics, wiring price/confidence
     extraction and regression coverage so adaptive runs can be validated without
@@ -117,10 +122,11 @@ Encyclopedia while acknowledging that most subsystems remain scaffolding.
     payloads on the event bus, and persist the latest posture for discovery,
     with pytest asserting snapshot and alert propagation so supervisors inherit
     actionable evidence when enforcement fails.【F:src/trading/risk/risk_interface_telemetry.py†L1-L156】【F:src/trading/trading_manager.py†L635-L678】【F:tests/trading/test_trading_manager_execution.py†L190-L287】
-  - *Progress*: `RiskConfig` now enforces positive position sizing, cross-field
-    exposure relationships, and research-mode overrides, emitting warnings when
-    mandatory stop losses are disabled outside research and blocking
-    inconsistent payloads under pytest coverage.【F:src/config/risk/risk_config.py†L1-L161】【F:tests/risk/test_risk_config_validation.py†L1-L36】
+  - *Progress*: `RiskConfig` now normalises sector/instrument mappings, rejects
+    duplicate or missing sector limits, caps sector exposure against the global
+    budget, and continues to enforce position sizing plus research-mode
+    overrides so governance reviews inherit deterministic, de-duplicated risk
+    inputs under pytest coverage.【F:src/config/risk/risk_config.py†L10-L205】【F:tests/risk/test_risk_config_validation.py†L39-L70】
   - *Progress*: Runtime builder now resolves the canonical `RiskConfig` from the
     trading manager, validates mandatory thresholds, wraps invalid payloads in a
     deterministic runtime error, and logs the enforced posture under regression
@@ -161,6 +167,16 @@ Encyclopedia while acknowledging that most subsystems remain scaffolding.
     publishes the payload via the shared failover helper so dashboards and
     runtime reports inherit the same hardened transport guarantees under pytest
     coverage.【F:src/operations/strategy_performance.py†L200-L531】【F:tests/operations/test_strategy_performance.py†L68-L193】
+  - *Progress*: Incident response readiness now parses policy/state mappings into
+    a severity snapshot, derives targeted alert events, and publishes telemetry
+    via the shared failover helper so operators get actionable runbook, roster,
+    and backlog evidence under pytest coverage covering escalation, dispatch,
+    and publish failure paths.【F:src/operations/incident_response.py†L1-L715】【F:tests/operations/test_incident_response.py†L1-L200】
+  - *Progress*: System validation evaluator ingests JSON/structured reports,
+    normalises timestamps and success rates, renders Markdown, derives alert
+    events, and routes/publishes snapshots through the failover helper so
+    readiness dashboards retain failing-check context even when the runtime bus
+    degrades, with pytest guarding evaluation, alerting, and failover flows.【F:src/operations/system_validation.py†L1-L312】【F:tests/operations/test_system_validation.py†L1-L195】
   - *Progress*: Coverage matrix CLI now surfaces lagging domains and can fail
     the build when coverage drops below a configurable threshold, with helper
     utilities and pytest coverage documenting the contract so guardrail

--- a/docs/status/operational_readiness.md
+++ b/docs/status/operational_readiness.md
@@ -35,6 +35,18 @@ if the breakdown or component mapping drift.
 Combine the snapshot with the observability dashboard output to give operators a
 clear view of which operational slices need attention each run.
 
+## Feeder snapshots
+
+- `evaluate_incident_response` turns policy/state mappings into a readiness
+  snapshot, attaches missing-runbook, roster, backlog, and chatops context, and
+  exposes Markdown plus alert derivation helpers so the operational readiness
+  aggregate inherits actionable incident evidence under pytest coverage.【F:src/operations/incident_response.py†L249-L715】【F:tests/operations/test_incident_response.py†L1-L200】
+- `evaluate_system_validation` ingests structured reports, computes success
+  rates, annotates failing checks, and publishes via the shared failover helper
+  so readiness retains validator metadata and degraded-check evidence even when
+  the runtime bus falters, with regressions covering evaluation, alerting, and
+  failover paths.【F:src/operations/system_validation.py†L1-L312】【F:tests/operations/test_system_validation.py†L1-L195】
+
 ## Dashboard integration
 
 The observability dashboard now renders operational readiness as a dedicated


### PR DESCRIPTION
## Summary
- document the evolution readiness snapshot alongside the latest incident response and system validation hardening in the roadmap
- refresh the operational readiness status page and context briefs with the new readiness and risk configuration capabilities
- capture risk configuration input normalisation in the institutional risk brief

## Testing
- not run (documentation updates only)


------
https://chatgpt.com/codex/tasks/task_e_68de8850f144832c8bb8f5781066ebed