### PR TITLE
Add ingest scheduler guardrail coverage

### DIFF
--- a/tests/data_foundation/test_ingest_scheduler.py
+++ b/tests/data_foundation/test_ingest_scheduler.py
@@ -3,6 +3,9 @@ from datetime import UTC, datetime, timedelta
 
 import pytest
 
+
+pytestmark = [pytest.mark.guardrail]
+
 from src.core.event_bus import AsyncEventBus
 from src.data_foundation.ingest.scheduler import (
     IngestSchedule,

--- a/tests/runtime/test_guardrail_suite_manifest.py
+++ b/tests/runtime/test_guardrail_suite_manifest.py
@@ -17,6 +17,7 @@ pytestmark = pytest.mark.guardrail
 
 _GUARDRAIL_TARGETS: dict[str, Path] = {
     "ingest_orchestration": Path("tests/data_foundation/test_timescale_backbone_orchestrator.py"),
+    "ingest_scheduler": Path("tests/data_foundation/test_ingest_scheduler.py"),
     "risk_policy": Path("tests/trading/test_risk_policy.py"),
     "observability_event_bus": Path("tests/operations/test_event_bus_health.py"),
 }


### PR DESCRIPTION
## Summary
- mark the ingest scheduler regression suite with the guardrail marker so it participates in the CI guardrail job
- extend the guardrail manifest to require the ingest scheduler test module alongside existing ingest, risk, and observability suites

## Testing
- pytest tests/runtime/test_guardrail_suite_manifest.py
- pytest tests/data_foundation/test_ingest_scheduler.py -k "scheduler_runs" -q


------
https://chatgpt.com/codex/tasks/task_e_68de89d15bfc832cb1397b97b8b8fea9