### PR TITLE
Enforce stop-loss in runtime risk configuration

### DIFF
--- a/src/trading/risk/risk_api.py
+++ b/src/trading/risk/risk_api.py
@@ -23,6 +23,10 @@ from src.config.risk.risk_config import RiskConfig
 _DEFAULT_RUNBOOK = "docs/operations/runbooks/risk_api_contract.md"
 
 
+# Public alias so runtime supervisors can surface consistent remediation links.
+RISK_API_RUNBOOK = _DEFAULT_RUNBOOK
+
+
 class RiskApiError(RuntimeError):
     """Raised when a trading manager violates the risk API contract."""
 
@@ -157,6 +161,7 @@ def build_runtime_risk_metadata(trading_manager: Any) -> dict[str, object]:
 
 
 __all__ = [
+    "RISK_API_RUNBOOK",
     "RiskApiError",
     "TradingRiskInterface",
     "build_runtime_risk_metadata",


### PR DESCRIPTION
## Summary
- prevent runtime applications from starting when the resolved RiskConfig disables mandatory stop losses outside research mode and surface runbook metadata for operators
- expose the risk API runbook constant for reuse and add regression coverage for the new guard

## Testing
- pytest tests/runtime/test_runtime_builder.py -k "risk_config or stop_loss" -q

------
https://chatgpt.com/codex/tasks/task_e_68de89d15bfc832cb1397b97b8b8fea9