### PR TITLE
Harden execution telemetry publishing

### DIFF
--- a/src/operations/execution.py
+++ b/src/operations/execution.py
@@ -9,7 +9,8 @@ from datetime import UTC, datetime
 from enum import StrEnum
 from typing import Mapping
 
-from src.core.event_bus import Event, EventBus, get_global_bus
+from src.core.event_bus import Event, EventBus
+from src.operations.event_bus_failover import publish_event_with_failover
 
 logger = logging.getLogger(__name__)
 
@@ -621,19 +622,21 @@ def publish_execution_snapshot(
         source=source,
     )
 
-    publish_from_sync = getattr(event_bus, "publish_from_sync", None)
-    if callable(publish_from_sync) and event_bus.is_running():
-        try:
-            publish_from_sync(event)
-            return
-        except Exception:  # pragma: no cover - defensive logging
-            logger.debug("Failed to publish execution readiness via runtime bus", exc_info=True)
-
-    try:
-        topic_bus = get_global_bus()
-        topic_bus.publish_sync(event.type, event.payload, source=event.source)
-    except Exception:  # pragma: no cover - defensive logging
-        logger.debug("Execution readiness telemetry publish skipped", exc_info=True)
+    publish_event_with_failover(
+        event_bus,
+        event,
+        logger=logger,
+        runtime_fallback_message=
+        "Runtime execution telemetry publish failed; falling back to global bus",
+        runtime_unexpected_message=
+        "Unexpected runtime error while publishing execution telemetry",
+        runtime_none_message=
+        "Runtime bus returned no result for execution telemetry; falling back to global bus",
+        global_not_running_message=
+        "Global bus unavailable while publishing execution telemetry",
+        global_unexpected_message=
+        "Unexpected global bus error while publishing execution telemetry",
+    )
 
 
 __all__ = [

--- a/tests/operations/test_execution.py
+++ b/tests/operations/test_execution.py
@@ -1,9 +1,15 @@
+from __future__ import annotations
+
 from datetime import datetime, timezone
+import logging
+from typing import Any, Mapping
 
 import pytest
 
+from src.operations.event_bus_failover import EventPublishError
 from src.operations.execution import (
     ExecutionPolicy,
+    ExecutionReadinessSnapshot,
     ExecutionState,
     ExecutionStatus,
     evaluate_execution_readiness,
@@ -12,15 +18,37 @@ from src.operations.execution import (
 )
 
 
-class StubBus:
+class _StubEventBus:
     def __init__(self) -> None:
         self.events: list[object] = []
 
-    def publish_from_sync(self, event: object) -> None:
+    def publish_from_sync(self, event: object) -> bool:
         self.events.append(event)
+        return True
 
     def is_running(self) -> bool:
         return True
+
+
+class _StubGlobalBus:
+    def __init__(self) -> None:
+        self.events: list[tuple[str, Mapping[str, object], str]] = []
+
+    def publish_sync(
+        self, event_type: str, payload: Mapping[str, object], *, source: str
+    ) -> None:
+        self.events.append((event_type, dict(payload), source))
+
+
+def _build_snapshot() -> ExecutionReadinessSnapshot:
+    policy = ExecutionPolicy()
+    state = ExecutionState(
+        orders_submitted=5,
+        orders_executed=5,
+        connection_healthy=True,
+        last_execution_at=datetime.now(timezone.utc),
+    )
+    return evaluate_execution_readiness(policy, state)
 
 
 def test_evaluate_execution_readiness_pass() -> None:
@@ -82,16 +110,104 @@ def test_evaluate_execution_readiness_flags_failures() -> None:
     assert "pending_orders_exceeded" in issue_codes
 
 
-def test_publish_execution_snapshot_emits_event() -> None:
-    policy = ExecutionPolicy()
-    state = ExecutionState(orders_submitted=5, orders_executed=5, connection_healthy=True)
-    snapshot = evaluate_execution_readiness(policy, state)
+def test_publish_execution_snapshot_prefers_runtime_bus(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    bus = _StubEventBus()
 
-    bus = StubBus()
+    def _unexpected_global() -> None:
+        raise AssertionError("global bus should not be used when runtime succeeds")
+
+    monkeypatch.setattr(
+        "src.operations.event_bus_failover.get_global_bus", _unexpected_global
+    )
+
+    snapshot = _build_snapshot()
+
     publish_execution_snapshot(bus, snapshot, source="test")
-    assert bus.events, "expected execution telemetry event"
+
+    assert bus.events
     event = bus.events[-1]
     assert getattr(event, "type", "") == "telemetry.operational.execution"
     assert getattr(event, "source", "") == "test"
-    payload = getattr(event, "payload", {})
-    assert payload.get("status") in {status.value for status in ExecutionStatus}
+
+
+def test_publish_execution_snapshot_falls_back_on_runtime_failure(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    bus = _StubEventBus()
+
+    def _failing_publish(_: object) -> bool:
+        raise RuntimeError("primary bus offline")
+
+    bus.publish_from_sync = _failing_publish  # type: ignore[assignment]
+
+    global_bus = _StubGlobalBus()
+    monkeypatch.setattr(
+        "src.operations.event_bus_failover.get_global_bus", lambda: global_bus
+    )
+
+    snapshot = _build_snapshot()
+
+    with caplog.at_level(logging.WARNING):
+        publish_execution_snapshot(bus, snapshot, source="test")
+
+    assert not bus.events
+    assert global_bus.events
+    event_type, payload, source = global_bus.events[-1]
+    assert event_type == "telemetry.operational.execution"
+    assert payload["status"] in {status.value for status in ExecutionStatus}
+    assert source == "test"
+    assert any(
+        "falling back to global bus" in message.lower() for message in caplog.messages
+    )
+
+
+def test_publish_execution_snapshot_raises_on_unexpected_runtime_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    bus = _StubEventBus()
+
+    def _unexpected(_: object) -> bool:
+        raise ValueError("boom")
+
+    bus.publish_from_sync = _unexpected  # type: ignore[assignment]
+
+    called: list[Any] = []
+
+    def _global_bus() -> _StubGlobalBus:
+        called.append("invoked")
+        return _StubGlobalBus()
+
+    monkeypatch.setattr("src.operations.event_bus_failover.get_global_bus", _global_bus)
+
+    snapshot = _build_snapshot()
+
+    with pytest.raises(EventPublishError) as exc:
+        publish_execution_snapshot(bus, snapshot)
+
+    assert exc.value.stage == "runtime"
+    assert not called, "global bus should not be invoked when runtime raises"
+
+
+def test_publish_execution_snapshot_raises_when_global_bus_unavailable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    bus = _StubEventBus()
+
+    def _runtime_failure(_: object) -> bool:
+        raise RuntimeError("runtime offline")
+
+    bus.publish_from_sync = _runtime_failure  # type: ignore[assignment]
+
+    def _global_failure() -> None:
+        raise RuntimeError("global offline")
+
+    monkeypatch.setattr("src.operations.event_bus_failover.get_global_bus", _global_failure)
+
+    snapshot = _build_snapshot()
+
+    with pytest.raises(EventPublishError) as exc:
+        publish_execution_snapshot(bus, snapshot)
+
+    assert exc.value.stage == "global"


### PR DESCRIPTION
## Summary
- route execution telemetry publishing through the shared event bus failover helper to drop blanket exception handling
- expand execution telemetry tests to cover runtime success, fallback, and failure modes while reusing deterministic snapshots

## Testing
- pytest tests/operations/test_execution.py

------
https://chatgpt.com/codex/tasks/task_e_68de89d15bfc832cb1397b97b8b8fea9