### PR TITLE
Enhance coverage telemetry summaries

### DIFF
--- a/tests/tools/test_ci_metrics.py
+++ b/tests/tools/test_ci_metrics.py
@@ -167,6 +167,8 @@ def test_record_coverage_domains_appends_entry(tmp_path: Path) -> None:
     assert entry["source"] == str(coverage_path)
     assert entry["threshold"] == 90.0
     assert entry["lagging_domains"] == ["core", "trading"]
+    assert entry["lagging_count"] == 2
+    assert entry["worst_domain"]["name"] == "core"
     assert entry["totals"]["files"] == 2
     assert isinstance(entry["generated_at"], str)
     domain_names = [domain["name"] for domain in entry["domains"]]
@@ -231,8 +233,11 @@ def test_update_ci_metrics_cli_updates_both(tmp_path: Path) -> None:
     assert stored["coverage_trend"][-1]["label"] == "coverage-sample"
     assert stored["formatter_trend"][-1]["label"] == "formatter-sample"
     assert stored["formatter_trend"][-1]["total_entries"] == 2
-    assert stored["coverage_domain_trend"][-1]["label"] == "coverage-sample"
-    assert stored["coverage_domain_trend"][-1]["domains"]
+    coverage_entry = stored["coverage_domain_trend"][-1]
+    assert coverage_entry["label"] == "coverage-sample"
+    assert coverage_entry["domains"]
+    assert coverage_entry["lagging_count"] == len(coverage_entry["lagging_domains"])
+    assert coverage_entry["worst_domain"]["name"] in coverage_entry["lagging_domains"]
     assert stored["remediation_trend"] == []
 
 

--- a/tests/tools/test_coverage_matrix.py
+++ b/tests/tools/test_coverage_matrix.py
@@ -137,6 +137,8 @@ def test_cli_writes_json_payload(tmp_path: Path, coverage_report: Path) -> None:
     payload = json.loads(output_path.read_text())
     assert payload["threshold"] == 70.0
     assert payload["laggards"] == ["other", "risk", "sensory"]
+    assert payload["lagging_count"] == 3
+    assert payload["worst_domain"]["name"] == "other"
     totals = payload["totals"]
     assert totals["files"] == 5
     assert totals["coverage_percent"] == pytest.approx(66.67)

--- a/tools/telemetry/ci_metrics.py
+++ b/tools/telemetry/ci_metrics.py
@@ -133,6 +133,13 @@ def record_coverage_domains(
             for domain in entry["domains"]
             if float(domain["coverage_percent"]) < float(threshold)
         ]
+        entry["lagging_count"] = len(entry["lagging_domains"])
+
+    if matrix.domains:
+        worst_domain = min(matrix.domains, key=lambda domain: domain.percent)
+        entry["worst_domain"] = worst_domain.as_dict()
+    else:
+        entry["worst_domain"] = None
 
     metrics["coverage_domain_trend"].append(entry)
     save_metrics(metrics_path, metrics)

--- a/tools/telemetry/coverage_matrix.py
+++ b/tools/telemetry/coverage_matrix.py
@@ -278,6 +278,12 @@ def main(argv: Sequence[str] | None = None) -> int:
         payload = matrix.as_dict()
         payload["threshold"] = args.threshold
         payload["laggards"] = [domain.name for domain in laggards]
+        payload["lagging_count"] = len(laggards)
+        payload["worst_domain"] = (
+            laggards[0].as_dict()
+            if laggards
+            else (matrix.domains[0].as_dict() if matrix.domains else None)
+        )
         output_text = json.dumps(payload, indent=2, sort_keys=True) + "\n"
     else:
         output_text = render_markdown(matrix, threshold=args.threshold)


### PR DESCRIPTION
## Summary
- add lagging domain counts and worst-domain snapshots to CI coverage telemetry entries
- extend the coverage matrix CLI JSON output with matching summary fields
- update regression tests to cover the new telemetry keys

## Testing
- pytest tests/tools/test_coverage_matrix.py tests/tools/test_ci_metrics.py

------
https://chatgpt.com/codex/tasks/task_e_68df727e34dc832c8dd4cba6c6c74db9