### PR TITLE
Add adaptive run decision telemetry for evolution orchestrator

### DIFF
--- a/src/evolution/feature_flags.py
+++ b/src/evolution/feature_flags.py
@@ -24,6 +24,24 @@ def _coerce_bool(value: object) -> bool:
     return False
 
 
+@dataclass(frozen=True, slots=True)
+class AdaptiveRunDecision:
+    """Decision metadata describing whether adaptive runs are enabled."""
+
+    enabled: bool
+    source: str
+    raw_value: object | None = None
+    reason: str | None = None
+
+    def as_dict(self) -> dict[str, object]:
+        payload: dict[str, object] = {"enabled": self.enabled, "source": self.source}
+        if self.reason:
+            payload["reason"] = self.reason
+        if self.raw_value is not None:
+            payload["raw_value"] = self.raw_value
+        return payload
+
+
 @dataclass(slots=True)
 class EvolutionFeatureFlags:
     """Resolve evolution feature flags with optional overrides for tests."""
@@ -33,12 +51,41 @@ class EvolutionFeatureFlags:
     def adaptive_runs_enabled(self, override: bool | None = None) -> bool:
         """Return whether adaptive evolution runs are enabled."""
 
+        return self.adaptive_runs_decision(override=override).enabled
+
+    def adaptive_runs_decision(
+        self, override: bool | None = None
+    ) -> AdaptiveRunDecision:
+        """Return the gating decision for adaptive evolution runs."""
+
         if override is not None:
-            return bool(override)
+            enabled = bool(override)
+            reason = "override_enabled" if enabled else "override_disabled"
+            return AdaptiveRunDecision(
+                enabled=enabled,
+                source="override",
+                raw_value=override,
+                reason=reason,
+            )
 
         source = self.env if self.env is not None else os.environ
         raw = source.get(ADAPTIVE_RUNS_FLAG)
-        return _coerce_bool(raw)
+        if raw is None:
+            return AdaptiveRunDecision(
+                enabled=False,
+                source="environment",
+                raw_value=None,
+                reason="flag_missing",
+            )
+
+        enabled = _coerce_bool(raw)
+        reason = "flag_enabled" if enabled else "flag_disabled"
+        return AdaptiveRunDecision(
+            enabled=enabled,
+            source="environment",
+            raw_value=raw,
+            reason=reason,
+        )
 
 
-__all__ = ["EvolutionFeatureFlags", "ADAPTIVE_RUNS_FLAG"]
+__all__ = ["AdaptiveRunDecision", "EvolutionFeatureFlags", "ADAPTIVE_RUNS_FLAG"]

--- a/tests/evolution/test_feature_flags.py
+++ b/tests/evolution/test_feature_flags.py
@@ -2,7 +2,11 @@ from __future__ import annotations
 
 import pytest
 
-from src.evolution.feature_flags import ADAPTIVE_RUNS_FLAG, EvolutionFeatureFlags
+from src.evolution.feature_flags import (
+    ADAPTIVE_RUNS_FLAG,
+    AdaptiveRunDecision,
+    EvolutionFeatureFlags,
+)
 
 
 @pytest.fixture(autouse=True)
@@ -12,16 +16,31 @@ def _clear_flags(monkeypatch: pytest.MonkeyPatch) -> None:
 
 def test_adaptive_runs_disabled_by_default() -> None:
     flags = EvolutionFeatureFlags()
+    decision = flags.adaptive_runs_decision()
+    assert isinstance(decision, AdaptiveRunDecision)
+    assert decision.enabled is False
+    assert decision.source == "environment"
+    assert decision.reason == "flag_missing"
     assert flags.adaptive_runs_enabled() is False
 
 
 def test_adaptive_runs_enabled_via_env(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv(ADAPTIVE_RUNS_FLAG, "yes")
     flags = EvolutionFeatureFlags()
+    decision = flags.adaptive_runs_decision()
+    assert decision.enabled is True
+    assert decision.source == "environment"
+    assert decision.reason == "flag_enabled"
+    assert decision.as_dict()["raw_value"] == "yes"
     assert flags.adaptive_runs_enabled() is True
 
 
 def test_adaptive_runs_override_and_custom_env() -> None:
     flags = EvolutionFeatureFlags(env={ADAPTIVE_RUNS_FLAG: "on"})
     assert flags.adaptive_runs_enabled() is True
-    assert flags.adaptive_runs_enabled(override=False) is False
+
+    override_decision = flags.adaptive_runs_decision(override=False)
+    assert override_decision.enabled is False
+    assert override_decision.source == "override"
+    assert override_decision.reason == "override_disabled"
+    assert override_decision.as_dict()["raw_value"] is False


### PR DESCRIPTION
## Summary
- add an AdaptiveRunDecision helper to evolution feature flags so callers can inspect gating metadata
- surface adaptive-run decisions and telemetry from the evolution cycle orchestrator, including override/env provenance
- extend evolution flag and orchestrator tests to cover the new telemetry contract and environment override behaviours

## Testing
- pytest tests/evolution/test_feature_flags.py tests/current/test_evolution_orchestrator.py

------
https://chatgpt.com/codex/tasks/task_e_68df80bc7ae4832c95e94ce0670513d7