### PR TITLE
Enforce sector budgets in RiskConfig metadata

### DIFF
--- a/src/config/risk/risk_config.py
+++ b/src/config/risk/risk_config.py
@@ -196,11 +196,19 @@ class RiskConfig(BaseModel):
 
         max_exposure_pct = values.get("max_total_exposure_pct")
         if isinstance(max_exposure_pct, Decimal):
+            sector_total = Decimal("0")
             for sector, limit in sector_limits.items():
                 if isinstance(limit, Decimal) and limit > max_exposure_pct:
                     raise ValueError(
                         "Sector %s exposure limit exceeds max_total_exposure_pct" % sector
                     )
+                if isinstance(limit, Decimal):
+                    sector_total += limit
+
+            if sector_limits and sector_total > max_exposure_pct:
+                raise ValueError(
+                    "Combined sector_exposure_limits exceed max_total_exposure_pct"
+                )
 
         return values
 

--- a/src/trading/risk/risk_api.py
+++ b/src/trading/risk/risk_api.py
@@ -11,6 +11,7 @@ consistent metadata snapshots.
 from __future__ import annotations
 
 from dataclasses import dataclass
+from decimal import Decimal
 from typing import Any
 
 from collections.abc import Mapping
@@ -103,7 +104,7 @@ def resolve_trading_risk_config(trading_manager: Any) -> RiskConfig:
 def summarise_risk_config(config: RiskConfig) -> dict[str, object]:
     """Render a serialisable summary of the supplied risk configuration."""
 
-    return {
+    summary: dict[str, object] = {
         "max_risk_per_trade_pct": float(config.max_risk_per_trade_pct),
         "max_total_exposure_pct": float(config.max_total_exposure_pct),
         "max_leverage": float(config.max_leverage),
@@ -113,6 +114,18 @@ def summarise_risk_config(config: RiskConfig) -> dict[str, object]:
         "mandatory_stop_loss": bool(config.mandatory_stop_loss),
         "research_mode": bool(config.research_mode),
     }
+
+    if config.sector_exposure_limits:
+        summary["sector_exposure_limits"] = {
+            sector: float(limit) for sector, limit in config.sector_exposure_limits.items()
+        }
+        sector_total = sum(config.sector_exposure_limits.values(), Decimal("0"))
+        summary["sector_budget_total_pct"] = float(sector_total)
+
+    if config.instrument_sector_map:
+        summary["instrument_sector_map"] = dict(config.instrument_sector_map)
+
+    return summary
 
 
 @dataclass(frozen=True)

--- a/tests/risk/test_risk_config_validation.py
+++ b/tests/risk/test_risk_config_validation.py
@@ -62,6 +62,17 @@ def test_sector_limit_cannot_exceed_total_exposure() -> None:
         )
 
 
+def test_sector_limits_cannot_exceed_global_budget() -> None:
+    with pytest.raises(ValidationError):
+        RiskConfig(
+            max_total_exposure_pct=Decimal("0.50"),
+            sector_exposure_limits={
+                "FX": Decimal("0.30"),
+                "EQUITIES": Decimal("0.30"),
+            },
+        )
+
+
 def test_instrument_sector_map_conflicting_assignment_rejected() -> None:
     with pytest.raises(ValidationError):
         RiskConfig(

--- a/tests/trading/test_risk_api.py
+++ b/tests/trading/test_risk_api.py
@@ -10,6 +10,7 @@ from src.trading.risk.risk_api import (
     build_runtime_risk_metadata,
     resolve_trading_risk_config,
     resolve_trading_risk_interface,
+    summarise_risk_config,
 )
 
 
@@ -94,6 +95,21 @@ def test_trading_risk_interface_summary_includes_policy_metadata() -> None:
     assert summary["policy_limits"]["max_drawdown_pct"] == pytest.approx(0.25)
     assert summary["policy_research_mode"] is True
     assert summary["latest_snapshot"]["max_risk_per_trade_pct"] == pytest.approx(0.02)
+
+
+def test_summarise_risk_config_includes_sector_metadata() -> None:
+    config = RiskConfig(
+        max_risk_per_trade_pct=Decimal("0.02"),
+        max_total_exposure_pct=Decimal("0.5"),
+        instrument_sector_map={"EURUSD": "FX"},
+        sector_exposure_limits={"FX": Decimal("0.30")},
+    )
+
+    summary = summarise_risk_config(config)
+
+    assert summary["sector_exposure_limits"] == {"FX": pytest.approx(0.30)}
+    assert summary["instrument_sector_map"] == {"EURUSD": "FX"}
+    assert summary["sector_budget_total_pct"] == pytest.approx(0.30)
 
 
 def test_build_runtime_metadata_respects_status_payload() -> None:


### PR DESCRIPTION
## Summary
- prevent RiskConfig from accepting sector exposure limits that exceed the configured global exposure budget
- expose sector allocation metadata through summarise_risk_config so runtime surfaces inherit deterministic sector coverage snapshots
- extend the risk configuration and API tests to cover aggregate budget validation and sector metadata exports

## Testing
- pytest tests/risk/test_risk_config_validation.py tests/trading/test_risk_api.py

------
https://chatgpt.com/codex/tasks/task_e_68df80bc7ae4832c95e94ce0670513d7