### PR TITLE
Add operational readiness alert routing and telemetry publisher

### DIFF
--- a/src/operations/__init__.py
+++ b/src/operations/__init__.py
@@ -187,6 +187,8 @@ from .operational_readiness import (
     derive_operational_alerts,
     evaluate_operational_readiness,
     format_operational_readiness_markdown,
+    publish_operational_readiness_snapshot,
+    route_operational_readiness_alerts,
 )
 from .ingest_trends import (
     IngestDimensionTrend,


### PR DESCRIPTION
## Summary
- add alert routing and event-bus publishing helpers for operational readiness snapshots
- tag readiness alerts with routing metadata and export the helpers via the operations package
- extend operational readiness tests to cover routing and failover behaviour

## Testing
- pytest tests/operations/test_operational_readiness.py

------
https://chatgpt.com/codex/tasks/task_e_68dfdcc60270832c94355dea5da85c10