### PR TITLE
Harden FIX pilot telemetry publishing

### DIFF
--- a/tests/operations/test_fix_pilot_ops.py
+++ b/tests/operations/test_fix_pilot_ops.py
@@ -1,10 +1,14 @@
 from datetime import UTC, datetime
+from unittest.mock import patch
 
+from src.core.event_bus import Event
 from src.operations.fix_pilot import (
     FixPilotPolicy,
     FixPilotStatus,
+    FixPilotSnapshot,
     evaluate_fix_pilot,
     format_fix_pilot_markdown,
+    publish_fix_pilot_snapshot,
 )
 from src.runtime.fix_pilot import FixPilotState
 
@@ -63,3 +67,98 @@ def test_evaluate_fix_pilot_warn_and_fail():
     assert components["compliance"].status is FixPilotStatus.warn
     assert components["dropcopy"].status is FixPilotStatus.warn
     assert "orders" in components
+
+
+class _StubRuntimeBus:
+    def __init__(self) -> None:
+        self.events: list[Event] = []
+
+    def is_running(self) -> bool:
+        return True
+
+    def publish_from_sync(self, event: Event) -> int:
+        self.events.append(event)
+        return 1
+
+
+class _StubTopicBus:
+    def __init__(self) -> None:
+        self.published: list[tuple[str, dict[str, object], str | None]] = []
+
+    def publish_sync(
+        self, topic: str, payload: dict[str, object], *, source: str | None = None
+    ) -> int:
+        self.published.append((topic, payload, source))
+        return 1
+
+
+def _snapshot() -> FixPilotSnapshot:
+    return FixPilotSnapshot(
+        status=FixPilotStatus.passed,
+        timestamp=datetime(2025, 1, 1, tzinfo=UTC),
+        components=(),
+        metadata={},
+    )
+
+
+def test_publish_fix_pilot_snapshot_uses_failover_helper() -> None:
+    runtime_bus = _StubRuntimeBus()
+    snapshot = _snapshot()
+
+    with patch("src.operations.fix_pilot.publish_event_with_failover") as helper:
+        publish_fix_pilot_snapshot(
+            runtime_bus,
+            snapshot,
+            channel="telemetry.execution.fix_pilot",
+            source="unit.test.fix_pilot",
+        )
+
+    helper.assert_called_once()
+    args, kwargs = helper.call_args
+    assert args[0] is runtime_bus
+    event = args[1]
+    assert event.type == "telemetry.execution.fix_pilot"
+    assert event.payload == snapshot.as_dict()
+    assert event.source == "unit.test.fix_pilot"
+    assert "logger" in kwargs and kwargs["logger"].name == "src.operations.fix_pilot"
+
+
+def test_publish_fix_pilot_snapshot_without_runtime_bus_uses_factory() -> None:
+    topic_bus = _StubTopicBus()
+    snapshot = _snapshot()
+
+    publish_fix_pilot_snapshot(
+        None,
+        snapshot,
+        channel="telemetry.execution.fix_pilot",
+        source="unit.test.fix_pilot",
+        global_bus_factory=lambda: topic_bus,
+    )
+
+    assert topic_bus.published == [
+        (
+            "telemetry.execution.fix_pilot",
+            snapshot.as_dict(),
+            "unit.test.fix_pilot",
+        )
+    ]
+
+
+def test_publish_fix_pilot_snapshot_direct_topic_bus() -> None:
+    topic_bus = _StubTopicBus()
+    snapshot = _snapshot()
+
+    publish_fix_pilot_snapshot(
+        topic_bus,
+        snapshot,
+        channel="telemetry.execution.fix_pilot",
+        source="unit.test.fix_pilot",
+    )
+
+    assert topic_bus.published == [
+        (
+            "telemetry.execution.fix_pilot",
+            snapshot.as_dict(),
+            "unit.test.fix_pilot",
+        )
+    ]


### PR DESCRIPTION
## Summary
- reuse the shared event-bus failover helper for FIX pilot telemetry and expose source/global bus hooks
- cover runtime, fallback, and topic-bus publishing flows with dedicated FIX pilot tests

## Testing
- pytest tests/operations/test_fix_pilot_ops.py

------
https://chatgpt.com/codex/tasks/task_e_68dfdcc60270832c94355dea5da85c10