### PR TITLE
Enhance recorded replay metrics

### DIFF
--- a/tests/evolution/test_recorded_replay_evaluator.py
+++ b/tests/evolution/test_recorded_replay_evaluator.py
@@ -68,6 +68,8 @@ def test_evaluator_generates_positive_return_for_trending_signals() -> None:
     assert ledger
     first_trade = ledger[0]
     assert first_trade["opened_at"] < first_trade["closed_at"]
+    assert result.max_consecutive_losses >= 0
+    assert result.average_trade_duration_minutes > 0
 
 
 def test_evaluator_handles_low_confidence_with_no_trades() -> None:
@@ -95,6 +97,8 @@ def test_evaluator_handles_low_confidence_with_no_trades() -> None:
     assert result.total_return == pytest.approx(0.0, abs=1e-6)
     assert result.max_drawdown == pytest.approx(0.0, abs=1e-6)
     assert result.trade_log == ()
+    assert result.max_consecutive_losses == 0
+    assert result.average_trade_duration_minutes == pytest.approx(0.0, abs=1e-6)
 
 
 def test_snapshot_from_serialised_payload_extracts_fields() -> None:


### PR DESCRIPTION
## Summary
- add loss streak and average duration metrics to recorded replay evaluation output
- ensure evaluation only records streaks for completed trades and expose the values in the serialised payload
- extend regression tests to cover the new replay metrics

## Testing
- pytest tests/evolution/test_recorded_replay_evaluator.py

------
https://chatgpt.com/codex/tasks/task_e_68e11e265b78832cbcce6f9662d014bb