### PR TITLE
Add CI guardrail coverage contract tests

### DIFF
--- a/tests/runtime/test_guardrail_suite_manifest.py
+++ b/tests/runtime/test_guardrail_suite_manifest.py
@@ -9,8 +9,10 @@ marker is removed, these checks fail and block the pipeline.
 from __future__ import annotations
 
 from pathlib import Path
+from typing import Any
 
 import pytest
+import yaml
 
 
 pytestmark = pytest.mark.guardrail
@@ -21,6 +23,14 @@ _GUARDRAIL_TARGETS: dict[str, Path] = {
     "risk_policy": Path("tests/trading/test_risk_policy.py"),
     "observability_event_bus": Path("tests/operations/test_event_bus_health.py"),
 }
+
+
+def _load_ci_workflow() -> dict[str, Any]:
+    """Load the CI workflow so tests can assert the guardrail coverage contract."""
+
+    workflow_path = Path(".github/workflows/ci.yml")
+    assert workflow_path.exists(), "CI workflow is missing"
+    return yaml.safe_load(workflow_path.read_text(encoding="utf-8"))
 
 
 def test_guardrail_manifest_targets_exist() -> None:
@@ -39,3 +49,43 @@ def test_guardrail_manifest_targets_marked() -> None:
         if "pytest.mark.guardrail" not in contents:
             missing_marker.append(label)
     assert not missing_marker, f"Guardrail marker missing in: {', '.join(missing_marker)}"
+
+
+def test_ci_guardrail_job_executes_guardrail_marker() -> None:
+    """The guardrail job must run the guardrail marker to block regressions early."""
+
+    workflow = _load_ci_workflow()
+    guardrail_step = next(
+        (
+            step
+            for step in workflow["jobs"]["tests"]["steps"]
+            if step.get("name") == "Pytest (guardrail suite)"
+        ),
+        None,
+    )
+    assert guardrail_step is not None, "Guardrail pytest step missing from CI workflow"
+    run_script = guardrail_step.get("run", "")
+    assert "pytest -m guardrail" in run_script, "Guardrail pytest step does not target the guardrail marker"
+
+
+def test_ci_guardrail_job_targets_ingest_risk_observability_domains() -> None:
+    """Coverage job should enumerate guardrail-critical domains explicitly."""
+
+    workflow = _load_ci_workflow()
+    coverage_step = next(
+        (
+            step
+            for step in workflow["jobs"]["tests"]["steps"]
+            if step.get("name") == "Pytest (coverage)"
+        ),
+        None,
+    )
+    assert coverage_step is not None, "Coverage pytest step missing from CI workflow"
+    run_script = coverage_step.get("run", "")
+    for domain in (
+        "tests/data_foundation",
+        "tests/trading",
+        "tests/operations",
+        "tests/observability",
+    ):
+        assert domain in run_script, f"Coverage pytest step does not target {domain}"


### PR DESCRIPTION
## Summary
- extend the guardrail manifest test module to inspect the CI workflow definition
- assert that the guardrail pytest job executes the guardrail marker step
- ensure the coverage step continues to target ingest, risk, and observability domains explicitly

## Testing
- pytest tests/runtime/test_guardrail_suite_manifest.py -q

------
https://chatgpt.com/codex/tasks/task_e_68e11e265b78832cbcce6f9662d014bb