### PR TITLE
Add sensory summary telemetry publisher

### DIFF
--- a/src/operations/__init__.py
+++ b/src/operations/__init__.py
@@ -167,6 +167,12 @@ from .sensory_drift import (
     evaluate_sensory_drift,
     publish_sensory_drift,
 )
+from .sensory_summary import (
+    SensoryDimensionSummary,
+    SensorySummary,
+    build_sensory_summary,
+    publish_sensory_summary,
+)
 from .slo import (
     DEFAULT_ALERT_ROUTES,
     OperationalSLOSnapshot,
@@ -336,6 +342,10 @@ __all__ = [
     "SensoryDriftSnapshot",
     "evaluate_sensory_drift",
     "publish_sensory_drift",
+    "SensoryDimensionSummary",
+    "SensorySummary",
+    "build_sensory_summary",
+    "publish_sensory_summary",
     "DEFAULT_ALERT_ROUTES",
     "OperationalSLOSnapshot",
     "ServiceSLO",

--- a/src/operations/sensory_summary.py
+++ b/src/operations/sensory_summary.py
@@ -1,0 +1,288 @@
+from __future__ import annotations
+
+"""Summarise sensory cortex state for runtime dashboards and telemetry feeds."""
+
+import logging
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any, Callable, Iterable, Mapping, MutableMapping, Sequence
+
+import pandas as pd
+
+from src.core.event_bus import Event, EventBus, TopicBus
+from src.operations.event_bus_failover import publish_event_with_failover
+
+__all__ = [
+    "SensoryDimensionSummary",
+    "SensorySummary",
+    "build_sensory_summary",
+    "publish_sensory_summary",
+]
+
+
+logger = logging.getLogger(__name__)
+
+
+def _coerce_float(value: Any) -> float | None:
+    if isinstance(value, (int, float)):
+        return float(value)
+    if value is None:
+        return None
+    try:
+        return float(str(value).strip())
+    except (TypeError, ValueError):
+        return None
+
+
+def _normalise_mapping(mapping: Mapping[str, Any] | None) -> Mapping[str, Any]:
+    if not isinstance(mapping, Mapping):
+        return {}
+    return {str(key): value for key, value in mapping.items()}
+
+
+def _parse_timestamp(value: Any) -> datetime | None:
+    if isinstance(value, datetime):
+        return value
+    try:
+        converted = pd.to_datetime(value, utc=True, errors="coerce")
+    except Exception:
+        return None
+    if converted is pd.NaT:
+        return None
+    if hasattr(converted, "to_pydatetime"):
+        return converted.to_pydatetime()
+    return None
+
+
+def _serialise_datetime(value: datetime | None) -> str | None:
+    if value is None:
+        return None
+    if value.tzinfo is not None:
+        return value.isoformat()
+    return value.replace(tzinfo=timezone.utc).isoformat()
+
+
+def _normalise_sequence(entries: Iterable[Any]) -> tuple[Mapping[str, Any], ...]:
+    normalised: list[Mapping[str, Any]] = []
+    for entry in entries:
+        if isinstance(entry, Mapping):
+            normalised.append({str(key): value for key, value in entry.items()})
+    return tuple(normalised)
+
+
+@dataclass(frozen=True)
+class SensoryDimensionSummary:
+    """Summarised telemetry for a single sensory dimension."""
+
+    name: str
+    signal: float | None
+    confidence: float | None
+    state: str | None
+    threshold_state: str | None
+    metadata: Mapping[str, Any]
+
+    def as_dict(self) -> Mapping[str, Any]:
+        payload: MutableMapping[str, Any] = {
+            "name": self.name,
+            "metadata": dict(self.metadata),
+        }
+        if self.signal is not None:
+            payload["signal"] = self.signal
+        if self.confidence is not None:
+            payload["confidence"] = self.confidence
+        if self.state is not None:
+            payload["state"] = self.state
+        if self.threshold_state is not None:
+            payload["threshold_state"] = self.threshold_state
+        return payload
+
+
+@dataclass(frozen=True)
+class SensorySummary:
+    """Aggregated sensory cortex snapshot for dashboards and telemetry."""
+
+    symbol: str | None
+    generated_at: datetime | None
+    samples: int
+    integrated_strength: float | None
+    integrated_confidence: float | None
+    integrated_direction: float | None
+    contributing: tuple[str, ...]
+    dimensions: tuple[SensoryDimensionSummary, ...]
+    drift_summary: Mapping[str, Any] | None
+    audit_entries: tuple[Mapping[str, Any], ...]
+
+    def as_dict(self) -> Mapping[str, Any]:
+        return {
+            "symbol": self.symbol,
+            "generated_at": _serialise_datetime(self.generated_at),
+            "samples": self.samples,
+            "integrated_strength": self.integrated_strength,
+            "integrated_confidence": self.integrated_confidence,
+            "integrated_direction": self.integrated_direction,
+            "contributing": list(self.contributing),
+            "dimensions": [dimension.as_dict() for dimension in self.dimensions],
+            "drift_summary": dict(self.drift_summary) if self.drift_summary else None,
+            "audit_entries": [dict(entry) for entry in self.audit_entries],
+        }
+
+    def top_dimensions(self, limit: int = 3) -> tuple[SensoryDimensionSummary, ...]:
+        if limit <= 0:
+            return ()
+        ranked = sorted(
+            self.dimensions,
+            key=lambda dimension: abs(dimension.signal or 0.0),
+            reverse=True,
+        )
+        return tuple(ranked[:limit])
+
+    def to_markdown(self, *, limit: int = 5) -> str:
+        header: list[str] = []
+        symbol = self.symbol or "UNKNOWN"
+        integrated_strength = self.integrated_strength
+        if integrated_strength is not None:
+            header.append(f"**Integrated strength:** {integrated_strength:+.3f}")
+        if self.integrated_confidence is not None:
+            header.append(f"confidence={self.integrated_confidence:.2f}")
+        if self.integrated_direction is not None:
+            header.append(f"direction={self.integrated_direction:+.0f}")
+
+        summary_line = f"**Symbol:** {symbol} | **Samples:** {self.samples}"
+        if header:
+            summary_line = summary_line + " | " + ", ".join(header)
+
+        lines = [summary_line, ""]
+        lines.append("| Dimension | Signal | Confidence | State | Threshold |")
+        lines.append("| --- | --- | --- | --- | --- |")
+
+        for dimension in self.top_dimensions(limit):
+            signal = dimension.signal if dimension.signal is not None else 0.0
+            confidence = dimension.confidence if dimension.confidence is not None else 0.0
+            state = dimension.state or "-"
+            threshold = dimension.threshold_state or "-"
+            lines.append(
+                f"| {dimension.name} | {signal:+.3f} | {confidence:.2f} | {state} | {threshold} |"
+            )
+
+        if self.drift_summary:
+            exceeded = self.drift_summary.get("exceeded")
+            if exceeded:
+                exceeded_names = ", ".join(
+                    str(entry.get("sensor")) for entry in exceeded if isinstance(entry, Mapping)
+                )
+                lines.append("")
+                lines.append(f"Drift alerts: {exceeded_names or 'None'}")
+
+        return "\n".join(lines)
+
+
+def _build_dimension(name: str, payload: Mapping[str, Any]) -> SensoryDimensionSummary:
+    signal = _coerce_float(payload.get("signal"))
+    confidence = _coerce_float(payload.get("confidence"))
+    metadata = _normalise_mapping(payload.get("metadata"))
+    state = metadata.get("state") if isinstance(metadata.get("state"), str) else None
+
+    threshold_state: str | None = None
+    thresholds = metadata.get("threshold_assessment")
+    if isinstance(thresholds, Mapping):
+        value = thresholds.get("state")
+        if isinstance(value, str):
+            threshold_state = value
+
+    return SensoryDimensionSummary(
+        name=name,
+        signal=signal,
+        confidence=confidence,
+        state=state,
+        threshold_state=threshold_state,
+        metadata=metadata,
+    )
+
+
+def build_sensory_summary(status: Mapping[str, Any] | None) -> SensorySummary:
+    mapping = status if isinstance(status, Mapping) else {}
+    samples = int(mapping.get("samples") or 0)
+
+    latest = mapping.get("latest") if isinstance(mapping.get("latest"), Mapping) else {}
+    generated_at = _parse_timestamp(latest.get("generated_at"))
+    symbol = latest.get("symbol") if isinstance(latest.get("symbol"), str) else None
+
+    integrated = latest.get("integrated_signal")
+    if not isinstance(integrated, Mapping):
+        integrated = {}
+
+    integrated_strength = _coerce_float(integrated.get("strength"))
+    integrated_confidence = _coerce_float(integrated.get("confidence"))
+    integrated_direction = _coerce_float(integrated.get("direction"))
+    contributions = tuple(
+        str(entry)
+        for entry in integrated.get("contributing", [])
+        if isinstance(entry, str)
+    )
+
+    dimensions_payload = latest.get("dimensions")
+    dimension_summaries: list[SensoryDimensionSummary] = []
+    if isinstance(dimensions_payload, Mapping):
+        for name, payload in dimensions_payload.items():
+            if not isinstance(name, str) or not isinstance(payload, Mapping):
+                continue
+            dimension_summaries.append(_build_dimension(name, payload))
+
+    dimension_summaries.sort(key=lambda dimension: dimension.name)
+
+    drift_summary_raw = mapping.get("drift_summary")
+    drift_summary = (
+        {
+            key: value if not isinstance(value, Sequence) else list(value)
+            for key, value in drift_summary_raw.items()
+        }
+        if isinstance(drift_summary_raw, Mapping)
+        else None
+    )
+
+    audit_entries_raw = mapping.get("sensor_audit")
+    audit_entries = _normalise_sequence(audit_entries_raw or [])
+
+    return SensorySummary(
+        symbol=symbol,
+        generated_at=generated_at,
+        samples=samples,
+        integrated_strength=integrated_strength,
+        integrated_confidence=integrated_confidence,
+        integrated_direction=integrated_direction,
+        contributing=contributions,
+        dimensions=tuple(dimension_summaries),
+        drift_summary=drift_summary,
+        audit_entries=audit_entries,
+    )
+
+
+def publish_sensory_summary(
+    summary: SensorySummary,
+    *,
+    event_bus: EventBus,
+    event_type: str = "telemetry.sensory.summary",
+    global_bus_factory: Callable[[], TopicBus] | None = None,
+) -> None:
+    """Publish the sensory summary via the runtime event bus with failover."""
+
+    payload = summary.as_dict()
+    payload["markdown"] = summary.to_markdown()
+
+    event = Event(
+        type=event_type,
+        payload=payload,
+        source="operations.sensory_summary",
+    )
+
+    publish_event_with_failover(
+        event_bus,
+        event,
+        logger=logger,
+        runtime_fallback_message="Runtime bus rejected sensory summary; falling back to global bus",
+        runtime_unexpected_message="Unexpected error publishing sensory summary via runtime bus",
+        runtime_none_message="Runtime bus returned no result while publishing sensory summary",
+        global_not_running_message="Global event bus not running while publishing sensory summary",
+        global_unexpected_message="Unexpected error publishing sensory summary via global bus",
+        global_bus_factory=global_bus_factory,  # type: ignore[arg-type]
+    )

--- a/tests/operations/test_sensory_summary.py
+++ b/tests/operations/test_sensory_summary.py
@@ -1,0 +1,163 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+import pytest
+
+from src.operations.sensory_summary import (
+    build_sensory_summary,
+    publish_sensory_summary,
+)
+
+
+def _sample_status() -> dict[str, Any]:
+    generated_at = datetime.now(timezone.utc) - timedelta(minutes=1)
+    return {
+        "samples": 12,
+        "latest": {
+            "symbol": "EURUSD",
+            "generated_at": generated_at.isoformat(),
+            "integrated_signal": {
+                "strength": 0.42,
+                "confidence": 0.68,
+                "direction": 1.0,
+                "contributing": ["WHY", "HOW", "ANOMALY"],
+            },
+            "dimensions": {
+                "WHY": {
+                    "signal": 0.45,
+                    "confidence": 0.70,
+                    "metadata": {
+                        "state": "bullish",
+                        "threshold_assessment": {"state": "warn"},
+                    },
+                },
+                "HOW": {
+                    "signal": 0.15,
+                    "confidence": 0.55,
+                    "metadata": {
+                        "state": "nominal",
+                        "threshold_assessment": {"state": "nominal"},
+                    },
+                },
+                "ANOMALY": {
+                    "signal": -0.6,
+                    "confidence": 0.65,
+                    "metadata": {
+                        "state": "alert",
+                        "threshold_assessment": {"state": "alert"},
+                    },
+                },
+            },
+        },
+        "sensor_audit": [
+            {
+                "generated_at": generated_at.isoformat(),
+                "dimensions": {
+                    "WHY": {"signal": 0.45, "confidence": 0.70},
+                    "ANOMALY": {"signal": -0.6, "confidence": 0.65},
+                },
+            }
+        ],
+        "drift_summary": {
+            "parameters": {
+                "baseline_window": 5,
+                "evaluation_window": 3,
+                "min_observations": 2,
+                "z_threshold": 2.5,
+            },
+            "results": [
+                {
+                    "sensor": "WHY",
+                    "baseline_mean": 0.3,
+                    "baseline_std": 0.1,
+                    "baseline_count": 5,
+                    "evaluation_mean": 0.45,
+                    "evaluation_std": 0.05,
+                    "evaluation_count": 3,
+                    "z_score": 3.2,
+                    "drift_ratio": 0.5,
+                    "exceeded": True,
+                }
+            ],
+            "exceeded": [
+                {
+                    "sensor": "WHY",
+                    "z_score": 3.2,
+                }
+            ],
+        },
+    }
+
+
+class _StubEventBus:
+    def __init__(self, *, running: bool = True, raise_runtime: bool = False) -> None:
+        self.running = running
+        self.raise_runtime = raise_runtime
+        self.events: list[Any] = []
+
+    def is_running(self) -> bool:
+        return self.running
+
+    def publish_from_sync(self, event: Any) -> int:
+        if self.raise_runtime:
+            raise RuntimeError("runtime bus failure")
+        self.events.append(event)
+        return 1
+
+
+class _StubTopicBus:
+    def __init__(self) -> None:
+        self.events: list[tuple[str, Any, str]] = []
+
+    def publish_sync(self, event_type: str, payload: Any, source: str) -> None:
+        self.events.append((event_type, payload, source))
+
+
+def test_build_sensory_summary_extracts_metrics() -> None:
+    summary = build_sensory_summary(_sample_status())
+
+    assert summary.symbol == "EURUSD"
+    assert summary.integrated_strength == pytest.approx(0.42)
+    assert summary.integrated_confidence == pytest.approx(0.68)
+    assert summary.samples == 12
+    assert len(summary.dimensions) == 3
+
+    names = [dimension.name for dimension in summary.dimensions]
+    assert set(names) == {"WHY", "HOW", "ANOMALY"}
+
+    top_dimension = summary.top_dimensions(1)[0]
+    assert top_dimension.name in {"WHY", "ANOMALY"}
+    assert top_dimension.threshold_state in {"warn", "alert"}
+
+    markdown = summary.to_markdown()
+    assert "Dimension" in markdown
+    assert "Drift alerts" in markdown
+
+
+def test_publish_sensory_summary_uses_runtime_bus() -> None:
+    summary = build_sensory_summary(_sample_status())
+    bus = _StubEventBus()
+
+    publish_sensory_summary(summary, event_bus=bus)
+
+    assert len(bus.events) == 1
+    event = bus.events[0]
+    assert event.type == "telemetry.sensory.summary"
+    assert "markdown" in event.payload
+
+
+def test_publish_sensory_summary_falls_back_to_global_bus() -> None:
+    summary = build_sensory_summary(_sample_status())
+    bus = _StubEventBus(raise_runtime=True)
+    topic_bus = _StubTopicBus()
+
+    publish_sensory_summary(summary, event_bus=bus, global_bus_factory=lambda: topic_bus)
+
+    assert len(bus.events) == 0
+    assert len(topic_bus.events) == 1
+    event_type, payload, source = topic_bus.events[0]
+    assert event_type == "telemetry.sensory.summary"
+    assert payload["symbol"] == "EURUSD"
+    assert source == "operations.sensory_summary"


### PR DESCRIPTION
## Summary
- add a sensory summary module that aggregates integrated signals, drift results, and Markdown output for runtime dashboards
- publish sensory summaries via the hardened event bus failover helper and surface the helpers in the operations package
- cover the summary builder and publisher behaviour with unit tests, including runtime and global bus paths

## Testing
- pytest tests/operations/test_sensory_summary.py

------
https://chatgpt.com/codex/tasks/task_e_68e210bbf240832cb806525c3b754194