### PR TITLE
Add institutional ingest provisioning helpers

### DIFF
--- a/docs/operations/timescale_failover_drills.md
+++ b/docs/operations/timescale_failover_drills.md
@@ -1,0 +1,30 @@
+# Timescale failover drills
+
+The institutional ingest vertical now provisions managed Timescale, Redis, and
+Kafka services through `InstitutionalIngestProvisioner`.  Operators can call the
+provisioner when constructing runtime applications to ensure the ingest
+scheduler and Kafka bridge run under a `TaskSupervisor`, while the Redis cache is
+configured with the institutional policy.  The `InstitutionalIngestServices`
+bundle exposes a `failover_metadata()` helper that returns the serialized
+`TimescaleFailoverDrillSettings`, making it trivial to surface drill
+requirements in dashboards or to kick off `execute_failover_drill()` workflows.
+
+Typical flow:
+
+1. Resolve ingest configuration via `build_institutional_ingest_config()` and
+   instantiate an `InstitutionalIngestProvisioner` with the resulting settings
+   plus any Redis extras required for managed caches.
+2. Call `provision()` with the ingest coroutine, runtime event bus, and a
+   `TaskSupervisor`.  The provisioner returns an
+   `InstitutionalIngestServices` bundle containing the scheduler, Kafka bridge,
+   and optional Redis cache.
+3. Start the services inside the runtime bootstrap.  The scheduler registers a
+   supervised task and any Kafka bridge is tracked by the same supervisor.
+4. When running recovery exercises, call `failover_metadata()` to retrieve the
+   active drill configuration and feed the result into
+   `operations.failover_drill.execute_failover_drill()`.
+
+By routing failover drills through the new helper, Tier-1 ingest deployments
+retain a consistent picture of which Timescale dimensions must participate in
+disaster-recovery simulations while ensuring all background workloads remain
+observable under the shared task supervisor.

--- a/src/data_foundation/ingest/institutional_vertical.py
+++ b/src/data_foundation/ingest/institutional_vertical.py
@@ -1,0 +1,275 @@
+"""Provisioning helpers for the institutional Timescale ingest vertical.
+
+The roadmap calls for Tier-1 institutional runs to operate against managed
+Timescale, Redis, and Kafka services while ensuring all background activity is
+supervised.  This module ties together the existing configuration dataclasses
+with runtime wiring so orchestration code can provision a fully supervised
+ingest stack without re-implementing boilerplate in the runtime builder.
+
+High-level responsibilities:
+
+* Hydrate :class:`TimescaleIngestScheduler` instances with sensible defaults
+  when the configuration does not request a bespoke schedule.
+* Configure Redis caches using the institutional policy and expose a summary
+  that can be surfaced in readiness dashboards.
+* Instantiate Kafka ingest consumers and register their long-running coroutine
+  with :class:`TaskSupervisor` so operators inherit lifecycle guarantees.
+* Surface failover drill metadata so disaster-recovery automation can discover
+  which scenarios are required for the active ingest slice.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+from dataclasses import dataclass, field
+from typing import Callable, Mapping, MutableMapping
+
+from src.data_foundation.cache.redis_cache import (
+    ManagedRedisCache,
+    RedisCachePolicy,
+    RedisConnectionSettings,
+    InMemoryRedis,
+)
+from src.data_foundation.ingest.configuration import InstitutionalIngestConfig
+from src.data_foundation.ingest.scheduler import (
+    IngestSchedule,
+    RunCallback,
+    TimescaleIngestScheduler,
+)
+from src.data_foundation.streaming.kafka_stream import (
+    KafkaConnectionSettings,
+    KafkaIngestEventConsumer,
+    KafkaConsumerFactory,
+    create_ingest_event_consumer,
+)
+from src.runtime.task_supervisor import TaskSupervisor
+
+
+DEFAULT_INTERVAL_SECONDS = 3_600.0
+DEFAULT_JITTER_SECONDS = 120.0
+DEFAULT_MAX_FAILURES = 3
+
+
+def default_institutional_schedule() -> IngestSchedule:
+    """Return the baseline ingest schedule for institutional runs."""
+
+    return IngestSchedule(
+        interval_seconds=DEFAULT_INTERVAL_SECONDS,
+        jitter_seconds=DEFAULT_JITTER_SECONDS,
+        max_failures=DEFAULT_MAX_FAILURES,
+    )
+
+
+def _plan_dimensions(config: InstitutionalIngestConfig) -> tuple[str, ...]:
+    plan = config.plan
+    dimensions: list[str] = []
+    if plan.daily is not None:
+        dimensions.append("daily")
+    if plan.intraday is not None:
+        dimensions.append("intraday")
+    if plan.macro is not None:
+        dimensions.append("macro")
+    return tuple(dimensions)
+
+
+def _redacted_url(url: str) -> str:
+    if "@" not in url:
+        return url
+    credential, _, host = url.partition("@")
+    if ":" in credential:
+        prefix, _, suffix = credential.rpartition(":")
+        prefix = prefix or "***"
+        return f"{prefix}:***@{host}"
+    return f"***@{host}"
+
+
+@dataclass(slots=True)
+class InstitutionalIngestServices:
+    """Runtime objects bound to the managed ingest vertical."""
+
+    config: InstitutionalIngestConfig
+    scheduler: TimescaleIngestScheduler
+    task_supervisor: TaskSupervisor
+    redis_settings: RedisConnectionSettings | None = None
+    redis_cache: ManagedRedisCache | None = None
+    kafka_settings: KafkaConnectionSettings | None = None
+    kafka_consumer: KafkaIngestEventConsumer | None = None
+    kafka_task_name: str = "timescale-ingest-kafka-bridge"
+    kafka_metadata: Mapping[str, object] = field(default_factory=dict)
+
+    _kafka_task: asyncio.Task[None] | None = field(init=False, default=None)
+    _kafka_stop_event: asyncio.Event | None = field(init=False, default=None)
+
+    def start(self) -> None:
+        """Start supervised components (scheduler plus Kafka bridge)."""
+
+        self.scheduler.start()
+        if self.kafka_consumer is None or self._kafka_task is not None:
+            return
+
+        stop_event = asyncio.Event()
+        self._kafka_stop_event = stop_event
+        metadata: MutableMapping[str, object] = {
+            "component": "timescale_ingest.kafka_consumer",
+            "topics": list(self.kafka_consumer.topics),
+        }
+        metadata.update(self.kafka_metadata)
+
+        self._kafka_task = self.task_supervisor.create(
+            self.kafka_consumer.run_forever(stop_event),
+            name=self.kafka_task_name,
+            metadata=metadata,
+        )
+
+    async def stop(self) -> None:
+        """Stop background components gracefully."""
+
+        if self._kafka_stop_event is not None:
+            self._kafka_stop_event.set()
+        if self._kafka_task is not None:
+            try:
+                await asyncio.wait_for(self._kafka_task, timeout=2.0)
+            except asyncio.TimeoutError:
+                self._kafka_task.cancel()
+                with contextlib.suppress(asyncio.CancelledError):
+                    await self._kafka_task
+            finally:
+                self._kafka_task = None
+                self._kafka_stop_event = None
+
+        await self.scheduler.stop()
+
+    def summary(self) -> Mapping[str, object]:
+        """Summarise managed connectors for observability dashboards."""
+
+        schedule = self.scheduler
+        schedule_state = schedule.state()
+
+        redis_summary: str | None = None
+        if self.redis_settings is not None and self.redis_settings.configured:
+            redis_summary = self.redis_settings.summary(redacted=True)
+
+        kafka_summary: str | None = None
+        if self.kafka_settings is not None and self.kafka_settings.configured:
+            kafka_summary = self.kafka_settings.summary(redacted=True)
+
+        return {
+            "timescale": {
+                "configured": self.config.timescale_settings.configured,
+                "application_name": self.config.timescale_settings.application_name,
+                "url": _redacted_url(self.config.timescale_settings.url),
+                "dimensions": list(_plan_dimensions(self.config)),
+            },
+            "schedule": {
+                "running": schedule.running,
+                "interval_seconds": schedule_state.interval_seconds,
+                "jitter_seconds": schedule_state.jitter_seconds,
+                "max_failures": schedule_state.max_failures,
+                "next_run_at": schedule_state.next_run_at.isoformat()
+                if schedule_state.next_run_at
+                else None,
+            },
+            "redis": redis_summary,
+            "kafka": kafka_summary,
+            "kafka_topics": list(self.kafka_consumer.topics)
+            if self.kafka_consumer is not None
+            else [],
+            "failover": self.failover_metadata(),
+        }
+
+    def failover_metadata(self) -> Mapping[str, object] | None:
+        """Expose configured failover drill requirements, if any."""
+
+        settings = self.config.failover_drill
+        if settings is None:
+            return None
+        return settings.to_metadata()
+
+
+@dataclass(slots=True)
+class InstitutionalIngestProvisioner:
+    """Construct institutional ingest services from configuration objects."""
+
+    ingest_config: InstitutionalIngestConfig
+    redis_settings: RedisConnectionSettings | None = None
+    redis_policy: RedisCachePolicy = field(
+        default_factory=RedisCachePolicy.institutional_defaults
+    )
+    kafka_mapping: Mapping[str, str] | None = None
+
+    def provision(
+        self,
+        *,
+        run_ingest: RunCallback,
+        event_bus: object,
+        task_supervisor: TaskSupervisor,
+        redis_client_factory: Callable[[RedisConnectionSettings], object] | None = None,
+        kafka_consumer_factory: KafkaConsumerFactory | None = None,
+        kafka_deserializer: Callable[[bytes | bytearray | str], Mapping[str, object]]
+        | None = None,
+    ) -> InstitutionalIngestServices:
+        """Instantiate connectors and wrap them in a service bundle."""
+
+        if task_supervisor is None:
+            raise ValueError("task_supervisor must be provided for institutional ingest")
+
+        schedule = self.ingest_config.schedule or default_institutional_schedule()
+
+        scheduler_metadata: MutableMapping[str, object] = {
+            "component": "timescale_ingest.scheduler",
+            "timescale_configured": self.ingest_config.timescale_settings.configured,
+            "dimensions": list(_plan_dimensions(self.ingest_config)),
+            "interval_seconds": schedule.interval_seconds,
+        }
+        if self.ingest_config.failover_drill is not None:
+            scheduler_metadata["failover_drill"] = (
+                self.ingest_config.failover_drill.to_metadata()
+            )
+
+        scheduler = TimescaleIngestScheduler(
+            schedule=schedule,
+            run_callback=run_ingest,
+            task_supervisor=task_supervisor,
+            task_metadata=scheduler_metadata,
+        )
+
+        redis_cache: ManagedRedisCache | None = None
+        redis_settings = self.redis_settings
+        if redis_settings is not None and redis_settings.configured:
+            client_factory = redis_client_factory or (lambda _settings: InMemoryRedis())
+            client = client_factory(redis_settings)
+            redis_cache = ManagedRedisCache(client, self.redis_policy)
+
+        kafka_consumer: KafkaIngestEventConsumer | None = None
+        kafka_settings = self.ingest_config.kafka_settings
+        if kafka_settings and kafka_settings.configured:
+            kafka_consumer = create_ingest_event_consumer(
+                kafka_settings,
+                self.kafka_mapping,
+                event_bus=event_bus,
+                consumer_factory=kafka_consumer_factory,
+                deserializer=kafka_deserializer,
+            )
+
+        kafka_metadata: dict[str, object] = {
+            "timescale_dimensions": list(_plan_dimensions(self.ingest_config)),
+        }
+
+        return InstitutionalIngestServices(
+            config=self.ingest_config,
+            scheduler=scheduler,
+            task_supervisor=task_supervisor,
+            redis_settings=redis_settings,
+            redis_cache=redis_cache,
+            kafka_settings=kafka_settings,
+            kafka_consumer=kafka_consumer,
+            kafka_metadata=kafka_metadata,
+        )
+
+
+__all__ = [
+    "InstitutionalIngestProvisioner",
+    "InstitutionalIngestServices",
+    "default_institutional_schedule",
+]

--- a/tests/runtime/test_institutional_ingest_vertical.py
+++ b/tests/runtime/test_institutional_ingest_vertical.py
@@ -1,0 +1,178 @@
+from __future__ import annotations
+
+import asyncio
+from collections import deque
+import dataclasses
+
+import pytest
+
+from src.data_foundation.cache.redis_cache import InMemoryRedis, RedisConnectionSettings
+from src.data_foundation.ingest.configuration import (
+    InstitutionalIngestConfig,
+    KafkaReadinessSettings,
+    TimescaleBackupSettings,
+    TimescaleFailoverDrillSettings,
+    TimescaleIngestRecoverySettings,
+    TimescaleRetentionSettings,
+)
+from src.data_foundation.ingest.institutional_vertical import (
+    InstitutionalIngestProvisioner,
+    default_institutional_schedule,
+)
+from src.data_foundation.ingest.scheduler import IngestSchedule
+from src.data_foundation.ingest.timescale_pipeline import TimescaleBackbonePlan
+from src.data_foundation.persist.timescale import TimescaleConnectionSettings
+from src.data_foundation.streaming.kafka_stream import KafkaConnectionSettings
+from src.runtime.task_supervisor import TaskSupervisor
+
+
+class _DummyEventBus:
+    def __init__(self) -> None:
+        self.published: deque[tuple[str, dict[str, object]]] = deque()
+
+    def publish_from_sync(self, event) -> None:  # pragma: no cover - defensive path
+        self.published.append((event.type, dict(event.payload)))
+
+    def is_running(self) -> bool:
+        return True
+
+
+class _DummyKafkaConsumer:
+    def __init__(self) -> None:
+        self.subscribed: list[str] = []
+        self.closed = False
+
+    def subscribe(self, topics) -> None:
+        self.subscribed = list(topics)
+
+    def poll(self, timeout):
+        return None
+
+    def close(self) -> None:
+        self.closed = True
+
+
+def _ingest_config(*, schedule: IngestSchedule | None = None) -> InstitutionalIngestConfig:
+    return InstitutionalIngestConfig(
+        should_run=True,
+        reason=None,
+        plan=TimescaleBackbonePlan(),
+        timescale_settings=TimescaleConnectionSettings(
+            url="postgresql://user:secret@example.com/emp"
+        ),
+        kafka_settings=KafkaConnectionSettings.from_mapping(
+            {"KAFKA_BROKERS": "broker:9092"}
+        ),
+        metadata={},
+        schedule=schedule,
+        recovery=TimescaleIngestRecoverySettings(),
+        operational_alert_routes={},
+        backup=TimescaleBackupSettings(enabled=False),
+        retention=TimescaleRetentionSettings(),
+        spark_export=None,
+        failover_drill=TimescaleFailoverDrillSettings(
+            enabled=True, dimensions=("daily",)
+        ),
+        spark_stress=None,
+        cross_region=None,
+        kafka_readiness=KafkaReadinessSettings(enabled=True),
+    )
+
+
+@pytest.mark.asyncio
+async def test_provisioned_services_supervise_components() -> None:
+    schedule = IngestSchedule(interval_seconds=0.05, jitter_seconds=0.0, max_failures=3)
+    config = _ingest_config(schedule=schedule)
+    redis_settings = RedisConnectionSettings.from_mapping(
+        {"REDIS_URL": "redis://localhost:6379/0"}
+    )
+    provisioner = InstitutionalIngestProvisioner(
+        config,
+        redis_settings=redis_settings,
+        kafka_mapping={
+            "KAFKA_INGEST_CONSUMER_TOPICS": "telemetry.ingest",
+            "KAFKA_INGEST_CONSUMER_POLL_TIMEOUT": "0",
+            "KAFKA_INGEST_CONSUMER_IDLE_SLEEP": "0.01",
+        },
+    )
+
+    run_calls: list[int] = []
+
+    async def _run_ingest() -> bool:
+        run_calls.append(1)
+        return True
+
+    bus = _DummyEventBus()
+    supervisor = TaskSupervisor(namespace="test")
+
+    services = provisioner.provision(
+        run_ingest=_run_ingest,
+        event_bus=bus,
+        task_supervisor=supervisor,
+        redis_client_factory=lambda settings: InMemoryRedis(),
+        kafka_consumer_factory=lambda config: _DummyKafkaConsumer(),
+    )
+
+    assert services.redis_cache is not None
+    assert services.kafka_consumer is not None
+
+    services.start()
+    await asyncio.sleep(0.1)
+    assert run_calls
+
+    await services.stop()
+    assert supervisor.active_count == 0
+    assert not services.scheduler.running
+
+    summary = services.summary()
+    assert summary["timescale"]["configured"] is True
+    assert summary["redis"] is not None
+    assert summary["kafka_topics"] == ["telemetry.ingest"]
+
+
+def test_summary_includes_failover_metadata() -> None:
+    config = _ingest_config(schedule=default_institutional_schedule())
+    provisioner = InstitutionalIngestProvisioner(config)
+    services = provisioner.provision(
+        run_ingest=lambda: asyncio.sleep(0),
+        event_bus=_DummyEventBus(),
+        task_supervisor=TaskSupervisor(namespace="summary"),
+    )
+
+    metadata = services.failover_metadata()
+    assert metadata == {
+        "enabled": True,
+        "dimensions": ["daily"],
+        "label": "required_timescale_failover",
+        "run_fallback": True,
+    }
+
+
+@pytest.mark.asyncio
+async def test_provision_skips_optional_connectors_when_unconfigured() -> None:
+    config = _ingest_config(schedule=default_institutional_schedule())
+    config = dataclasses.replace(
+        config,
+        kafka_settings=KafkaConnectionSettings.from_mapping({}),
+        failover_drill=None,
+    )
+    provisioner = InstitutionalIngestProvisioner(
+        config,
+        redis_settings=RedisConnectionSettings(),
+    )
+
+    services = provisioner.provision(
+        run_ingest=lambda: asyncio.sleep(0),
+        event_bus=_DummyEventBus(),
+        task_supervisor=TaskSupervisor(namespace="optional"),
+    )
+
+    assert services.redis_cache is None
+    assert services.kafka_consumer is None
+
+    services.start()
+    await services.stop()
+
+    summary = services.summary()
+    assert summary["redis"] is None
+    assert summary["kafka"] is None


### PR DESCRIPTION
## Summary
- add an institutional ingest provisioning module that wires Timescale, Redis, and Kafka connectors under the shared task supervisor
- document how to surface failover drill metadata from the new service bundle for operational runbooks
- cover the provisioning flow with async regression tests that exercise scheduler supervision and optional connector handling

## Testing
- pytest tests/runtime/test_institutional_ingest_vertical.py

------
https://chatgpt.com/codex/tasks/task_e_68e210bbf240832cb806525c3b754194