### PR TITLE
Refresh roadmap and briefs for ingest hardening and sensory telemetry

### DIFF
--- a/docs/context/alignment_briefs/institutional_data_backbone.md
+++ b/docs/context/alignment_briefs/institutional_data_backbone.md
@@ -69,6 +69,14 @@
   symbols, fetched rows, macro windows, and ingest results on every slice while
   guardrail tests lock macro window fallbacks and zero-payload execution so
   institutional telemetry reflects what was ingested or skipped.【F:src/data_foundation/ingest/timescale_pipeline.py†L70-L213】【F:tests/data_foundation/test_timescale_backbone_orchestrator.py†L1-L200】
+- Progress: Institutional ingest provisioner now builds supervised Timescale
+  schedules, Redis caches, and Kafka bridges from a single configuration
+  surface, exposing failover drill metadata and a runtime summary so operators
+  can bootstrap the ingest vertical with guardrails and surface disaster-recovery
+  requirements in dashboards, with docs capturing the drill workflow.【F:src/data_foundation/ingest/institutional_vertical.py†L1-L239】【F:tests/runtime/test_institutional_ingest_vertical.py†L1-L164】【F:docs/operations/timescale_failover_drills.md†L1-L27】
+- Progress: Timescale ingest helpers now validate schema/table identifiers at
+  construction time and assert the contract under regression coverage so policy
+  payloads cannot inject unsafe SQL into institutional ingest jobs.【F:src/data_foundation/persist/timescale.py†L1-L120】【F:tests/data_foundation/test_timescale_ingest.py†L1-L83】
 - Wire all runtime entrypoints through `RuntimeApplication` and a task supervisor
   so ingest, cache, and stream jobs are supervised.【F:docs/technical_debt_assessment.md†L33-L56】
 - Document current gaps and expected telemetry in updated runbooks and status

--- a/docs/context/alignment_briefs/operational_readiness.md
+++ b/docs/context/alignment_briefs/operational_readiness.md
@@ -51,6 +51,10 @@
   via the guarded runtime→global failover path so outage evidence, roster gaps,
   and postmortem backlog context stay visible under pytest coverage documenting
   escalation and publish failures.【F:src/operations/incident_response.py†L1-L715】【F:tests/operations/test_incident_response.py†L1-L200】【F:src/operations/event_bus_failover.py†L1-L174】
+- Document Timescale failover drill requirements via the institutional ingest
+  provisioner, which now exposes drill metadata from configuration and captures
+  the workflow in updated runbooks so operators can rehearse recoveries using a
+  consistent source of truth.【F:src/data_foundation/ingest/institutional_vertical.py†L160-L239】【F:docs/operations/timescale_failover_drills.md†L1-L27】
 - Aggregate operational readiness into a single severity snapshot that merges
   system validation, incident response, and ingest SLO posture, emits Markdown
   summaries, derives alert events, and now exposes status breakdown/component

--- a/docs/context/alignment_briefs/quality_observability.md
+++ b/docs/context/alignment_briefs/quality_observability.md
@@ -105,9 +105,10 @@
     feeding remediation summaries under pytest coverage so responders inherit a
     consolidated operational view without bespoke wiring.【F:src/operations/observability_dashboard.py†L443-L493】【F:tests/operations/test_observability_dashboard.py†L135-L236】
   - Progress: Observability dashboard guard CLI grades snapshot freshness,
-    required panels, and failing slices, emitting JSON or human-readable
-    summaries with status-driven exit codes so CI hooks and drills can block on
-    stale observability evidence under pytest coverage.【F:tools/telemetry/dashboard_guard.py†L1-L260】【F:tests/tools/test_dashboard_guard.py†L16-L140】
+    required panels, failing slices, and normalised overall status strings while
+    emitting JSON or human-readable summaries with status-driven exit codes so
+    CI hooks and drills can block on stale, failing, or WARN observability
+    evidence under pytest coverage.【F:tools/telemetry/dashboard_guard.py†L1-L220】【F:tests/tools/test_dashboard_guard.py†L16-L140】
   - Progress: Configuration audit telemetry now evaluates `SystemConfig` diffs,
     annotates tracked toggles and extras, renders Markdown summaries, and
     publishes via the shared failover helper so configuration changes generate a

--- a/docs/context/alignment_briefs/sensory_cortex.md
+++ b/docs/context/alignment_briefs/sensory_cortex.md
@@ -49,6 +49,11 @@
   scaffolding so new organs can land incrementally.
 - Update documentation to reflect the mock status, preserving the truth-first
   narrative for reviewers.【F:docs/DEVELOPMENT_STATUS.md†L7-L35】
+- Progress: Sensory summary telemetry now constructs ranked Markdown/JSON
+  rollups from integrated sensor payloads, preserves drift metadata, and
+  publishes via the event-bus failover helper so dashboards receive resilient
+  sensory status updates backed by regression coverage of runtime and fallback
+  paths.【F:src/operations/sensory_summary.py†L1-L215】【F:tests/operations/test_sensory_summary.py†L1-L155】
 
 ### Next (30–90 days)
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -44,6 +44,16 @@ Encyclopedia while acknowledging that most subsystems remain scaffolding.
     telemetry exposes what was fetched, normalised, or skipped; guardrail tests
     cover macro window fallbacks, empty payloads, and metadata emission to
     prevent regressions in institutional ingest coverage.【F:src/data_foundation/ingest/timescale_pipeline.py†L70-L213】【F:tests/data_foundation/test_timescale_backbone_orchestrator.py†L1-L200】
+  - *Progress*: Institutional ingest provisioner now hydrates supervised
+    Timescale schedules, optional Redis caches, and Kafka ingest bridges from a
+    single configuration bundle while exposing failover drill metadata and
+    documenting how to surface the requirements so operators can bootstrap the
+    full ingest vertical with guardrails and discover required recovery
+    exercises without bespoke wiring.【F:src/data_foundation/ingest/institutional_vertical.py†L1-L239】【F:tests/runtime/test_institutional_ingest_vertical.py†L1-L164】【F:docs/operations/timescale_failover_drills.md†L1-L27】
+  - *Progress*: Timescale ingest helpers now validate schema/table identifiers
+    before emitting SQL, raising deterministic errors on unsafe names and
+    pinning the contract via regression tests so institutional slices cannot
+    smuggle raw SQL through policy or schedule configuration.【F:src/data_foundation/persist/timescale.py†L1-L120】【F:tests/data_foundation/test_timescale_ingest.py†L1-L83】
   - *Progress*: JSONL persistence now raises typed errors for unserialisable payloads,
     logs filesystem failures, and cleans up partial files so ingest tooling surfaces
     genuine persistence faults instead of emitting empty paths under silent
@@ -111,6 +121,11 @@ Encyclopedia while acknowledging that most subsystems remain scaffolding.
     configurable baseline/evaluation policy, publishes telemetry snapshots, and
     surfaces status summaries so runtime consumers inherit a single executable
     sensory surface with drift alerts under pytest coverage.【F:src/sensory/real_sensory_organ.py†L23-L199】【F:src/sensory/real_sensory_organ.py†L288-L375】【F:tests/sensory/test_real_sensory_organ.py†L98-L142】
+  - *Progress*: Sensory summary publisher now normalises integrated sensor
+    payloads into ranked Markdown/JSON snapshots, captures drift metadata, and
+    emits telemetry via the event-bus failover helper so dashboards inherit
+    resilient sensory rollups backed by pytest coverage of runtime and failover
+    paths.【F:src/operations/sensory_summary.py†L1-L215】【F:tests/operations/test_sensory_summary.py†L1-L155】
   - *Progress*: Core module now logs and documents the sensory organ import
     fallback, emitting warnings and restoring stub exports under regression
     coverage so bootstrap environments surface degraded sensory wiring instead of
@@ -234,9 +249,10 @@ Encyclopedia while acknowledging that most subsystems remain scaffolding.
     under regression coverage so responders inherit a consolidated operational
     view.【F:src/operations/observability_dashboard.py†L443-L493】【F:tests/operations/test_observability_dashboard.py†L135-L236】
   - *Progress*: Observability dashboard guard CLI now grades snapshot freshness,
-    required panels, and failing slices with machine-readable output and
-    severity-driven exit codes so CI pipelines and drills can block on stale or
-    missing observability evidence under pytest coverage.【F:tools/telemetry/dashboard_guard.py†L1-L260】【F:tests/tools/test_dashboard_guard.py†L16-L140】
+    required panels, failing slices, and normalised overall status strings with
+    machine-readable output plus severity-driven exit codes so CI pipelines and
+    drills can block on stale, failing, or operator-reported WARN/FAIL snapshots
+    under pytest coverage.【F:tools/telemetry/dashboard_guard.py†L1-L220】【F:tests/tools/test_dashboard_guard.py†L16-L140】
   - *Progress*: Configuration audit telemetry now normalises `SystemConfig`
     diffs, grades tracked toggles plus extras, renders Markdown summaries, and
     publishes via the shared failover helper so configuration changes leave a


### PR DESCRIPTION
## Summary
- document the new institutional ingest provisioner, failover drill metadata, and identifier validation work in the roadmap and ingest brief
- record the sensory summary telemetry publisher in the roadmap and sensory cortex context pack
- highlight dashboard guard overall-status handling and failover drill documentation across the observability and operational readiness briefs

## Testing
- not run (documentation updates only)

------
https://chatgpt.com/codex/tasks/task_e_68e217327ab0832c95e115a2e0ec34ac