### PR TITLE
Enhance risk config summary telemetry

### DIFF
--- a/src/trading/risk/risk_api.py
+++ b/src/trading/risk/risk_api.py
@@ -113,6 +113,12 @@ def summarise_risk_config(config: RiskConfig) -> dict[str, object]:
         "max_position_size": int(config.max_position_size),
         "mandatory_stop_loss": bool(config.mandatory_stop_loss),
         "research_mode": bool(config.research_mode),
+        "target_volatility_pct": float(config.target_volatility_pct),
+        "volatility_window": int(config.volatility_window),
+        "max_volatility_leverage": float(config.max_volatility_leverage),
+        "volatility_annualisation_factor": float(
+            config.volatility_annualisation_factor
+        ),
     }
 
     if config.sector_exposure_limits:
@@ -123,7 +129,12 @@ def summarise_risk_config(config: RiskConfig) -> dict[str, object]:
         summary["sector_budget_total_pct"] = float(sector_total)
 
     if config.instrument_sector_map:
-        summary["instrument_sector_map"] = dict(config.instrument_sector_map)
+        instrument_sector_map = dict(config.instrument_sector_map)
+        summary["instrument_sector_map"] = instrument_sector_map
+        sector_instrument_counts: dict[str, int] = {}
+        for sector in instrument_sector_map.values():
+            sector_instrument_counts[sector] = sector_instrument_counts.get(sector, 0) + 1
+        summary["sector_instrument_counts"] = sector_instrument_counts
 
     return summary
 

--- a/tests/trading/test_risk_api.py
+++ b/tests/trading/test_risk_api.py
@@ -110,6 +110,13 @@ def test_summarise_risk_config_includes_sector_metadata() -> None:
     assert summary["sector_exposure_limits"] == {"FX": pytest.approx(0.30)}
     assert summary["instrument_sector_map"] == {"EURUSD": "FX"}
     assert summary["sector_budget_total_pct"] == pytest.approx(0.30)
+    assert summary["sector_instrument_counts"] == {"FX": 1}
+    assert summary["target_volatility_pct"] == pytest.approx(float(config.target_volatility_pct))
+    assert summary["volatility_window"] == config.volatility_window
+    assert summary["max_volatility_leverage"] == pytest.approx(float(config.max_volatility_leverage))
+    assert summary["volatility_annualisation_factor"] == pytest.approx(
+        float(config.volatility_annualisation_factor)
+    )
 
 
 def test_build_runtime_metadata_respects_status_payload() -> None:


### PR DESCRIPTION
## Summary
- enrich `summarise_risk_config` to expose volatility targeting parameters and sector instrument counts
- extend the risk API unit test to assert the richer telemetry surface

## Testing
- pytest tests/trading/test_risk_api.py

------
https://chatgpt.com/codex/tasks/task_e_68e22c462390832ca7d56a60725bc8ca