### PR TITLE
Add replay telemetry snapshot and coverage guardrail checks

### DIFF
--- a/src/evolution/__init__.py
+++ b/src/evolution/__init__.py
@@ -23,6 +23,16 @@ from src.evolution.catalogue_telemetry import (
     EvolutionCatalogueSnapshot,
     build_catalogue_snapshot,
 )
+from src.evolution.evaluation import (
+    RecordedEvaluationResult,
+    RecordedSensoryEvaluator,
+    RecordedSensorySnapshot,
+    RecordedTrade,
+)
+from src.evolution.evaluation.telemetry import (
+    RecordedReplayTelemetrySnapshot,
+    summarise_recorded_replay,
+)
 from src.evolution.feature_flags import EvolutionFeatureFlags
 from src.evolution.lineage_telemetry import (
     EvolutionLineageSnapshot,
@@ -46,4 +56,10 @@ __all__ = [
     "EvolutionLineageSnapshot",
     "build_lineage_snapshot",
     "EvolutionFeatureFlags",
+    "RecordedEvaluationResult",
+    "RecordedReplayTelemetrySnapshot",
+    "RecordedSensoryEvaluator",
+    "RecordedSensorySnapshot",
+    "RecordedTrade",
+    "summarise_recorded_replay",
 ]

--- a/src/evolution/evaluation/telemetry.py
+++ b/src/evolution/evaluation/telemetry.py
@@ -1,0 +1,261 @@
+"""Telemetry helpers for recorded sensory replay evaluations."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from typing import Any, Mapping, MutableMapping, Sequence
+
+from src.evolution.evaluation.recorded_replay import (
+    RecordedEvaluationResult,
+    RecordedTrade,
+)
+from src.sensory.lineage import SensorLineageRecord, build_lineage_record
+
+__all__ = [
+    "RecordedReplayTelemetrySnapshot",
+    "summarise_recorded_replay",
+]
+
+
+def _coerce_parameters(parameters: Mapping[str, Any] | None) -> dict[str, float]:
+    cleaned: MutableMapping[str, float] = {}
+    if not parameters:
+        return {}
+    for key, value in parameters.items():
+        try:
+            cleaned[str(key)] = float(value)  # type: ignore[arg-type]
+        except Exception:
+            continue
+    return dict(cleaned)
+
+
+def _serialise_trade(trade: RecordedTrade | None) -> dict[str, Any] | None:
+    if trade is None:
+        return None
+    payload = trade.as_dict()
+    duration = (trade.closed_at - trade.opened_at).total_seconds() / 60.0
+    payload["holding_minutes"] = round(duration, 4)
+    return payload
+
+
+def _profit_factor(trades: Sequence[RecordedTrade]) -> float:
+    gains = sum(trade.return_pct for trade in trades if trade.return_pct > 0)
+    losses = sum(trade.return_pct for trade in trades if trade.return_pct < 0)
+    if gains == 0 and losses == 0:
+        return 0.0
+    if losses == 0:
+        return float("inf")
+    return gains / abs(losses)
+
+
+def _exposure_minutes(trades: Sequence[RecordedTrade]) -> float:
+    total_seconds = sum(
+        (trade.closed_at - trade.opened_at).total_seconds() for trade in trades
+    )
+    return total_seconds / 60.0
+
+
+def _rank_trade(
+    trades: Sequence[RecordedTrade], *, reverse: bool
+) -> RecordedTrade | None:
+    if not trades:
+        return None
+    if reverse:
+        return max(trades, key=lambda trade: trade.return_pct, default=None)
+    return min(trades, key=lambda trade: trade.return_pct, default=None)
+
+
+def _elevate_status(current: str, candidate: str) -> str:
+    order = {"normal": 0, "warn": 1, "alert": 2}
+    if order.get(candidate, 0) > order.get(current, 0):
+        return candidate
+    return current
+
+
+@dataclass(frozen=True)
+class RecordedReplayTelemetrySnapshot:
+    """Aggregated telemetry describing a recorded replay evaluation."""
+
+    generated_at: datetime
+    status: str
+    genome_id: str
+    dataset_id: str | None
+    evaluation_id: str | None
+    metrics: Mapping[str, float]
+    trade_summary: Mapping[str, Any]
+    lineage: SensorLineageRecord
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+    def as_dict(self) -> dict[str, Any]:
+        payload: dict[str, Any] = {
+            "generated_at": self.generated_at.isoformat(),
+            "status": self.status,
+            "genome_id": self.genome_id,
+            "metrics": dict(self.metrics),
+            "trade_summary": dict(self.trade_summary),
+            "lineage": self.lineage.as_dict(),
+        }
+        if self.dataset_id is not None:
+            payload["dataset_id"] = self.dataset_id
+        if self.evaluation_id is not None:
+            payload["evaluation_id"] = self.evaluation_id
+        if self.metadata:
+            payload["metadata"] = dict(self.metadata)
+        return payload
+
+    def to_markdown(self) -> str:
+        lines = [
+            f"### Recorded replay telemetry for genome `{self.genome_id}`",
+            "",
+            "| Metric | Value |",
+            "| --- | --- |",
+        ]
+        total_return = self.metrics.get("total_return")
+        max_drawdown = self.metrics.get("max_drawdown")
+        sharpe = self.metrics.get("sharpe_ratio")
+        win_rate = self.metrics.get("win_rate")
+        volatility = self.metrics.get("volatility")
+        trades = self.metrics.get("trades")
+        exposure = self.trade_summary.get("exposure_minutes")
+        profit_factor = self.trade_summary.get("profit_factor")
+
+        if total_return is not None:
+            lines.append(f"| Total return | {total_return:.2%} |")
+        if max_drawdown is not None:
+            lines.append(f"| Max drawdown | {max_drawdown:.2%} |")
+        if sharpe is not None:
+            lines.append(f"| Sharpe ratio | {sharpe:.3f} |")
+        if volatility is not None:
+            lines.append(f"| Volatility | {volatility:.3f} |")
+        if win_rate is not None:
+            lines.append(f"| Win rate | {win_rate:.2%} |")
+        if trades is not None:
+            lines.append(f"| Trades | {int(trades)} |")
+        if exposure is not None:
+            lines.append(f"| Exposure (minutes) | {exposure:.2f} |")
+        if profit_factor is not None:
+            if profit_factor == float("inf"):
+                display = "∞"
+            else:
+                display = f"{profit_factor:.3f}"
+            lines.append(f"| Profit factor | {display} |")
+
+        best = self.trade_summary.get("best_trade")
+        worst = self.trade_summary.get("worst_trade")
+        if isinstance(best, dict) and best:
+            lines.append(
+                f"| Best trade | {best.get('return_pct', 0.0):.2%} ({best.get('holding_minutes', 0.0):.1f} min) |"
+            )
+        if isinstance(worst, dict) and worst:
+            lines.append(
+                f"| Worst trade | {worst.get('return_pct', 0.0):.2%} ({worst.get('holding_minutes', 0.0):.1f} min) |"
+            )
+
+        return "\n".join(lines)
+
+
+def summarise_recorded_replay(
+    result: RecordedEvaluationResult,
+    *,
+    genome_id: str,
+    dataset_id: str | None = None,
+    evaluation_id: str | None = None,
+    parameters: Mapping[str, Any] | None = None,
+    metadata: Mapping[str, Any] | None = None,
+    warn_drawdown: float = 0.15,
+    alert_drawdown: float = 0.25,
+) -> RecordedReplayTelemetrySnapshot:
+    """Fuse replay evaluation metrics into a telemetry snapshot."""
+
+    parameters_payload = _coerce_parameters(parameters)
+    trades: Sequence[RecordedTrade] = result.trade_log
+
+    best_trade = _rank_trade(trades, reverse=True)
+    worst_trade = _rank_trade(trades, reverse=False)
+    profit_factor = _profit_factor(trades)
+    exposure = _exposure_minutes(trades)
+
+    metrics: dict[str, float] = {
+        "total_return": float(result.total_return),
+        "max_drawdown": float(result.max_drawdown),
+        "sharpe_ratio": float(result.sharpe_ratio),
+        "volatility": float(result.volatility),
+        "win_rate": float(result.win_rate),
+        "trades": float(result.trades),
+        "average_trade_duration_minutes": float(result.average_trade_duration_minutes),
+    }
+
+    trade_summary: dict[str, Any] = {
+        "profit_factor": profit_factor,
+        "exposure_minutes": exposure,
+    }
+    serialised_best = _serialise_trade(best_trade)
+    serialised_worst = _serialise_trade(worst_trade)
+    if serialised_best is not None:
+        trade_summary["best_trade"] = serialised_best
+    if serialised_worst is not None:
+        trade_summary["worst_trade"] = serialised_worst
+
+    status = "normal"
+    if result.max_drawdown >= warn_drawdown:
+        status = _elevate_status(status, "warn")
+    if result.max_drawdown >= alert_drawdown:
+        status = _elevate_status(status, "alert")
+    if result.total_return <= 0:
+        status = _elevate_status(status, "alert")
+    elif result.total_return < 0.02:
+        status = _elevate_status(status, "warn")
+    if result.trades > 0 and result.win_rate < 0.35:
+        status = _elevate_status(status, "warn")
+    if result.trades == 0:
+        status = _elevate_status(status, "warn")
+
+    lineage_inputs: dict[str, Any] = {"parameters": parameters_payload}
+    if dataset_id is not None:
+        lineage_inputs["dataset_id"] = dataset_id
+    if evaluation_id is not None:
+        lineage_inputs["evaluation_id"] = evaluation_id
+
+    lineage_outputs: dict[str, Any] = {
+        "total_return": metrics["total_return"],
+        "max_drawdown": metrics["max_drawdown"],
+        "win_rate": metrics["win_rate"],
+        "trades": int(result.trades),
+        "status": status,
+    }
+
+    lineage = build_lineage_record(
+        "EVOLUTION",
+        "evolution.recorded_replay",
+        inputs=lineage_inputs,
+        outputs=lineage_outputs,
+        telemetry={
+            "profit_factor": profit_factor,
+            "exposure_minutes": exposure,
+            "sharpe_ratio": metrics["sharpe_ratio"],
+        },
+        metadata={
+            "genome_id": genome_id,
+            "drawdown_thresholds": {
+                "warn": warn_drawdown,
+                "alert": alert_drawdown,
+            },
+        },
+    )
+
+    snapshot_metadata: dict[str, Any] = dict(metadata or {})
+    if parameters_payload:
+        snapshot_metadata.setdefault("parameters", parameters_payload)
+
+    return RecordedReplayTelemetrySnapshot(
+        generated_at=datetime.now(tz=UTC),
+        status=status,
+        genome_id=genome_id,
+        dataset_id=dataset_id,
+        evaluation_id=evaluation_id,
+        metrics=metrics,
+        trade_summary=trade_summary,
+        lineage=lineage,
+        metadata=snapshot_metadata,
+    )

--- a/tests/evolution/test_recorded_replay_telemetry.py
+++ b/tests/evolution/test_recorded_replay_telemetry.py
@@ -1,0 +1,119 @@
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from src.core.genome import NoOpGenomeProvider
+from src.evolution import (
+    RecordedEvaluationResult,
+    RecordedSensoryEvaluator,
+    RecordedSensorySnapshot,
+    RecordedTrade,
+    summarise_recorded_replay,
+)
+from src.sensory.signals import IntegratedSignal
+
+
+def _snapshot(ts: datetime, price: float, strength: float, confidence: float) -> RecordedSensorySnapshot:
+    payload = {
+        "generated_at": ts,
+        "integrated_signal": IntegratedSignal(
+            direction=1.0 if strength >= 0 else -1.0,
+            strength=strength,
+            confidence=confidence,
+            contributing=["WHY", "WHAT", "WHEN", "HOW", "ANOMALY"],
+        ),
+        "dimensions": {
+            "WHAT": {
+                "signal": strength,
+                "confidence": confidence,
+                "value": {"last_close": price},
+                "metadata": {"last_close": price},
+            }
+        },
+    }
+    return RecordedSensorySnapshot.from_snapshot(payload)
+
+
+def test_recorded_replay_summary_builds_lineage_and_markdown() -> None:
+    start = datetime.now(timezone.utc) - timedelta(minutes=40)
+    price = 100.0
+    snapshots: list[RecordedSensorySnapshot] = []
+    for idx in range(30):
+        ts = start + timedelta(minutes=idx)
+        price += 0.45
+        strength = 0.6 if idx > 3 else 0.2
+        confidence = 0.78
+        snapshots.append(_snapshot(ts, price, strength, confidence))
+
+    genome = NoOpGenomeProvider().new_genome(
+        "genome-telemetry",
+        {
+            "entry_threshold": 0.4,
+            "exit_threshold": 0.2,
+            "risk_fraction": 0.4,
+            "min_confidence": 0.7,
+            "cooldown_steps": 1,
+        },
+    )
+
+    evaluator = RecordedSensoryEvaluator(snapshots)
+    result = evaluator.evaluate(genome)
+
+    summary = summarise_recorded_replay(
+        result,
+        genome_id=getattr(genome, "id", "genome-telemetry"),
+        dataset_id="timescale-session-42",
+        evaluation_id="replay-20240101",
+        parameters=getattr(genome, "parameters", {}),
+        metadata={"run": "integration"},
+    )
+
+    data = summary.as_dict()
+    assert data["status"] in {"normal", "warn", "alert"}
+    assert data["lineage"]["metadata"]["genome_id"] == getattr(genome, "id", "genome-telemetry")
+    assert data["lineage"]["inputs"]["dataset_id"] == "timescale-session-42"
+    assert pytest.approx(result.total_return, rel=1e-6) == data["metrics"]["total_return"]
+    assert "Total return" in summary.to_markdown()
+    assert data["trade_summary"]["profit_factor"] >= 0
+    assert "best_trade" in data["trade_summary"]
+
+
+def test_recorded_replay_summary_flags_alert_on_large_drawdown() -> None:
+    now = datetime.now(timezone.utc)
+    trade = RecordedTrade(
+        opened_at=now - timedelta(minutes=10),
+        closed_at=now,
+        direction=-1,
+        entry_price=100.0,
+        exit_price=80.0,
+        return_pct=-0.2,
+        confidence_open=0.9,
+        confidence_close=0.2,
+        strength_open=0.5,
+        strength_close=-0.3,
+    )
+    result = RecordedEvaluationResult(
+        equity_curve=(1.0, 0.8),
+        total_return=-0.2,
+        max_drawdown=0.4,
+        sharpe_ratio=-1.1,
+        volatility=0.3,
+        win_rate=0.0,
+        trades=1,
+        wins=0,
+        losses=1,
+        trade_log=(trade,),
+        max_consecutive_losses=1,
+        average_trade_duration_minutes=10.0,
+    )
+
+    summary = summarise_recorded_replay(
+        result,
+        genome_id="stress-genome",
+        warn_drawdown=0.1,
+        alert_drawdown=0.3,
+    )
+
+    assert summary.status == "alert"
+    assert summary.trade_summary["worst_trade"]["return_pct"] == pytest.approx(-0.2)
+    assert summary.trade_summary["exposure_minutes"] == pytest.approx(10.0)

--- a/tests/tools/test_coverage_guardrails.py
+++ b/tests/tools/test_coverage_guardrails.py
@@ -1,0 +1,87 @@
+from pathlib import Path
+
+import pytest
+
+from tools.telemetry.coverage_guardrails import (
+    evaluate_guardrails,
+    main,
+    render_report,
+)
+
+
+def _write_report(tmp_path: Path, coverage: dict[str, list[int]]) -> Path:
+    lines = [
+        "<?xml version=\"1.0\" encoding=\"UTF-8\"?>",
+        "<coverage>",
+        "  <packages>",
+        "    <package>",
+        "      <classes>",
+    ]
+    for filename, hits in coverage.items():
+        lines.append(f'        <class filename="{filename}">')
+        lines.append("          <lines>")
+        for idx, hit in enumerate(hits, start=1):
+            lines.append(f'            <line number="{idx}" hits="{hit}"/>')
+        lines.append("          </lines>")
+        lines.append("        </class>")
+    lines.extend([
+        "      </classes>",
+        "    </package>",
+        "  </packages>",
+        "</coverage>",
+    ])
+    path = tmp_path / "coverage.xml"
+    path.write_text("\n".join(lines), encoding="utf-8")
+    return path
+
+
+@pytest.fixture()
+def sample_report(tmp_path: Path) -> Path:
+    coverage = {
+        "src/data_foundation/ingest/production_slice.py": [1, 1, 1, 0],
+        "src/data_foundation/ingest/timescale_pipeline.py": [1, 1, 1, 1, 0],
+        "src/trading/risk/risk_policy.py": [1, 1, 0, 1, 1],
+    }
+    return _write_report(tmp_path, coverage)
+
+
+def test_evaluate_guardrails_passes_when_threshold_met(sample_report: Path) -> None:
+    report = evaluate_guardrails(sample_report, minimum_percent=60.0)
+    assert not report.has_failures
+    assert {target.label for target in report.targets} == {
+        "ingest_production_slice",
+        "timescale_pipeline",
+        "risk_policy",
+    }
+    for target in report.targets:
+        assert target.percent >= 60.0
+        assert not target.missing
+    markdown = render_report(report)
+    assert "ok" in markdown
+
+
+def test_evaluate_guardrails_marks_missing_targets(tmp_path: Path) -> None:
+    coverage = {
+        "src/data_foundation/ingest/production_slice.py": [1, 0, 1],
+        "src/trading/risk/risk_policy.py": [1, 0, 0, 1],
+    }
+    report_path = _write_report(tmp_path, coverage)
+    report = evaluate_guardrails(report_path, minimum_percent=80.0)
+
+    assert report.has_failures
+    assert "timescale_pipeline" in report.failing
+    missing = {target.label for target in report.targets if target.missing}
+    assert missing == {"timescale_pipeline"}
+
+
+def test_cli_returns_failure_exit_code_on_low_coverage(sample_report: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    exit_code = main([
+        "--report",
+        str(sample_report),
+        "--min-percent",
+        "95",
+        "--json",
+    ])
+    captured = capsys.readouterr()
+    assert exit_code == 1
+    assert "failing" in captured.out

--- a/tools/telemetry/coverage_guardrails.py
+++ b/tools/telemetry/coverage_guardrails.py
@@ -1,0 +1,271 @@
+"""Guardrail checks that ensure critical domains retain test coverage."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import xml.etree.ElementTree as ET
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any, Iterable, Mapping, Sequence
+
+__all__ = [
+    "CoverageGuardrail",
+    "CoverageGuardrailReport",
+    "evaluate_guardrails",
+    "render_report",
+    "main",
+]
+
+_DEFAULT_TARGETS: dict[str, str] = {
+    "ingest_production_slice": "src/data_foundation/ingest/production_slice.py",
+    "timescale_pipeline": "src/data_foundation/ingest/timescale_pipeline.py",
+    "risk_policy": "src/trading/risk/risk_policy.py",
+}
+
+
+@dataclass(frozen=True)
+class CoverageGuardrail:
+    """Coverage summary for a single guardrail target."""
+
+    label: str
+    path: str
+    covered: int
+    missed: int
+    missing: bool = False
+
+    @property
+    def total(self) -> int:
+        return self.covered + self.missed
+
+    @property
+    def percent(self) -> float:
+        total = self.total
+        if total == 0:
+            return 0.0
+        return round((self.covered / total) * 100.0, 2)
+
+    def as_dict(self) -> dict[str, Any]:
+        payload = {
+            "label": self.label,
+            "path": self.path,
+            "covered": self.covered,
+            "missed": self.missed,
+            "coverage_percent": self.percent,
+        }
+        if self.missing:
+            payload["missing"] = True
+        return payload
+
+
+@dataclass(frozen=True)
+class CoverageGuardrailReport:
+    """Evaluation outcome for a set of guardrail targets."""
+
+    generated_at: str
+    minimum_percent: float
+    targets: tuple[CoverageGuardrail, ...]
+    failing: tuple[str, ...]
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "generated_at": self.generated_at,
+            "minimum_percent": self.minimum_percent,
+            "targets": [target.as_dict() for target in self.targets],
+            "failing": list(self.failing),
+        }
+
+    @property
+    def has_failures(self) -> bool:
+        return bool(self.failing)
+
+
+def _normalise_parts(filename: str) -> tuple[str, ...]:
+    parts: list[str] = []
+    for part in Path(filename).parts:
+        if part in {"", "."}:
+            continue
+        if part == "..":
+            if parts:
+                parts.pop()
+            continue
+        parts.append(part)
+    return tuple(parts)
+
+
+def _iter_class_nodes(root: ET.Element) -> Iterable[ET.Element]:
+    yield from root.iter("class")
+
+
+def _count_line_coverage(node: ET.Element) -> tuple[int, int]:
+    covered = 0
+    missed = 0
+    for line in node.iter("line"):
+        hits = int(line.attrib.get("hits", "0") or "0")
+        if hits > 0:
+            covered += 1
+        else:
+            missed += 1
+    return covered, missed
+
+
+def _build_coverage_index(root: ET.Element) -> dict[str, tuple[int, int]]:
+    coverage: dict[str, tuple[int, int]] = {}
+    for class_node in _iter_class_nodes(root):
+        filename = class_node.attrib.get("filename")
+        if not filename:
+            continue
+        normalised = "/".join(_normalise_parts(filename))
+        if not normalised:
+            continue
+        covered, missed = _count_line_coverage(class_node)
+        if covered == 0 and missed == 0:
+            continue
+        existing = coverage.get(normalised)
+        if existing:
+            covered += existing[0]
+            missed += existing[1]
+        coverage[normalised] = (covered, missed)
+    return coverage
+
+
+def _resolve_targets(targets: Mapping[str, str]) -> tuple[tuple[str, str], ...]:
+    resolved: list[tuple[str, str]] = []
+    for label, path in targets.items():
+        resolved.append((str(label), "/".join(_normalise_parts(path))))
+    return tuple(resolved)
+
+
+def evaluate_guardrails(
+    coverage_report: Path,
+    targets: Mapping[str, str] | None = None,
+    *,
+    minimum_percent: float = 80.0,
+) -> CoverageGuardrailReport:
+    """Evaluate guardrail targets against a Cobertura XML report."""
+
+    if targets is None:
+        targets = _DEFAULT_TARGETS
+
+    tree = ET.parse(coverage_report)
+    root = tree.getroot()
+    coverage_index = _build_coverage_index(root)
+    resolved_targets = _resolve_targets(targets)
+
+    guardrails: list[CoverageGuardrail] = []
+    failing: list[str] = []
+
+    for label, path in resolved_targets:
+        stats = coverage_index.get(path)
+        if stats is None:
+            guardrails.append(
+                CoverageGuardrail(label=label, path=path, covered=0, missed=0, missing=True)
+            )
+            failing.append(label)
+            continue
+        covered, missed = stats
+        guardrail = CoverageGuardrail(
+            label=label,
+            path=path,
+            covered=covered,
+            missed=missed,
+        )
+        guardrails.append(guardrail)
+        if guardrail.percent < minimum_percent:
+            failing.append(label)
+
+    report = CoverageGuardrailReport(
+        generated_at=datetime.now(tz=UTC).isoformat(timespec="seconds"),
+        minimum_percent=minimum_percent,
+        targets=tuple(guardrails),
+        failing=tuple(failing),
+    )
+    return report
+
+
+def render_report(report: CoverageGuardrailReport) -> str:
+    lines = [
+        f"Guardrail coverage (minimum {report.minimum_percent:.2f}%):",
+    ]
+    for target in report.targets:
+        status: str
+        if target.missing:
+            status = "missing"
+        elif target.percent < report.minimum_percent:
+            status = "fail"
+        else:
+            status = "ok"
+        lines.append(
+            f"- {target.label}: {target.percent:.2f}% ({status}) [{target.path}]"
+        )
+    if report.has_failures:
+        lines.append("Guardrail coverage failed")
+    else:
+        lines.append("All guardrail targets met minimum coverage")
+    return "\n".join(lines)
+
+
+def _parse_target_overrides(entries: Sequence[str] | None) -> dict[str, str]:
+    if not entries:
+        return {}
+    overrides: dict[str, str] = {}
+    for entry in entries:
+        if "=" not in entry:
+            raise ValueError(f"Invalid target specification: {entry!r}")
+        label, path = entry.split("=", 1)
+        overrides[label.strip()] = path.strip()
+    return overrides
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Evaluate coverage guardrails")
+    parser.add_argument(
+        "--report",
+        type=Path,
+        default=Path("coverage.xml"),
+        help="Path to the Cobertura XML report",
+    )
+    parser.add_argument(
+        "--min-percent",
+        type=float,
+        default=80.0,
+        help="Minimum required coverage percentage",
+    )
+    parser.add_argument(
+        "--target",
+        action="append",
+        dest="targets",
+        help="Override default targets using label=path",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Render the report as JSON",
+    )
+
+    args = parser.parse_args(argv)
+
+    overrides = _parse_target_overrides(args.targets)
+    if overrides:
+        targets = overrides
+    else:
+        targets = _DEFAULT_TARGETS
+
+    report = evaluate_guardrails(
+        args.report,
+        targets,
+        minimum_percent=args.min_percent,
+    )
+
+    if args.json:
+        print(json.dumps(report.as_dict(), indent=2, sort_keys=True))
+    else:
+        print(render_report(report))
+
+    return 1 if report.has_failures else 0
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- add a recorded replay telemetry snapshot helper that fuses lineage metadata, trade summaries, and markdown output for sensory/evolution evaluations
- expose the telemetry helper through the evolution facade and cover it with replay-focused unit tests
- introduce a coverage guardrail CLI to enforce ingest orchestration and risk policy coverage, with regression tests and CLI validation

## Testing
- `pytest tests/evolution/test_recorded_replay_telemetry.py tests/tools/test_coverage_guardrails.py`


------
https://chatgpt.com/codex/tasks/task_e_68e288495954832c8fb42400793e9328