### PR TITLE
Add sensory metrics telemetry and dead-code triage tooling

### DIFF
--- a/src/operations/sensory_metrics.py
+++ b/src/operations/sensory_metrics.py
@@ -1,0 +1,159 @@
+"""Build and publish sensory cortex metrics for runtime dashboards."""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Callable, Iterable, Mapping, MutableMapping, Sequence
+
+from src.core.event_bus import Event, EventBus, TopicBus
+from src.operations.event_bus_failover import publish_event_with_failover
+from src.operations.sensory_summary import SensorySummary, build_sensory_summary
+
+__all__ = [
+    "DimensionMetric",
+    "SensoryMetrics",
+    "build_sensory_metrics",
+    "build_sensory_metrics_from_status",
+    "publish_sensory_metrics",
+]
+
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class DimensionMetric:
+    """Structured telemetry for a single sensory dimension."""
+
+    name: str
+    signal: float | None
+    confidence: float | None
+    state: str | None
+    threshold_state: str | None
+
+    def as_dict(self) -> Mapping[str, object]:
+        payload: MutableMapping[str, object] = {"name": self.name}
+        if self.signal is not None:
+            payload["signal"] = self.signal
+        if self.confidence is not None:
+            payload["confidence"] = self.confidence
+        if self.state is not None:
+            payload["state"] = self.state
+        if self.threshold_state is not None:
+            payload["threshold_state"] = self.threshold_state
+        return payload
+
+
+@dataclass(frozen=True)
+class SensoryMetrics:
+    """Aggregated metrics derived from a sensory cortex snapshot."""
+
+    symbol: str | None
+    generated_at: datetime | None
+    samples: int
+    integrated_strength: float | None
+    integrated_confidence: float | None
+    integrated_direction: float | None
+    dimensions: tuple[DimensionMetric, ...]
+    drift_alerts: tuple[str, ...]
+
+    def as_dict(self) -> Mapping[str, object]:
+        return {
+            "symbol": self.symbol,
+            "generated_at": self.generated_at.isoformat() if self.generated_at else None,
+            "samples": self.samples,
+            "integrated_strength": self.integrated_strength,
+            "integrated_confidence": self.integrated_confidence,
+            "integrated_direction": self.integrated_direction,
+            "dimensions": [dimension.as_dict() for dimension in self.dimensions],
+            "drift_alerts": list(self.drift_alerts),
+        }
+
+    def filter_dimensions(self, names: Sequence[str]) -> tuple[DimensionMetric, ...]:
+        lookup = {name.upper(): name for name in names}
+        selected: list[DimensionMetric] = []
+        for dimension in self.dimensions:
+            if dimension.name.upper() in lookup:
+                selected.append(dimension)
+        return tuple(selected)
+
+
+def build_sensory_metrics(summary: SensorySummary) -> SensoryMetrics:
+    """Convert a sensory summary into dimension metrics."""
+
+    dimensions = tuple(
+        DimensionMetric(
+            name=dimension.name,
+            signal=dimension.signal,
+            confidence=dimension.confidence,
+            state=dimension.state,
+            threshold_state=dimension.threshold_state,
+        )
+        for dimension in summary.dimensions
+    )
+
+    drift_alerts = _extract_drift_alerts(summary)
+
+    return SensoryMetrics(
+        symbol=summary.symbol,
+        generated_at=summary.generated_at,
+        samples=summary.samples,
+        integrated_strength=summary.integrated_strength,
+        integrated_confidence=summary.integrated_confidence,
+        integrated_direction=summary.integrated_direction,
+        dimensions=dimensions,
+        drift_alerts=drift_alerts,
+    )
+
+
+def build_sensory_metrics_from_status(status: Mapping[str, object] | None) -> SensoryMetrics:
+    """Build metrics from a sensory organ status mapping."""
+
+    summary = build_sensory_summary(status)
+    return build_sensory_metrics(summary)
+
+
+def publish_sensory_metrics(
+    metrics: SensoryMetrics,
+    *,
+    event_bus: EventBus,
+    event_type: str = "telemetry.sensory.metrics",
+    global_bus_factory: Callable[[], TopicBus] | None = None,
+) -> None:
+    """Publish sensory metrics using the hardened event-bus failover helper."""
+
+    event = Event(
+        type=event_type,
+        payload=metrics.as_dict(),
+        source="operations.sensory_metrics",
+    )
+
+    publish_event_with_failover(
+        event_bus,
+        event,
+        logger=logger,
+        runtime_fallback_message="Runtime bus rejected sensory metrics; falling back to global bus",
+        runtime_unexpected_message="Unexpected error publishing sensory metrics via runtime bus",
+        runtime_none_message="Runtime bus returned no result while publishing sensory metrics",
+        global_not_running_message="Global event bus not running while publishing sensory metrics",
+        global_unexpected_message="Unexpected error publishing sensory metrics via global bus",
+        global_bus_factory=global_bus_factory,  # type: ignore[arg-type]
+    )
+
+
+def _extract_drift_alerts(summary: SensorySummary) -> tuple[str, ...]:
+    payload = summary.drift_summary or {}
+    exceeded = payload.get("exceeded") if isinstance(payload, Mapping) else None
+    if not isinstance(exceeded, Iterable):
+        return ()
+
+    alerts: list[str] = []
+    for entry in exceeded:
+        if not isinstance(entry, Mapping):
+            continue
+        sensor = entry.get("sensor")
+        if isinstance(sensor, str):
+            alerts.append(sensor)
+    return tuple(alerts)

--- a/tests/operations/test_sensory_metrics.py
+++ b/tests/operations/test_sensory_metrics.py
@@ -1,0 +1,118 @@
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+import pytest
+
+from src.operations.sensory_metrics import (
+    DimensionMetric,
+    build_sensory_metrics_from_status,
+    publish_sensory_metrics,
+)
+
+
+def _sample_status() -> dict[str, Any]:
+    generated_at = datetime.now(timezone.utc) - timedelta(minutes=5)
+    return {
+        "samples": 8,
+        "latest": {
+            "symbol": "EURUSD",
+            "generated_at": generated_at.isoformat(),
+            "integrated_signal": {
+                "strength": 0.35,
+                "confidence": 0.62,
+                "direction": 1.0,
+                "contributing": ["WHY", "HOW", "ANOMALY"],
+            },
+            "dimensions": {
+                "WHY": {
+                    "signal": 0.38,
+                    "confidence": 0.70,
+                    "metadata": {"state": "bullish", "threshold_assessment": {"state": "warn"}},
+                },
+                "HOW": {
+                    "signal": 0.22,
+                    "confidence": 0.55,
+                    "metadata": {"state": "nominal", "threshold_assessment": {"state": "nominal"}},
+                },
+                "ANOMALY": {
+                    "signal": -0.6,
+                    "confidence": 0.65,
+                    "metadata": {"state": "alert", "threshold_assessment": {"state": "alert"}},
+                },
+            },
+        },
+        "drift_summary": {
+            "exceeded": [
+                {"sensor": "ANOMALY", "z_score": 3.1},
+            ]
+        },
+    }
+
+
+class _StubEventBus:
+    def __init__(self, *, running: bool = True, raise_runtime: bool = False) -> None:
+        self.running = running
+        self.raise_runtime = raise_runtime
+        self.events: list[Any] = []
+
+    def is_running(self) -> bool:
+        return self.running
+
+    def publish_from_sync(self, event: Any) -> int:
+        if self.raise_runtime:
+            raise RuntimeError("runtime bus failure")
+        self.events.append(event)
+        return 1
+
+
+class _StubTopicBus:
+    def __init__(self) -> None:
+        self.events: list[tuple[str, Any, str]] = []
+
+    def publish_sync(self, event_type: str, payload: Any, source: str) -> None:
+        self.events.append((event_type, payload, source))
+
+
+def test_build_sensory_metrics_from_status_focuses_on_dimensions() -> None:
+    metrics = build_sensory_metrics_from_status(_sample_status())
+
+    assert metrics.symbol == "EURUSD"
+    assert metrics.integrated_strength == pytest.approx(0.35)
+    assert metrics.integrated_confidence == pytest.approx(0.62)
+
+    dimensions = metrics.dimensions
+    assert len(dimensions) == 3
+    assert isinstance(dimensions[0], DimensionMetric)
+
+    how_metric = {metric.name: metric for metric in metrics.dimensions}["HOW"]
+    assert how_metric.state == "nominal"
+    assert how_metric.threshold_state == "nominal"
+
+    assert metrics.drift_alerts == ("ANOMALY",)
+
+
+def test_publish_sensory_metrics_uses_event_bus() -> None:
+    metrics = build_sensory_metrics_from_status(_sample_status())
+    bus = _StubEventBus()
+
+    publish_sensory_metrics(metrics, event_bus=bus)
+
+    assert len(bus.events) == 1
+    event = bus.events[0]
+    assert event.type == "telemetry.sensory.metrics"
+    assert event.payload["symbol"] == "EURUSD"
+
+
+def test_publish_sensory_metrics_falls_back_to_global_bus() -> None:
+    metrics = build_sensory_metrics_from_status(_sample_status())
+    bus = _StubEventBus(raise_runtime=True)
+    topic_bus = _StubTopicBus()
+
+    publish_sensory_metrics(metrics, event_bus=bus, global_bus_factory=lambda: topic_bus)
+
+    assert len(bus.events) == 0
+    assert len(topic_bus.events) == 1
+    event_type, payload, source = topic_bus.events[0]
+    assert event_type == "telemetry.sensory.metrics"
+    assert payload["symbol"] == "EURUSD"
+    assert source == "operations.sensory_metrics"

--- a/tests/sensory/test_real_sensory_organ.py
+++ b/tests/sensory/test_real_sensory_organ.py
@@ -140,3 +140,20 @@ def test_real_sensory_organ_exposes_drift_summary_after_window() -> None:
     latest_event = bus.events[-1][1]
     assert latest_event["drift_summary"] is not None
     assert latest_event["drift_summary"]["parameters"]["z_threshold"] == config.z_threshold
+
+
+def test_real_sensory_organ_metrics_exposes_dimension_state() -> None:
+    frame = _build_market_frame()
+    organ = RealSensoryOrgan()
+    organ.observe(frame)
+
+    metrics = organ.metrics()
+
+    assert metrics["samples"] >= 1
+    assert metrics["integrated"] is not None
+    dimensions = metrics["dimensions"]
+    assert "HOW" in dimensions and "ANOMALY" in dimensions
+
+    how_metrics = dimensions["HOW"]
+    assert "signal" in how_metrics
+    assert "threshold_state" in how_metrics

--- a/tests/tools/test_dead_code_tracker.py
+++ b/tests/tools/test_dead_code_tracker.py
@@ -1,0 +1,33 @@
+from pathlib import Path
+
+import pytest
+
+from tools.cleanup.dead_code_tracker import (
+    DeadCodeSummary,
+    parse_cleanup_report,
+    summarise_candidates,
+)
+
+
+@pytest.fixture(scope="module")
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parents[2]
+
+
+def test_parse_cleanup_report_extracts_paths(_repo_root: Path) -> None:
+    report_path = _repo_root / "docs" / "reports" / "CLEANUP_REPORT.md"
+    candidates = parse_cleanup_report(report_path)
+
+    assert "src/core/sensory_organ.py" in candidates
+    assert all(candidate.startswith("src/") for candidate in candidates)
+
+
+def test_summarise_candidates_identifies_shims(_repo_root: Path) -> None:
+    report_path = _repo_root / "docs" / "reports" / "CLEANUP_REPORT.md"
+    candidates = parse_cleanup_report(report_path)
+
+    summary = summarise_candidates(candidates, repo_root=_repo_root)
+
+    assert isinstance(summary, DeadCodeSummary)
+    assert "src/core/sensory_organ.py" in summary.present
+    assert "src/core/sensory_organ.py" in summary.shim_exports

--- a/tools/__init__.py
+++ b/tools/__init__.py
@@ -1,0 +1,1 @@
+"""Helper scripts supporting roadmap and operational tooling."""

--- a/tools/cleanup/__init__.py
+++ b/tools/cleanup/__init__.py
@@ -1,0 +1,1 @@
+"""Cleanup helpers for triaging dead code and shim modules."""

--- a/tools/cleanup/dead_code_tracker.py
+++ b/tools/cleanup/dead_code_tracker.py
@@ -1,0 +1,146 @@
+"""Utilities for triaging the roadmap dead-code backlog."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Mapping, Sequence
+
+__all__ = [
+    "DeadCodeSummary",
+    "parse_cleanup_report",
+    "summarise_candidates",
+    "main",
+]
+
+
+_REPORT_PATTERN = re.compile(r"src\\[\\\\\w./]+")
+
+
+@dataclass(frozen=True)
+class DeadCodeSummary:
+    """Structured view of the dead-code candidates declared in the cleanup report."""
+
+    total_candidates: int
+    present: tuple[str, ...]
+    missing: tuple[str, ...]
+    shim_exports: tuple[str, ...]
+
+    def as_dict(self) -> Mapping[str, object]:
+        return {
+            "total_candidates": self.total_candidates,
+            "present": list(self.present),
+            "missing": list(self.missing),
+            "shim_exports": list(self.shim_exports),
+        }
+
+    def to_json(self) -> str:
+        return json.dumps(self.as_dict(), indent=2, sort_keys=True)
+
+
+def parse_cleanup_report(report_path: Path) -> list[str]:
+    """Return normalised candidate paths from ``CLEANUP_REPORT.md``."""
+
+    text = report_path.read_text(encoding="utf-8")
+    matches = _REPORT_PATTERN.findall(text)
+    candidates: list[str] = []
+    for match in matches:
+        normalised = match.replace("\\", "/")
+        normalised = normalised.strip("~ ")
+        if normalised.endswith("."):
+            normalised = normalised[:-1]
+        if normalised not in candidates:
+            candidates.append(normalised)
+    return candidates
+
+
+def summarise_candidates(candidates: Sequence[str], *, repo_root: Path) -> DeadCodeSummary:
+    """Classify candidate paths and highlight shim exports for triage."""
+
+    present: list[str] = []
+    missing: list[str] = []
+    shim_exports: list[str] = []
+
+    for candidate in sorted(dict.fromkeys(candidates)):
+        path = repo_root / candidate
+        if path.exists():
+            present.append(candidate)
+            if path.is_file() and path.suffix == ".py" and _looks_like_shim(path):
+                shim_exports.append(candidate)
+        else:
+            missing.append(candidate)
+
+    return DeadCodeSummary(
+        total_candidates=len(candidates),
+        present=tuple(present),
+        missing=tuple(missing),
+        shim_exports=tuple(shim_exports),
+    )
+
+
+def _looks_like_shim(path: Path) -> bool:
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError:
+        return False
+    lower = text.lower()
+    if "shim" in lower:
+        return True
+    if "__getattr__" in text and "importlib" in text:
+        return True
+    return False
+
+
+def _format_summary(summary: DeadCodeSummary) -> str:
+    lines = [
+        f"Total candidates: {summary.total_candidates}",
+        f"Present: {len(summary.present)}",
+        f"Missing: {len(summary.missing)}",
+        f"Shim exports: {len(summary.shim_exports)}",
+    ]
+    if summary.shim_exports:
+        lines.append("Shim modules:")
+        lines.extend(f"  - {path}" for path in summary.shim_exports)
+    if summary.missing:
+        lines.append("Missing modules:")
+        lines.extend(f"  - {path}" for path in summary.missing)
+    return "\n".join(lines)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--format",
+        choices={"text", "json"},
+        default="text",
+        help="Output format (text or json).",
+    )
+    parser.add_argument(
+        "--report",
+        type=Path,
+        default=Path("docs/reports/CLEANUP_REPORT.md"),
+        help="Path to the cleanup report markdown file.",
+    )
+    parser.add_argument(
+        "--root",
+        type=Path,
+        default=Path.cwd(),
+        help="Repository root containing the candidate modules.",
+    )
+    args = parser.parse_args(argv)
+
+    candidates = parse_cleanup_report(args.report)
+    summary = summarise_candidates(candidates, repo_root=args.root)
+
+    if args.format == "json":
+        print(summary.to_json())
+    else:
+        print(_format_summary(summary))
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- expose dimension-level metrics from the real sensory organ so runtime summaries include HOW and ANOMALY posture
- add an operational helper that builds and publishes sensory metrics with failover-aware event bus publishing and drift alerts
- introduce a cleanup CLI for parsing the dead-code backlog and highlight shim modules under new regression coverage

## Testing
- pytest tests/sensory/test_real_sensory_organ.py tests/operations/test_sensory_metrics.py tests/tools/test_dead_code_tracker.py

------
https://chatgpt.com/codex/tasks/task_e_68e288495954832c8fb42400793e9328