### PR TITLE
Refine data foundation persistence and replay tooling

### DIFF
--- a/src/data_foundation/config/sizing_config.py
+++ b/src/data_foundation/config/sizing_config.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import os
 from dataclasses import dataclass
 from types import ModuleType
-from typing import Optional
+from typing import Mapping, Optional, cast
 
 # Optional yaml module handle (typed)
 _yaml_mod: ModuleType | None
@@ -25,21 +25,42 @@ class SizingConfig:
     )
 
 
+def _as_mapping(value: object) -> Mapping[str, object]:
+    if isinstance(value, Mapping):
+        return value
+    return {}
+
+
+def _as_float(value: object, default: float) -> float:
+    try:
+        return float(value)  # type: ignore[arg-type]
+    except (TypeError, ValueError):
+        return default
+
+
 def load_sizing_config(path: Optional[str] = None) -> SizingConfig:
     if path is None:
         path = os.environ.get("SIZING_CONFIG_PATH", "config/execution/sizing.yaml")
-    default_regime = {"calm": 1.0, "normal": 0.8, "storm": 0.5}
+    default_regime: dict[str, float] = {"calm": 1.0, "normal": 0.8, "storm": 0.5}
     if _yaml_mod is None or not os.path.exists(path):
         return SizingConfig(regime_multipliers=default_regime)
     try:
         with open(path, "r", encoding="utf-8") as fh:
-            data = _yaml_mod.safe_load(fh) or {}
-        sz = data.get("sizing", data)
+            raw = _yaml_mod.safe_load(fh) if _yaml_mod else {}
+        data = cast(Mapping[str, object], raw or {})
+        sizing_section = _as_mapping(data.get("sizing", data))
+        regime_raw = _as_mapping(sizing_section.get("regime_multipliers", default_regime))
+        regime_multipliers = {
+            str(key): _as_float(value, default_regime.get(str(key), 1.0))
+            for key, value in regime_raw.items()
+        }
+        if not regime_multipliers:
+            regime_multipliers = default_regime
         return SizingConfig(
-            k_exposure=float(sz.get("k_exposure", 0.8)),
-            sigma_floor=float(sz.get("sigma_floor", 0.05)),
-            sigma_ceiling=float(sz.get("sigma_ceiling", 0.30)),
-            regime_multipliers=sz.get("regime_multipliers", default_regime) or default_regime,
+            k_exposure=_as_float(sizing_section.get("k_exposure"), 0.8),
+            sigma_floor=_as_float(sizing_section.get("sigma_floor"), 0.05),
+            sigma_ceiling=_as_float(sizing_section.get("sigma_ceiling"), 0.30),
+            regime_multipliers=regime_multipliers,
         )
     except Exception:
         return SizingConfig(regime_multipliers=default_regime)

--- a/src/data_foundation/ingest/yahoo_ingest.py
+++ b/src/data_foundation/ingest/yahoo_ingest.py
@@ -1,7 +1,5 @@
 #!/usr/bin/env python3
-"""
-Tier-0 Yahoo ingest: fetch daily bars for symbols and persist to DuckDB (if available) or CSV.
-"""
+"""Canonical Yahoo Finance ingest helpers used by tier-0 pipelines."""
 
 from __future__ import annotations
 
@@ -13,6 +11,8 @@ from typing import Any, cast
 
 import pandas as pd
 import yfinance as yf
+
+from src.core.types import JSONObject
 
 
 def fetch_daily_bars(symbols: list[str], days: int = 60) -> pd.DataFrame:

--- a/src/data_foundation/persist/jsonl_writer.py
+++ b/src/data_foundation/persist/jsonl_writer.py
@@ -3,7 +3,9 @@ from __future__ import annotations
 import json
 import logging
 import os
+from collections.abc import Iterable, Mapping
 from contextlib import suppress
+from typing import Final
 
 
 logger = logging.getLogger(__name__)
@@ -13,23 +15,44 @@ class JsonlWriterError(RuntimeError):
     """Raised when JSONL persistence fails."""
 
 
-def write_events_jsonl(events: list[dict[str, object]], out_path: str) -> str:
-    """Persist a list of event dictionaries to a JSONL file.
+_JSON_SEPARATORS: Final[tuple[str, str]] = (",", ":")
+
+
+def _normalise_events(events: Iterable[Mapping[str, object] | dict[str, object]]) -> list[dict[str, object]]:
+    """Copy events into ``dict`` instances to ensure JSON serialisation stability."""
+
+    normalised: list[dict[str, object]] = []
+    for event in events:
+        if isinstance(event, dict):
+            normalised.append(event)
+            continue
+        normalised.append({str(key): value for key, value in event.items()})
+    return normalised
+
+
+def write_events_jsonl(
+    events: Iterable[Mapping[str, object] | dict[str, object]], out_path: str
+) -> str:
+    """Persist iterable ``events`` to ``out_path`` in JSON Lines format.
 
     The implementation avoids swallowing unexpected exceptions so operational
     tooling sees genuine filesystem/serialisation failures instead of silently
     receiving an empty path.
     """
 
+    serialisable_events = _normalise_events(events)
+
     os.makedirs(os.path.dirname(out_path) or ".", exist_ok=True)
 
     try:
         with open(out_path, "w", encoding="utf-8") as fh:
-            for event in events:
+            for event in serialisable_events:
                 try:
-                    payload = json.dumps(event)
+                    payload = json.dumps(event, separators=_JSON_SEPARATORS)
                 except (TypeError, ValueError) as exc:  # defensive against unsafe payloads
-                    logger.error("Event payload is not JSON serialisable for %s: %s", out_path, exc)
+                    logger.error(
+                        "Event payload is not JSON serialisable for %s: %s", out_path, exc
+                    )
                     raise JsonlWriterError("Event payload is not JSON serialisable") from exc
                 fh.write(f"{payload}\n")
     except JsonlWriterError:

--- a/src/data_foundation/replay/multidim_replayer.py
+++ b/src/data_foundation/replay/multidim_replayer.py
@@ -1,76 +1,109 @@
-"""
-Multi-dimension replayer: plays back MD (WHAT) and macro (WHY) streams with a unified clock.
-"""
+"""Multi-dimensional replay helpers used by the ingestion regression suite."""
 
 from __future__ import annotations
 
 import json
-from collections.abc import Iterator
+import logging
+from collections.abc import Callable, Iterable, Iterator
+from dataclasses import dataclass
 from datetime import datetime
-from typing import Callable, Optional
+from typing import Literal, TypedDict, cast
+
+from src.core.types import JSONObject
+
+logger = logging.getLogger(__name__)
+
+ReplayKind = Literal["md", "macro", "yield"]
 
 
-def _parse_jsonl(path: str) -> Iterator[dict[str, object]]:
+class ReplayEvent(TypedDict, total=False):
+    """Typed representation of a replay event entry."""
+
+    timestamp: str
+    _kind: ReplayKind
+
+
+def _parse_jsonl(path: str, kind: ReplayKind) -> Iterator[ReplayEvent]:
+    """Yield JSON payloads from ``path`` tagged with ``kind``."""
+
     try:
         with open(path, "r", encoding="utf-8") as fh:
             for line in fh:
-                try:
-                    yield json.loads(line)
-                except Exception:
+                line = line.strip()
+                if not line:
                     continue
-    except Exception:
-        return
+                try:
+                    payload = cast(JSONObject, json.loads(line))
+                except json.JSONDecodeError:
+                    logger.debug("Skipping malformed JSONL line in %s", path, exc_info=True)
+                    continue
+                event: ReplayEvent = {"_kind": kind}
+                if "timestamp" in payload and isinstance(payload["timestamp"], str):
+                    event["timestamp"] = payload["timestamp"]
+                event.update(cast(dict[str, object], payload))
+                yield event
+    except OSError:
+        logger.warning("Replay source %s is unavailable", path)
 
 
+def _timestamp_key(event: ReplayEvent) -> datetime:
+    raw = event.get("timestamp")
+    if isinstance(raw, str):
+        try:
+            return datetime.fromisoformat(raw)
+        except ValueError:
+            logger.debug("Invalid timestamp on replay event: %s", raw, exc_info=True)
+    return datetime.min
+
+
+@dataclass(slots=True)
 class MultiDimReplayer:
-    def __init__(
-        self,
-        md_path: Optional[str] = None,
-        macro_path: Optional[str] = None,
-        yields_path: Optional[str] = None,
-    ):
-        self.md_path = md_path
-        self.macro_path = macro_path
-        self.yields_path = yields_path
+    """Merge market data, macro, and yield event streams from JSONL inputs."""
+
+    md_path: str | None = None
+    macro_path: str | None = None
+    yields_path: str | None = None
+
+    def _iter_events(self) -> Iterable[ReplayEvent]:
+        if self.md_path:
+            yield from _parse_jsonl(self.md_path, "md")
+        if self.macro_path:
+            yield from _parse_jsonl(self.macro_path, "macro")
+        if self.yields_path:
+            yield from _parse_jsonl(self.yields_path, "yield")
 
     def replay(
         self,
-        on_md: Optional[Callable[[dict[str, object]], None]] = None,
-        on_macro: Optional[Callable[[dict[str, object]], None]] = None,
-        on_yield: Optional[Callable[[dict[str, object]], None]] = None,
-        limit: Optional[int] = None,
+        *,
+        on_md: Callable[[ReplayEvent], None] | None = None,
+        on_macro: Callable[[ReplayEvent], None] | None = None,
+        on_yield: Callable[[ReplayEvent], None] | None = None,
+        limit: int | None = None,
     ) -> int:
-        """Simple merge by timestamp ISO; no sleeping to keep offline fast."""
-        events: list[dict[str, object]] = []
-        if self.md_path:
-            for e in _parse_jsonl(self.md_path):
-                e["_kind"] = "md"
-                events.append(e)
-        if self.macro_path:
-            for e in _parse_jsonl(self.macro_path):
-                e["_kind"] = "macro"
-                events.append(e)
-        if self.yields_path:
-            for e in _parse_jsonl(self.yields_path):
-                e["_kind"] = "yield"
-                events.append(e)
+        """Replay events ordered by timestamp, invoking the provided callbacks."""
 
-        def ts(e: dict[str, object]) -> datetime:
-            try:
-                return datetime.fromisoformat(e.get("timestamp"))  # type: ignore[arg-type]
-            except Exception:
-                return datetime.min
+        events = sorted(self._iter_events(), key=_timestamp_key)
+        callbacks: dict[ReplayKind, Callable[[ReplayEvent], None] | None] = {
+            "md": on_md,
+            "macro": on_macro,
+            "yield": on_yield,
+        }
 
-        events.sort(key=ts)
         emitted = 0
-        for e in events:
-            if limit and emitted >= limit:
+        for event in events:
+            if limit is not None and emitted >= limit:
                 break
-            if e.get("_kind") == "md" and on_md:
-                on_md(e)
+            kind = event.get("_kind")
+            if kind not in callbacks:
+                continue
+            callback = callbacks[cast(ReplayKind, kind)]
+            if callback is None:
+                continue
+            callback(event)
+            if kind == "md":
                 emitted += 1
-            elif e.get("_kind") == "macro" and on_macro:
-                on_macro(e)
-            elif e.get("_kind") == "yield" and on_yield:
-                on_yield(e)
+
         return emitted
+
+
+__all__ = ["MultiDimReplayer", "ReplayEvent", "ReplayKind"]


### PR DESCRIPTION
## Summary
- harden sizing configuration loading by normalising mappings and numeric coercions
- extend JSONL and Parquet writers to handle generic iterables with stricter error handling and logging
- modernise the multi-dimensional replayer and Yahoo ingest module with typed payloads and updated documentation

## Testing
- `pytest tests/data_foundation/test_jsonl_writer.py tests_data_foundation/test_parquet_writer.py tests/data_foundation/test_yahoo_ingest_security.py`


------
https://chatgpt.com/codex/tasks/task_e_68e2a5fb66c8832cbc7e64a5c33c1014