### PR TITLE
Update roadmap for guardrail coverage and readiness metadata

### DIFF
--- a/docs/context/alignment_briefs/operational_readiness.md
+++ b/docs/context/alignment_briefs/operational_readiness.md
@@ -43,23 +43,27 @@
   professional readiness feeds warn on runtime bus failures, fall back
   deterministically, and raise on unexpected errors with pytest coverage
   guarding the behaviour. The system validation track now evaluates structured
-  reports into readiness snapshots, derives alert events, and publishes via the
-  shared failover helper while preserving failing-check metadata in Markdown and
-  payloads so responders see the exact degradation.【F:src/operations/security.py†L536-L579】【F:tests/operations/test_security.py†L101-L211】【F:src/operations/system_validation.py†L1-L312】【F:tests/operations/test_system_validation.py†L1-L195】【F:src/operations/professional_readiness.py†L268-L305】【F:tests/operations/test_professional_readiness.py†L164-L239】
+  reports into readiness snapshots, derives alert events, publishes via the
+  shared failover helper, and exposes gating helpers that return blocking
+  reasons and success metrics so responders see the exact degradation and
+  deployment posture.【F:src/operations/security.py†L536-L579】【F:tests/operations/test_security.py†L101-L211】【F:src/operations/system_validation.py†L1-L452】【F:tests/operations/test_system_validation.py†L1-L279】【F:src/operations/professional_readiness.py†L268-L305】【F:tests/operations/test_professional_readiness.py†L164-L239】
 - Harden incident response readiness by parsing policy/state mappings into a
   severity snapshot, deriving targeted alert events, and publishing telemetry
   via the guarded runtime→global failover path so outage evidence, roster gaps,
-  and postmortem backlog context stay visible under pytest coverage documenting
-  escalation and publish failures.【F:src/operations/incident_response.py†L1-L715】【F:tests/operations/test_incident_response.py†L1-L200】【F:src/operations/event_bus_failover.py†L1-L174】
+  postmortem backlog context, and structured issue catalogs (counts, highest
+  severity, category tags) stay visible under pytest coverage documenting
+  escalation and publish failures.【F:src/operations/incident_response.py†L242-L715】【F:tests/operations/test_incident_response.py†L1-L200】【F:src/operations/event_bus_failover.py†L1-L174】
 - Document Timescale failover drill requirements via the institutional ingest
   provisioner, which now exposes drill metadata from configuration and captures
   the workflow in updated runbooks so operators can rehearse recoveries using a
   consistent source of truth.【F:src/data_foundation/ingest/institutional_vertical.py†L160-L239】【F:docs/operations/timescale_failover_drills.md†L1-L27】
 - Aggregate operational readiness into a single severity snapshot that merges
   system validation, incident response, and ingest SLO posture, emits Markdown
-  summaries, derives alert events, and now exposes status breakdown/component
-  metadata so dashboards can render severity chips without recomputing logic,
-  with pytest guarding the contract and docs capturing the payload update.【F:src/operations/operational_readiness.py†L1-L256】【F:tests/operations/test_operational_readiness.py†L1-L86】【F:docs/status/operational_readiness.md†L1-L34】【F:tests/runtime/test_professional_app_timescale.py†L722-L799】
+  summaries, derives alert events, and exposes status breakdowns, component
+  status maps, issue counts, and per-component issue catalogs so dashboards can
+  render severity chips and remediation context without recomputing logic, with
+  pytest guarding alert derivation, routing, and the failover publish path while
+  docs capture the enriched payload contract.【F:src/operations/operational_readiness.py†L113-L373】【F:tests/operations/test_operational_readiness.py†L86-L221】【F:docs/status/operational_readiness.md†L1-L73】【F:tests/runtime/test_professional_app_timescale.py†L722-L799】
 - Wire the observability dashboard to consume the readiness snapshot directly,
   rendering a dedicated panel with component summaries and remediation roll-ups
   under pytest coverage so operators see readiness posture alongside risk,

--- a/docs/context/alignment_briefs/quality_observability.md
+++ b/docs/context/alignment_briefs/quality_observability.md
@@ -105,9 +105,11 @@
     regression coverage so CI exporters can consume a canonical operational
     readiness signal without recomputing severities.【F:src/operations/observability_dashboard.py†L60-L109】【F:tests/operations/test_observability_dashboard.py†L60-L116】
   - Progress: Operational readiness telemetry now enriches snapshots with
-    per-status breakdowns and component maps so dashboards can render severity
-    chips without reimplementing escalation logic, with pytest and docs locking
-    the contract alongside the runtime exposure.【F:src/operations/operational_readiness.py†L200-L256】【F:tests/operations/test_operational_readiness.py†L1-L86】【F:docs/status/operational_readiness.md†L1-L34】【F:tests/runtime/test_professional_app_timescale.py†L722-L799】
+    per-status breakdowns, component status maps, rolled-up issue counts, and
+    per-component issue catalogs while routing derived alerts through the
+    failover helper so dashboards and responders inherit machine-readable
+    remediation context under pytest coverage documenting alert derivation and
+    publish fallbacks.【F:src/operations/operational_readiness.py†L113-L373】【F:tests/operations/test_operational_readiness.py†L86-L221】【F:docs/status/operational_readiness.md†L1-L73】【F:tests/runtime/test_professional_app_timescale.py†L722-L799】
 - Progress: Coverage matrix CLI now exposes lagging domains via the
   `identify_laggards` helper, exports the list of covered source files, and
   enforces required regression suites through `--require-file`, failing the

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -46,7 +46,13 @@ kit that the roadmap calls back to in each checklist.
     cut-offs, jitter bounds, supervisor telemetry, and snapshot publishing so
     the guardrail remains deterministic. The guardrail manifest now pins the
     ingest scheduler regression to the `guardrail` matrix, ensuring CI fails
-    fast if the scheduler suite drifts or loses its guardrail marker.【F:src/data_foundation/ingest/scheduler.py†L1-L138】【F:tests/data_foundation/test_ingest_scheduler.py†L1-L200】【F:tests/runtime/test_guardrail_suite_manifest.py†L18-L40】
+    fast if the scheduler suite drifts or loses its guardrail marker.【F:src/data_foundation/ingest/scheduler.py†L1-L138】【F:tests/data_foundation/test_ingest_scheduler.py†L1-L200】【F:tests/runtime/test_guardrail_suite_manifest.py†L18-L90】
+  - *Progress*: Cobertura coverage guardrail tooling now parses XML reports,
+    asserts coverage for ingest, risk, and observability hotspots, flags missing
+    targets, and exits non-zero for WARN/FAIL thresholds so CI pipelines and
+    local audits block on regression drift; pytest locks success/failure paths
+    and the guardrail manifest keeps the guardrail suites wired into the
+    dedicated CI marker.【F:tools/telemetry/coverage_guardrails.py†L1-L268】【F:tests/tools/test_coverage_guardrails.py†L1-L83】【F:tests/runtime/test_guardrail_suite_manifest.py†L18-L90】
   - *Progress*: Production ingest slice now orchestrates Timescale runs and
     supervised services from a single entrypoint, wiring the institutional
     provisioner, Kafka bridge, and Redis cache through the shared
@@ -88,6 +94,12 @@ kit that the roadmap calls back to in each checklist.
     failures, escalates unexpected exceptions, and falls back to the global bus
     under pytest coverage so ingest snapshots are not silently dropped when the
     runtime transport degrades.【F:src/data_foundation/ingest/telemetry.py†L33-L99】【F:tests/data_foundation/test_ingest_publishers.py†L1-L164】
+  - *Progress*: Operational readiness aggregation fuses system validation,
+    incident response, alerts, and dashboard telemetry into enriched snapshots
+    that expose per-status counts, component issue catalogs, and structured
+    alert contexts; publishing now rides the shared failover helper with pytest
+    coverage for alert routing and bus failover so responders inherit actionable
+    metadata when WARN/FAIL posture shifts.【F:src/operations/operational_readiness.py†L113-L373】【F:src/operations/incident_response.py†L242-L715】【F:src/operations/system_validation.py†L1-L312】【F:tests/operations/test_operational_readiness.py†L86-L221】【F:docs/status/operational_readiness.md†L1-L73】
 - [ ] **Sensory + evolution execution** – Replace HOW/ANOMALY stubs, wire lineage
   telemetry, and prove adaptive strategies against recorded data.
   - *Progress*: Ecosystem optimizer now defends against unsafe genomes and


### PR DESCRIPTION
## Summary
- Document the new Cobertura coverage guardrail tooling and refresh the roadmap guardrail marker references.
- Capture the enriched operational readiness snapshot metadata, alert routing, and gating behaviour in the roadmap and operational alignment brief.
- Align the quality/observability brief with the readiness metadata upgrades so context packs highlight machine-readable issue catalogs.

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e3e02fc39c832c94a46c65f088246e